### PR TITLE
Remove wrong default parameter value in formatLocalized()

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -835,7 +835,7 @@ class Carbon extends DateTime
     *
     * @return string
     */
-   public function formatLocalized($format = self::COOKIE)
+   public function formatLocalized($format)
    {
       // Check for Windows to find and replace the %e
       // modifier correctly


### PR DESCRIPTION
This value did not work, as it is not a strftime() format.
Introduced in #121, seems to be a leftover.
