### PR TITLE
[WIP] Add DateInterval handling to Carbon

### DIFF
--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -29,7 +29,7 @@ class CarbonInterval extends DateInterval
    ///////////////////////////////////////////////////////////////////
 
    /**
-    * Create a new CarbonInterval instance from specific interval components (days, months, years, etc.)
+    * Create a new CarbonInterval instance from periods (days, months, years, etc.)
     *
     * @param  integer             $years
     * @param  integer             $months
@@ -46,6 +46,20 @@ class CarbonInterval extends DateInterval
        return new static(static::buildIntervalSpec($years, $months, $weeks, $days, $hours, $minutes, $seconds));
    }
 
+   /**
+    * Build an interval spec string from periods (days, months, years, etc.)
+    * @link http://www.php.net/manual/en/dateinterval.construct.php DateInterval interval_spec documentation
+    *
+    * @param  integer             $years
+    * @param  integer             $months
+    * @param  integer             $weeks
+    * @param  integer             $days
+    * @param  integer             $hours
+    * @param  integer             $minutes
+    * @param  integer             $seconds
+    *
+    * @return string The interval spec
+    */
    public static function buildIntervalSpec($years = null, $months = null, $weeks = null, $days = null, $hours = null, $minutes = null, $seconds = null)
    {
        $datePeriods = array_filter(array(

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -95,4 +95,76 @@ class CarbonInterval extends DateInterval
        return implode('', $parts);
    }
 
+   public function years()
+   {
+       return (int) $this->format('%y');
+   }
+
+   public function months()
+   {
+       return (int) $this->format('%m');
+   }
+
+   public function days($excludeWeeks = false)
+   {
+       $days = (int) $this->format('%d');
+       if ( ! $excludeWeeks) {
+          return $days;
+       }
+
+       return $days % Carbon::DAYS_PER_WEEK;
+   }
+
+   public function weeks()
+   {
+       return $this->days() >= Carbon::DAYS_PER_WEEK ? floor($this->days() / Carbon::DAYS_PER_WEEK) : 0;
+   }
+
+   public function totalDays()
+   {
+       return ($this->years() * 365) + ($this->months() * 4 * Carbon::DAYS_PER_WEEK) + $this->days();
+   }
+
+   public function hours()
+   {
+       return (int) $this->format('%h');
+   }
+
+   public function minutes()
+   {
+       return (int) $this->format('%i');
+   }
+
+   public function seconds()
+   {
+       return (int) $this->format('%s');
+   }
+
+   public function totalSeconds()
+   {
+       $daysInSeconds = $this->totalDays() * Carbon::HOURS_PER_DAY * Carbon::MINUTES_PER_HOUR * Carbon::SECONDS_PER_MINUTE;
+       $hoursInSeconds = $this->hours() * Carbon::MINUTES_PER_HOUR * Carbon::SECONDS_PER_MINUTE;
+
+       return $this->seconds() + $daysInSeconds + $hoursInSeconds;
+   }
+
+   public function intervalForHumans()
+   {
+       $periods = array_filter(array(
+          'year' => $this->years(),
+          'month' => $this->months(),
+          'week' => $this->weeks() ?: null,
+          'day' => $this->weeks() ? $this->days(true) : $this->days(),
+          'hour' => $this->hours(),
+          'minute' => $this->minutes(),
+          'second' => $this->seconds(),
+       ));
+
+       $parts = array();
+       foreach ($periods as $label => $value) {
+           array_push($parts, $value, $value > 1 ? $label.'s' : $label);
+       }
+
+       return implode(' ', $parts);
+    }
 }

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Ben Glassman <bglassman@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Carbon;
+
+use DateInterval;
+
+class CarbonInterval extends DateInterval
+{
+   const PERIOD_PREFIX      = 'P';
+   const PERIOD_YEARS       = 'Y';
+   const PERIOD_MONTHS      = 'M';
+   const PERIOD_DAYS        = 'D';
+   const PERIOD_HOURS       = 'H';
+   const PERIOD_MINUTES     = 'M';
+   const PERIOD_SECONDS     = 'S';
+   const PERIOD_TIME_PREFIX = 'T';
+
+   ///////////////////////////////////////////////////////////////////
+   //////////////////////////// CONSTRUCTORS /////////////////////////
+   ///////////////////////////////////////////////////////////////////
+
+   /**
+    * Create a new CarbonInterval instance from specific interval components (days, months, years, etc.)
+    *
+    * @param  integer             $years
+    * @param  integer             $months
+    * @param  integer             $weeks
+    * @param  integer             $days
+    * @param  integer             $hours
+    * @param  integer             $minutes
+    * @param  integer             $seconds
+    *
+    * @return CarbonInterval
+    */
+   public static function create($years = null, $months = null, $weeks = null, $days = null, $hours = null, $minutes = null, $seconds = null)
+   {
+       return new static(static::buildIntervalSpec($years, $months, $weeks, $days, $hours, $minutes, $seconds));
+   }
+
+   public static function buildIntervalSpec($years = null, $months = null, $weeks = null, $days = null, $hours = null, $minutes = null, $seconds = null)
+   {
+       $datePeriods = array_filter(array(
+           static::PERIOD_YEARS => $years,
+           static::PERIOD_MONTHS => $months,
+           static::PERIOD_DAYS => $weeks ? (int) $days + ($weeks * 7) : $days,
+       ));
+
+       $timePeriods = array_filter(array(
+           static::PERIOD_HOURS => $hours,
+           static::PERIOD_MINUTES => $minutes,
+           static::PERIOD_SECONDS => $seconds
+       ));
+
+       if (empty($datePeriods) && empty($timePeriods)) {
+           throw new \InvalidArgumentException('Cannot create a CarbonInterval without specify any date or time arguments.');
+       }
+
+       $parts = array(static::PERIOD_PREFIX);
+
+       foreach ($datePeriods as $period => $value) {
+           array_push($parts, $value, $period);
+       }
+
+       if ($timePeriods) {
+           $parts[] = static::PERIOD_TIME_PREFIX;
+       }
+
+       foreach ($timePeriods as $period => $value) {
+           array_push($parts, $value, $period);
+       }
+
+       return implode('', $parts);
+   }
+
+}

--- a/tests/IntervalTest.php
+++ b/tests/IntervalTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Ben Glassman <bglassman@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Carbon\CarbonInterval;
+
+class IntervalTest extends TestFixture
+{
+    /**
+     * @dataProvider providerTestCreateTests
+     */
+    public function testCreate($years, $months, $weeks, $days, $hours, $minutes, $seconds, $expected)
+    {
+        $interval = CarbonInterval::create($years, $months, $weeks, $days, $hours, $minutes, $seconds);
+
+        $this->assertSame($expected, $interval->format('%y years %m months %d days %h hours %i minutes %s seconds'));
+    }
+
+    public function providerTestCreateTests()
+    {
+        return array(
+            array(1, null, null, null, null, null, null, '1 years 0 months 0 days 0 hours 0 minutes 0 seconds'),
+            array(null, 1, null, null, null, null, null, '0 years 1 months 0 days 0 hours 0 minutes 0 seconds'),
+            array(null, null, 1, null, null, null, null, '0 years 0 months 7 days 0 hours 0 minutes 0 seconds'),
+            array(null, null, null, 1, null, null, null, '0 years 0 months 1 days 0 hours 0 minutes 0 seconds'),
+            array(null, null, null, null, 1, null, null, '0 years 0 months 0 days 1 hours 0 minutes 0 seconds'),
+            array(null, null, null, null, null, 1, null, '0 years 0 months 0 days 0 hours 1 minutes 0 seconds'),
+            array(null, null, null, null, null, null, 1, '0 years 0 months 0 days 0 hours 0 minutes 1 seconds'),
+            array(1, 1, 1, 1, 1, 1, 1, '1 years 1 months 8 days 1 hours 1 minutes 1 seconds'),
+        );
+    }
+
+    public function testCreateWeeks()
+    {
+        $interval = CarbonInterval::create(null, null, 2, 3);
+        $this->assertSame('17 days', $interval->format('%d days'));
+        $interval = CarbonInterval::create(null, null, 5);
+        $this->assertSame('35 days', $interval->format('%d days'));
+    }
+}

--- a/tests/IntervalTest.php
+++ b/tests/IntervalTest.php
@@ -14,26 +14,24 @@ use Carbon\CarbonInterval;
 class IntervalTest extends TestFixture
 {
     /**
-     * @dataProvider providerTestCreateTests
+     * @dataProvider provideTestCreateTests
      */
-    public function testCreate($years, $months, $weeks, $days, $hours, $minutes, $seconds, $expected)
+    public function testCreate(CarbonInterval $interval, $expected)
     {
-        $interval = CarbonInterval::create($years, $months, $weeks, $days, $hours, $minutes, $seconds);
-
         $this->assertSame($expected, $interval->format('%y years %m months %d days %h hours %i minutes %s seconds'));
     }
 
-    public function providerTestCreateTests()
+    public function provideTestCreateTests()
     {
         return array(
-            array(1, null, null, null, null, null, null, '1 years 0 months 0 days 0 hours 0 minutes 0 seconds'),
-            array(null, 1, null, null, null, null, null, '0 years 1 months 0 days 0 hours 0 minutes 0 seconds'),
-            array(null, null, 1, null, null, null, null, '0 years 0 months 7 days 0 hours 0 minutes 0 seconds'),
-            array(null, null, null, 1, null, null, null, '0 years 0 months 1 days 0 hours 0 minutes 0 seconds'),
-            array(null, null, null, null, 1, null, null, '0 years 0 months 0 days 1 hours 0 minutes 0 seconds'),
-            array(null, null, null, null, null, 1, null, '0 years 0 months 0 days 0 hours 1 minutes 0 seconds'),
-            array(null, null, null, null, null, null, 1, '0 years 0 months 0 days 0 hours 0 minutes 1 seconds'),
-            array(1, 1, 1, 1, 1, 1, 1, '1 years 1 months 8 days 1 hours 1 minutes 1 seconds'),
+            array(CarbonInterval::create(1), '1 years 0 months 0 days 0 hours 0 minutes 0 seconds'),
+            array(CarbonInterval::create(null, 1), '0 years 1 months 0 days 0 hours 0 minutes 0 seconds'),
+            array(CarbonInterval::create(null, null, 1), '0 years 0 months 7 days 0 hours 0 minutes 0 seconds'),
+            array(CarbonInterval::create(null, null, null, 1), '0 years 0 months 1 days 0 hours 0 minutes 0 seconds'),
+            array(CarbonInterval::create(null, null, null, null, 1), '0 years 0 months 0 days 1 hours 0 minutes 0 seconds'),
+            array(CarbonInterval::create(null, null, null, null, null, 1), '0 years 0 months 0 days 0 hours 1 minutes 0 seconds'),
+            array(CarbonInterval::create(null, null, null, null, null, null, 1), '0 years 0 months 0 days 0 hours 0 minutes 1 seconds'),
+            array(CarbonInterval::create(1, 1, 1, 1, 1, 1, 1), '1 years 1 months 8 days 1 hours 1 minutes 1 seconds'),
         );
     }
 
@@ -43,5 +41,26 @@ class IntervalTest extends TestFixture
         $this->assertSame('17 days', $interval->format('%d days'));
         $interval = CarbonInterval::create(null, null, 5);
         $this->assertSame('35 days', $interval->format('%d days'));
+    }
+
+    /**
+     * @dataProvider provideTestIntervalForHumans
+     */
+    public function testIntervalForHumans(CarbonInterval $interval, $expected)
+    {
+        $this->assertSame($expected, $interval->intervalForHumans());
+    }
+
+    public function provideTestIntervalForHumans()
+    {
+        return array(
+            array(CarbonInterval::create(1), '1 year'),
+            array(CarbonInterval::create(2), '2 years'),
+            array(CarbonInterval::create(3, 1), '3 years 1 month'),
+            array(CarbonInterval::create(3, null, 3), '3 years 3 weeks'),
+            array(CarbonInterval::create(3, 1, 3, 1), '3 years 1 month 3 weeks 1 day'),
+            array(CarbonInterval::create(6, null, 3, null, 1, 30), '6 years 3 weeks 1 hour 30 minutes'),
+            array(CarbonInterval::create(null, null, null, null, 3, 30, 1), '3 hours 30 minutes 1 second'),
+        );
     }
 }


### PR DESCRIPTION
This is a work in progress to address #87

It provides a CarbonInterval class which has a handle create method for creating an interval without using the strange interval_spec ('P1Y2M') using CarbonInterval::create(1, 4). It also has a intervalForHumans method which will convert an interval into a readable string ('1 year 4 months'). 