### PR TITLE
Performances

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1681,7 +1681,7 @@ class Carbon extends DateTime
     */
    public function diffInHours(Carbon $dt = null, $abs = true)
    {
-      return intval($this->diffInMinutes($dt, $abs) / self::MINUTES_PER_HOUR);
+      return intval($this->diffInSeconds($dt, $abs) / self::SECONDS_PER_MINUTE / self::MINUTES_PER_HOUR);
    }
 
    /**
@@ -1707,9 +1707,7 @@ class Carbon extends DateTime
     */
    public function diffInSeconds(Carbon $dt = null, $abs = true)
    {
-      $dt = ($dt === null) ? static::now($this->tz) : $dt;
-
-      $value = $dt->getTimestamp() - $this->getTimestamp();
+      $value = (($dt === null) ? time() : $dt->getTimestamp()) - $this->getTimestamp();
 
       return $abs ? abs($value) : $value;
    }


### PR DESCRIPTION
Calling instead `time()` is much faster than creating a new `Carbon` instance.
Change `diffInHours` so that only one child function (`diffInSeconds`) is called.
