### PR TITLE
timezone support for method formatLocalized

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -842,7 +842,7 @@ class Carbon extends DateTime
         if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') {
              $format = preg_replace('#(?<!%)((?:%%)*)%e#', '\1%#d', $format);
         }
-        
+
         return strftime($format, strtotime($this));
     }
 

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -842,8 +842,8 @@ class Carbon extends DateTime
         if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') {
              $format = preg_replace('#(?<!%)((?:%%)*)%e#', '\1%#d', $format);
         }
-
-        return strftime($format, $this->timestamp);
+        
+        return strftime($format, strtotime($this));
     }
 
     /**

--- a/tests/StringsTest.php
+++ b/tests/StringsTest.php
@@ -65,6 +65,11 @@ class StringsTest extends TestFixture
 
       *****************/
     }
+    public function testToLocalizedFormattedTimezonedDateString()
+    {        
+      $d = Carbon::create(1975, 12, 25, 14, 15, 16, 'Europe/London');
+      $this->assertSame('Thursday 25 December 1975 14:15', $d->formatLocalized('%A %d %B %Y %H:%M'));      
+    }
     public function testToTimeString()
     {
         $d = Carbon::create(1975, 12, 25, 14, 15, 16);


### PR DESCRIPTION
formatLocalized didn't respect the timezone set on a date object. this can be fixed by using ...

    strtotime($this)

instead of 
    
    $this->timestamp
