### PR TITLE
Month has average 4.35 weeks

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1715,7 +1715,7 @@ class Carbon extends DateTime
          'minute' => self::MINUTES_PER_HOUR,
          'hour'   => self::HOURS_PER_DAY,
          'day'    => self::DAYS_PER_WEEK,
-         'week'   => 4,
+         'week'   => 4.35,
          'month'  => self::MONTHS_PER_YEAR
       );
 


### PR DESCRIPTION
Calculation error when handling years ago due to inaccurate weeks in month
