### PR TITLE
Add yearIso property

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -22,6 +22,7 @@ use InvalidArgumentException;
  * A simple API extension for DateTime
  *
  * @property      integer $year
+ * @property      integer $yearIso
  * @property      integer $month
  * @property      integer $day
  * @property      integer $hour
@@ -437,6 +438,7 @@ class Carbon extends DateTime
     {
         switch ($name) {
             case 'year':
+            case 'yearIso':
             case 'month':
             case 'day':
             case 'hour':
@@ -450,6 +452,7 @@ class Carbon extends DateTime
             case 'timestamp':
                 $formats = array(
                     'year' => 'Y',
+                    'yearIso' => 'o',
                     'month' => 'n',
                     'day' => 'j',
                     'hour' => 'G',

--- a/tests/GettersTest.php
+++ b/tests/GettersTest.php
@@ -24,6 +24,12 @@ class GettersTest extends TestFixture
         $d = Carbon::create(1234, 5, 6, 7, 8, 9);
         $this->assertSame(1234, $d->year);
     }
+    
+    public function testYearIsoGetter()
+    {
+        $d = Carbon::createFromDate(2012, 12, 31);
+        $this->assertSame(2013, $d->yearIso);
+    }
 
     public function testMonthGetter()
     {


### PR DESCRIPTION
This time of year usually gives problems with dates. I have a project that works with week numbers.

$date = new \Carbon\Carbon('2014-12-30');
echo $date->weekOfYear .' '.$date->year;

Gives `1 2014`. So the correct usage (in this particular case) is `$date->format('o')`, which gives 2015.

Would it be good to give this a property on the date object? Something like `$date->yearIso` / `$date->IsoYear`? Even though it's not much shorter then `format->('o')` but it might make it more obvious to people with autocomplete etc.