### PR TITLE
Micro-optimization in __construct method

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -164,8 +164,9 @@ class Carbon extends DateTime
    {
       // If the class has a test now set and we are trying to create a now()
       // instance then override as required
-      if (static::hasTestNow() && (empty($time) || $time === 'now' || static::hasRelativeKeywords($time))) {
-         $testInstance = clone static::getTestNow();
+      $testNow = static::getTestNow();
+      if ($testNow && (empty($time) || $time === 'now' || static::hasRelativeKeywords($time))) {
+         $testInstance = clone $testNow;
          if (static::hasRelativeKeywords($time)) {
             $testInstance->modify($time);
          }


### PR DESCRIPTION
I have a script that is creating several carbon objects. I did some profiling and discovered I could save a few milliseconds by avoiding the call to `hasTestNow`. This is probably very small when creating just a couple instances, but helped in the script where I create a few hundred of them
