### PR TITLE
Added option to disable suffix on diffForHumans

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1694,10 +1694,11 @@ class Carbon extends DateTime
     * 5 months after
     *
     * @param  Carbon  $other
+    * @param  boolean $suffix Include the suffix ('ago', 'from now', 'before', 'after')
     *
     * @return string
     */
-   public function diffForHumans(Carbon $other = null)
+   public function diffForHumans(Carbon $other = null, $suffix = true)
    {
       $isNow = $other === null;
 
@@ -1736,6 +1737,10 @@ class Carbon extends DateTime
 
       $txt = $delta . ' ' . $unit;
       $txt .= $delta == 1 ? '' : 's';
+
+      if(!$suffix) {
+      	return $txt;
+      }
 
       if ($isNow) {
          if ($isFuture) {


### PR DESCRIPTION
I was disappointed to find that there is no method for a 'human time' without the suffix in Carbon. I added a second parameter to diffForHumans were the suffix can be disabled for this reason.