### PR TITLE
Fixed issue with isPast returning true when testing current time

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1201,7 +1201,7 @@ class Carbon extends DateTime
     */
    public function isPast()
    {
-      return !$this->isFuture();
+      return $this->lt(self::now($this->tz));
    }
 
    /**

--- a/tests/IsTest.php
+++ b/tests/IsTest.php
@@ -93,5 +93,6 @@ class IsTest extends TestFixture
    public function testIsPast()
    {
       $this->assertFalse(Carbon::now()->addSecond()->isPast());
+      $this->assertFalse(Carbon::now()->isPast());
    }
 }


### PR DESCRIPTION
This pull request fixes the issue where isPast() would return true when the time you were testing was the same as Carbon::now(). This is because it was just using the negation of isFuture() which isn't necessarily correct.

Props to @tharumax for reporting this in #109
