### PR TITLE
Create minimal and maximal possible date

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -263,6 +263,26 @@ class Carbon extends DateTime
    }
 
    /**
+    * Create a Carbon instance for the greatest supported date.
+    *
+    * @return Carbon
+    */
+   public static function maximal()
+   {
+      return static::createFromTimestamp(PHP_INT_MAX);
+   }
+
+   /**
+    * Create a Carbon instance for the lowest supported date.
+    *
+    * @return Carbon
+    */
+   public static function minimal()
+   {
+      return static::createFromTimestamp(~PHP_INT_MAX);
+   }
+
+   /**
     * Create a new Carbon instance from a specific date and time.
     *
     * If any of $year, $month or $day are set to null their now() values

--- a/tests/NowAndOtherStaticHelpersTest.php
+++ b/tests/NowAndOtherStaticHelpersTest.php
@@ -62,4 +62,14 @@ class NowAndOtherStaticHelpersTest extends TestFixture
       $dt2 = new \DateTime('yesterday', new \DateTimeZone('Europe/London'));
       $this->assertSame($dt2->format('Y-m-d 00:00:00'), $dt->toDateTimeString());
    }
+
+   public function testMinimal()
+   {
+      $this->assertLessThanOrEqual(- 2147483647, Carbon::minimal()->getTimestamp());
+   }
+
+   public function testMaximal()
+   {
+      $this->assertGreaterThanOrEqual(2147483647, Carbon::maximal()->getTimestamp());
+   }
 }


### PR DESCRIPTION
Allows to create the lowest and the greatest possible date.
Useful to determine a real min and max when comparing dates with `min` and `max`.
