### PR TITLE
Test Aid Fix

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -146,12 +146,19 @@ class Carbon extends DateTime
       // If the class has a test now set and we are trying to create a now()
       // instance then override as required
       if (static::hasTestNow() && (empty($time) || $time === 'now' || self::hasRelativeKeywords($time))) {
-         if (self::hasRelativeKeywords($time)) {
-            $time = static::getRelativeTest($time)->toDateTimeString();
-         } else {
-            $time = static::getTestNow()->toDateTimeString();
-         }
-         $tz = static::getTestNow()->tz;
+	 $testInstance = clone static::getTestNow();
+	 if (self::hasRelativeKeywords($time)) {
+	     $testInstance->modify($time);
+	 }
+
+	 //shift the time according to the given time zone
+	 if ($tz !== NULL && $tz != static::getTestNow()->tz) {
+	     $testInstance->setTimezone($tz);
+	 } else {
+	     $tz = $testInstance->tz;
+	 }
+
+         $time = $testInstance->toDateTimeString();
       }
 
       if ($tz !== null) {
@@ -749,18 +756,6 @@ class Carbon extends DateTime
         }
       }
       return false;
-   }
-
-   /**
-    * Gets a Carbon instance relative to the current test instance.
-    * e.g.: last thursday, tomorrow
-    *
-    * @return Carbon relative to the current instance used for testing
-    */
-   public static function getRelativeTest($time) {
-      $instance = new static();
-      $instance->modify($time);
-      return $instance;
    }
 
    ///////////////////////////////////////////////////////////////////

--- a/tests/TestingAidsTest.php
+++ b/tests/TestingAidsTest.php
@@ -101,4 +101,14 @@ class TestingAidsTest extends TestFixture
 	  $this->assertEquals('2013-10-01 05:15:05', Carbon::parse('first day of next month')->toDateTimeString());
 	  $this->assertEquals('2013-09-30 05:15:05', Carbon::parse('last day of this month')->toDateTimeString());
    }
+
+   public function testTimeZoneWithTestValueSet()
+   {
+      $notNow = Carbon::parse('2013-07-01 12:00:00', 'America/New_York');
+      Carbon::setTestNow($notNow);
+      
+      $this->assertEquals('2013-07-01T12:00:00-0400', Carbon::parse('now')->toISO8601String());
+      $this->assertEquals('2013-07-01T11:00:00-0500', Carbon::parse('now', 'America/Mexico_City')->toISO8601String());
+      $this->assertEquals('2013-07-01T09:00:00-0700', Carbon::parse('now', 'America/Vancouver')->toISO8601String());
+   }
 }


### PR DESCRIPTION
Fixes the problem where if a test aid is set, it's time zone would override any time zone passed in code.

Instead will alter the test time relative to the time zone passed.
