### PR TITLE
Not using property setters in setDate and setTime

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -596,7 +596,8 @@ class Carbon extends DateTime
     */
    public function setDate($year, $month, $day)
    {
-      return $this->year($year)->month($month)->day($day);
+      parent::setDate($year, $month, $day);
+      return $this;
    }
 
    /**
@@ -652,7 +653,8 @@ class Carbon extends DateTime
     */
    public function setTime($hour, $minute, $second = 0)
    {
-      return $this->hour($hour)->minute($minute)->second($second);
+      parent::setTime($hour, $minute, $second);
+      return $this;
    }
 
    /**


### PR DESCRIPTION
Setting a full date in multiple steps can lead to the wrong results when setting a date falling in a "daylight saving timezone". It is also slower to use magic setters without an actual good reason.
