### PR TITLE
Implement __isset

### DIFF
--- a/Carbon/Carbon.php
+++ b/Carbon/Carbon.php
@@ -149,6 +149,15 @@ class Carbon extends \DateTime
       if ($name == 'tzName') return $this->timezoneName;
       throw new \InvalidArgumentException(sprintf("Unknown getter '%s'", $name));
    }
+   public function __isset($name)
+   {
+      try {
+         $this->__get($name);
+      } catch (\InvalidArgumentException $e) {
+         return false;
+      }
+      return true;
+   }
    public function __set($name, $value)
    {
       $handled = true;

--- a/Carbon/Tests/IssetTest.php
+++ b/Carbon/Tests/IssetTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Carbon\Tests;
+
+use Carbon\Carbon;
+
+class IssetTest extends TestFixture
+{
+    public function testIssetReturnFalseForUnknownProperty()
+    {
+        $this->assertFalse(isset(Carbon::create(1234, 5, 6, 7, 8, 9)->sdfsdfss));
+    }
+    public function testIssetReturnTrueForProperties()
+    {
+        $properties = array('year', 'month', 'day', 'hour', 'minute', 'second', 'dayOfWeek', 'dayOfYear', 'daysInMonth', 'timestamp', 'age', 'quarter', 'dst', 'offset', 'offsetHours', 'timezone', 'timezoneName', 'tz', 'tzName');
+        foreach ($properties as $property) {
+            $this->assertTrue(isset(Carbon::create(1234, 5, 6, 7, 8, 9)->$property));
+        }
+    }
+}


### PR DESCRIPTION
I turns out that some systems out there (for example Twig) require an object to implement __isset whenever it uses __get. In this way they can test whether a given method/property exist before referencing it.
I encountered such an issue when trying to use Carbon inside a Twig template (see more here http://twig.sensiolabs.org/doc/recipes.html#using-dynamic-object-properties).

This PR introduces the __isset method and the appropriate tests.
