### PR TITLE
Updated formatLocalized to be more OS independent

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -718,7 +718,13 @@ class Carbon extends DateTime
     */
    public function formatLocalized($format)
    {
-     return strftime($format, $this->timestamp);
+      // Check for Windows to find and replace the %e 
+      // modifier correctly
+      if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') {
+          $format = preg_replace('#(?<!%)((?:%%)*)%e#', '\1%#d', $format);
+      }
+      
+      return strftime($format, $this->timestamp);
    }
 
    /**


### PR DESCRIPTION
It would be great if the user won't need to check whether to use the %e modifier or the %#d modifier.
