### PR TITLE
Added secondsSinceMidnight and secondsUntilEndOfDay helper methods

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -2204,10 +2204,30 @@ class Carbon extends DateTime
     /**
      * Check if its the birthday. Compares the date/month values of the two dates.
      * @param  Carbon  $dt
-     * @return boolean  
+     * @return boolean
      */
     public function isBirthday(Carbon $dt)
     {
         return $this->month === $dt->month && $this->day === $dt->day;
+    }
+
+    /**
+     * The number of seconds since midnight.
+     *
+     * @return integer
+     */
+    public function secondsSinceMidnight()
+    {
+        return $this->diffInSeconds($this->copy()->startOfDay());
+    }
+
+    /**
+     * The number of seconds until 23:23:59.
+     *
+     * @return integer
+     */
+    public function secondsUntilEndOfDay()
+    {
+        return $this->diffInSeconds($this->copy()->endOfDay());
     }
 }

--- a/tests/RelativeTest.php
+++ b/tests/RelativeTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Carbon\Carbon;
+
+class RelativeTest extends TestFixture
+{
+    public function testSecondsSinceMidnight()
+    {
+        $d = Carbon::today()->addSeconds(30);
+        $this->assertSame(30, $d->secondsSinceMidnight());
+
+        $d = Carbon::today()->addDays(1);
+        $this->assertSame(0, $d->secondsSinceMidnight());
+
+        $d = Carbon::today()->addDays(1)->addSeconds(120);
+        $this->assertSame(120, $d->secondsSinceMidnight());
+
+        $d = Carbon::today()->addMonths(3)->addSeconds(42);
+        $this->assertSame(42, $d->secondsSinceMidnight());
+    }
+
+    public function testSecondsUntilEndOfDay()
+    {
+        $d = Carbon::today()->endOfDay();
+        $this->assertSame(0, $d->secondsUntilEndOfDay());
+
+        $d = Carbon::today()->endOfDay()->subSeconds(60);
+        $this->assertSame(60, $d->secondsUntilEndOfDay());
+
+        $d = Carbon::create(2014, 10, 24, 12, 34, 56);
+        $this->assertSame(41103, $d->secondsUntilEndOfDay());
+
+         $d = Carbon::create(2014, 10, 24, 0, 0, 0);
+        $this->assertSame(86399, $d->secondsUntilEndOfDay());
+    }
+}


### PR DESCRIPTION
Wrote these two helpers methods because they are often quite useful. They're based of similar methods in Ruby On Rails found [here](http://api.rubyonrails.org/classes/DateTime.html#method-i-seconds_since_midnight) and [here](http://api.rubyonrails.org/classes/DateTime.html#method-i-seconds_until_end_of_day).

- secondsSinceMidnight gets the number of seconds since midnight of the current Carbon object.
- secondsUntilEndOfDay get the number of seconds from the current Carbon object to 23:59:59 of the current day.