### PR TITLE
Added optional 2nd parameter to diffForHumans

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -709,6 +709,8 @@ This method will add a phrase after the difference value relative to the instanc
     * 1 hour after
     * 5 months after
 
+You may also pass `true` to remove the modifiers *ago*, *from now*, etc as a 2nd parameter: `diffForHumans(Carbon $other, true)`
+
 ```php
 // The most typical usage is for comments
 // The instance is the date the comment was created and its being compared to default now()
@@ -724,6 +726,7 @@ echo $dt->diffForHumans($dt->copy()->subMonth());              // 1 month after
 echo Carbon::now()->addSeconds(5)->diffForHumans();            // 5 seconds from now
 
 echo Carbon::now()->subDays(24)->diffForHumans();              // 3 weeks ago
+echo Carbon::now()->subDays(24)->diffForHumans(null, true);    // 3 weeks
 ```
 
 <a name="api-modifiers"/>

--- a/readme.md
+++ b/readme.md
@@ -709,8 +709,6 @@ This method will add a phrase after the difference value relative to the instanc
     * 1 hour after
     * 5 months after
 
-You may also pass `true` to remove the modifiers *ago*, *from now*, etc as a 2nd parameter: `diffForHumans(Carbon $other, true)`
-
 ```php
 // The most typical usage is for comments
 // The instance is the date the comment was created and its being compared to default now()
@@ -726,7 +724,6 @@ echo $dt->diffForHumans($dt->copy()->subMonth());              // 1 month after
 echo Carbon::now()->addSeconds(5)->diffForHumans();            // 5 seconds from now
 
 echo Carbon::now()->subDays(24)->diffForHumans();              // 3 weeks ago
-echo Carbon::now()->subDays(24)->diffForHumans(null, true);    // 3 weeks
 ```
 
 <a name="api-modifiers"/>

--- a/readme.src.md
+++ b/readme.src.md
@@ -731,6 +731,8 @@ This method will add a phrase after the difference value relative to the instanc
     * 1 hour after
     * 5 months after
 
+You may also pass `true` as a 2nd parameter to remove the modifiers *ago*, *from now*, etc : `diffForHumans(Carbon $other, true)`
+
 ```php
 // The most typical usage is for comments
 // The instance is the date the comment was created and its being compared to default now()
@@ -746,6 +748,7 @@ This method will add a phrase after the difference value relative to the instanc
 {{humandiff6::exec(echo Carbon::now()->addSeconds(5)->diffForHumans();/*pad(62)*/)}} // {{humandiff6_eval}}
 
 {{humandiff7::exec(echo Carbon::now()->subDays(24)->diffForHumans();/*pad(62)*/)}} // {{humandiff7_eval}}
+{{humandiff8::exec(echo Carbon::now()->subDays(24)->diffForHumans(null, true);/*pad(62)*/)}} // {{humandiff8_eval}}
 ```
 
 <a name="api-modifiers"/>

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1805,7 +1805,7 @@ class Carbon extends DateTime
      *
      * @return string
      */
-    public function diffForHumans(Carbon $other = null)
+    public function diffForHumans(Carbon $other = null, $absolute = false)
     {
         $isNow = $other === null;
 
@@ -1846,6 +1846,10 @@ class Carbon extends DateTime
 
         $txt = $delta . ' ' . $unit;
         $txt .= $delta == 1 ? '' : 's';
+
+        if ($absolute) {
+            return $txt;
+        }
 
         if ($isNow) {
             if ($isFuture) {
@@ -2204,7 +2208,7 @@ class Carbon extends DateTime
     /**
      * Check if its the birthday. Compares the date/month values of the two dates.
      * @param  Carbon  $dt
-     * @return boolean  
+     * @return boolean
      */
     public function isBirthday(Carbon $dt)
     {

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1802,6 +1802,7 @@ class Carbon extends DateTime
      * 5 months after
      *
      * @param Carbon $other
+     * @param bool   $absolute removes time difference modifiers ago, after, etc
      *
      * @return string
      */

--- a/tests/DiffTest.php
+++ b/tests/DiffTest.php
@@ -867,4 +867,60 @@ class DiffTest extends TestFixture
         $d = Carbon::now()->subYears(2);
         $this->assertSame('2 years after', Carbon::now()->diffForHumans($d));
     }
+
+    public function testDiffForHumansAbsoluteSeconds()
+    {
+        $d = Carbon::now()->subSeconds(59);
+        $this->assertSame('59 seconds', Carbon::now()->diffForHumans($d, true));
+        $d = Carbon::now()->addSeconds(59);
+        $this->assertSame('59 seconds', Carbon::now()->diffForHumans($d, true));
+    }
+
+    public function testDiffForHumansAbsoluteMinutes()
+    {
+        $d = Carbon::now()->subMinutes(30);
+        $this->assertSame('30 minutes', Carbon::now()->diffForHumans($d, true));
+        $d = Carbon::now()->addMinutes(30);
+        $this->assertSame('30 minutes', Carbon::now()->diffForHumans($d, true));
+    }
+
+    public function testDiffForHumansAbsoluteHours()
+    {
+        $d = Carbon::now()->subHours(3);
+        $this->assertSame('3 hours', Carbon::now()->diffForHumans($d, true));
+        $d = Carbon::now()->addHours(3);
+        $this->assertSame('3 hours', Carbon::now()->diffForHumans($d, true));
+    }
+
+    public function testDiffForHumansAbsoluteDays()
+    {
+        $d = Carbon::now()->subDays(2);
+        $this->assertSame('2 days', Carbon::now()->diffForHumans($d, true));
+        $d = Carbon::now()->addDays(2);
+        $this->assertSame('2 days', Carbon::now()->diffForHumans($d, true));
+    }
+
+    public function testDiffForHumansAbsoluteWeeks()
+    {
+        $d = Carbon::now()->subWeeks(2);
+        $this->assertSame('2 weeks', Carbon::now()->diffForHumans($d, true));
+        $d = Carbon::now()->addWeeks(2);
+        $this->assertSame('2 weeks', Carbon::now()->diffForHumans($d, true));
+    }
+
+    public function testDiffForHumansAbsoluteMonths()
+    {
+        $d = Carbon::now()->subMonths(2);
+        $this->assertSame('2 months', Carbon::now()->diffForHumans($d, true));
+        $d = Carbon::now()->addMonths(2);
+        $this->assertSame('2 months', Carbon::now()->diffForHumans($d, true));
+    }
+
+    public function testDiffForHumansAbsoluteYears()
+    {
+        $d = Carbon::now()->subYears(1);
+        $this->assertSame('1 year', Carbon::now()->diffForHumans($d, true));
+        $d = Carbon::now()->addYears(1);
+        $this->assertSame('1 year', Carbon::now()->diffForHumans($d, true));
+    }
 }


### PR DESCRIPTION
When set to true, it modifies the string to only contain the human-readable time difference by omitting modifiers **ago**, **from now**, **before**, and **after**

This is similar to #100, but with passing tests.