### PR TITLE
Default Localization Method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -177,13 +177,13 @@ To accompany `now()`, a few other static instantiation helpers exist to create w
 
 ```php
 $now = Carbon::now();
-echo $now;                               // 2014-01-06 22:52:03
+echo $now;                               // 2014-03-15 09:12:01
 $today = Carbon::today();
-echo $today;                             // 2014-01-06 00:00:00
+echo $today;                             // 2014-03-15 00:00:00
 $tomorrow = Carbon::tomorrow('Europe/London');
-echo $tomorrow;                          // 2014-01-08 00:00:00
+echo $tomorrow;                          // 2014-03-16 00:00:00
 $yesterday = Carbon::yesterday();
-echo $yesterday;                         // 2014-01-05 00:00:00
+echo $yesterday;                         // 2014-03-14 00:00:00
 ```
 
 The next group of static helpers are the `createXXX()` helpers. Most of the static `create` functions allow you to provide as many or as few arguments as you want and will provide default values for all others.  Generally default values are the current date, time or timezone.  Higher values will wrap appropriately but invalid values will throw an `InvalidArgumentException` with an informative message.  The message is obtained from an [DateTime::getLastErrors()](http://php.net/manual/en/datetime.getlasterrors.php) call.
@@ -261,7 +261,7 @@ echo Carbon::parse('now');                             // 2001-05-21 12:00:00
 var_dump(Carbon::hasTestNow());                        // bool(true)
 Carbon::setTestNow();                                  // clear the mock
 var_dump(Carbon::hasTestNow());                        // bool(false)
-echo Carbon::now();                                    // 2014-01-06 22:52:03
+echo Carbon::now();                                    // 2014-03-15 09:12:01
 ```
 
 A more meaning full example:
@@ -456,13 +456,15 @@ Carbon::resetToStringFormat();
 echo $dt;                                          // 1975-12-25 14:15:16
 ```
 
-Unfortunately the base class DateTime does not have any localization support.  To begin localization support a `formatLocalized($format)` method has been added.  The implementation makes a call to [strftime](http://www.php.net/strftime) using the current instance timestamp.  If you first set the current locale with [setlocale()](http://www.php.net/setlocale) then the string returned will be formatted in the correct locale.
+Unfortunately the base class DateTime does not have any localization support.  To begin localization support a `formatLocalized($format)` and `toLocalizedDateString()` method has been added.  The implementation makes a call to [strftime](http://www.php.net/strftime) using the current instance timestamp.  If you first set the current locale with [setlocale()](http://www.php.net/setlocale) then the string returned will be formatted in the correct locale.
 
 ```php
 setlocale(LC_TIME, 'German');                     
-echo $dt->formatLocalized('%A %d %B %Y');          // Donnerstag 25 Dezember 1975
-setlocale(LC_TIME, '');                           
+echo $dt->toLocalizedDateString();                 // 25 December 1975
 echo $dt->formatLocalized('%A %d %B %Y');          // Thursday 25 December 1975
+setlocale(LC_TIME, '');                           
+echo $dt->toLocalizedDateString();                 // 25 Aralık 1975
+echo $dt->formatLocalized('%A %d %B %Y');          // Perşembe 25 Aralık 1975
 ```
 
 <a name="api-commonformats"/>
@@ -542,7 +544,7 @@ echo $dt1->max($dt2);                              // 2014-01-30 00:00:00
 
 // now is the default param
 $dt1 = Carbon::create(2000, 1, 1, 0, 0, 0);
-echo $dt1->max();                                  // 2014-01-06 22:52:03
+echo $dt1->max();                                  // 2014-03-15 09:12:01
 ```
 
 To handle the most used cases there are some simple helper functions that hopefully are obvious from their names.  For the methods that compare to `now()` (ex. isToday()) in some manner the `now()` is created in the same timezone as the instance.

--- a/readme.src.md
+++ b/readme.src.md
@@ -474,13 +474,15 @@ Carbon::resetToStringFormat();
 {{format9::exec(echo $dt;/*pad(50)*/)}} // {{format9_eval}}
 ```
 
-Unfortunately the base class DateTime does not have any localization support.  To begin localization support a `formatLocalized($format)` method has been added.  The implementation makes a call to [strftime](http://www.php.net/strftime) using the current instance timestamp.  If you first set the current locale with [setlocale()](http://www.php.net/setlocale) then the string returned will be formatted in the correct locale.
+Unfortunately the base class DateTime does not have any localization support.  To begin localization support a `formatLocalized($format)` and `toLocalizedDateString()` method has been added.  The implementation makes a call to [strftime](http://www.php.net/strftime) using the current instance timestamp.  If you first set the current locale with [setlocale()](http://www.php.net/setlocale) then the string returned will be formatted in the correct locale.
 
 ```php
 {{::lint(setlocale(LC_TIME, 'German');/*pad(50)*/)}}
-{{format20::exec(echo $dt->formatLocalized('%A %d %B %Y');/*pad(50)*/)}} // {{format20_eval}}
-{{::lint(setlocale(LC_TIME, '');/*pad(50)*/)}}
+{{format20::exec(echo $dt->toLocalizedDateString();/*pad(50)*/)}} // {{format20_eval}}
 {{format21::exec(echo $dt->formatLocalized('%A %d %B %Y');/*pad(50)*/)}} // {{format21_eval}}
+{{::lint(setlocale(LC_TIME, '');/*pad(50)*/)}}
+{{format22::exec(echo $dt->toLocalizedDateString();/*pad(50)*/)}} // {{format22_eval}}
+{{format23::exec(echo $dt->formatLocalized('%A %d %B %Y');/*pad(50)*/)}} // {{format23_eval}}
 ```
 
 <a name="api-commonformats"/>

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -867,6 +867,16 @@ class Carbon extends DateTime
    }
 
    /**
+    * Format the instance as a localized readable date
+    *
+    * @return string
+    */
+   public function toLocalizedDateString()
+   {
+      return $this->formatLocalized('%e %B %Y');
+   }
+
+   /**
     * Format the instance as time
     *
     * @return string


### PR DESCRIPTION
According to the [Wikipedia](http://en.wikipedia.org/wiki/Date_format_by_country), a huge number of countries use the *little-endian* format for dates. That's why I added `toLocalizedDateString` method which does that without bloating the views (or whereever developer converts dates to localized strings).

There of course must be a locale check to decide which \*-endian format to use, but until me or someone else does it, this should be enough.

**The problem with the readme.md** is because I don't have German locale installed on my machine and my default locale is Turkish. So a lot of thing has changed. It would be probably better if you run the PHP again and replace the readme file.