### PR TITLE
Added to day of week modifiers. startOfWeek() & endOfWeek()

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1485,23 +1485,24 @@ class Carbon extends DateTime
    }
 
     /**
-     * Resets the date to the first day of the week and the time to 00:00:00
+     * Resets the date to the first day of the ISO-8601 week and the time to 00:00:00
      *
      * @return self
      */
     public function startOfWeek()
     {
-        return $this->subDays($this->dayOfWeek)->startOfDay();
+        return $this->setISODate($this->year, $this->weekOfYear, 1)->startOfDay();
     }
 
+
     /**
-     * Resets the date to end of the week and time to 23:59:59
+     * Resets the date to end of the ISO-8601 week and time to 23:59:59
      *
      * @return self
      */
     public function endOfWeek()
     {
-        return $this->addDays(6 - $this->dayOfWeek)->endOfDay();
+        return $this->setISODate($this->year, $this->weekOfYear, 7)->endOfDay();
     }
 
     ///////////////////////////////////////////////////////////////////

--- a/tests/DayOfWeekModifiersTest.php
+++ b/tests/DayOfWeekModifiersTest.php
@@ -16,25 +16,25 @@ class DayOfWeekModifiersTest extends TestFixture
    public function testStartOfWeek()
    {
        $d = Carbon::createFromDate(1980, 8, 7)->startOfWeek();
-       $this->assertCarbon($d, 1980, 8, 3, 0, 0, 0);
+       $this->assertCarbon($d, 1980, 8, 4, 0, 0, 0);
    }
 
    public function testStartOfWeekFromWeekStart()
    {
-       $d = Carbon::createFromDate(1980, 8, 3)->startOfWeek();
-       $this->assertCarbon($d, 1980, 8, 3, 0, 0, 0);
+       $d = Carbon::createFromDate(1980, 8, 4)->startOfWeek();
+       $this->assertCarbon($d, 1980, 8, 4, 0, 0, 0);
    }
 
    public function testEndOfWeek()
    {
        $d = Carbon::createFromDate(1980, 8, 7)->endOfWeek();
-       $this->assertCarbon($d, 1980, 8, 9, 23, 59, 59);
+       $this->assertCarbon($d, 1980, 8, 10, 23, 59, 59);
    }
 
    public function testEndOfWeekFromWeekEnd()
    {
        $d = Carbon::createFromDate(1980, 8, 9)->endOfWeek();
-       $this->assertCarbon($d, 1980, 8, 9, 23, 59, 59);
+       $this->assertCarbon($d, 1980, 8, 10, 23, 59, 59);
    }
 
    public function testNext()


### PR DESCRIPTION
When using Carbon for building an application that used the beginning and end of the weeks a lot I found adding these methods to come in quite handy when looking to keep my code clean.
