### PR TITLE
Add / Subtract months with no overflow

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1349,6 +1349,64 @@ class Carbon extends DateTime
     }
 
     /**
+     * Add months without overflowing to the instance. Positive $value 
+     * travels forward while negative $value travels into the past.
+     *
+     * @param integer $value
+     *
+     * @return static
+     */
+    public function addMonthsNoOverflow($value)
+    {
+        // jump straight into the month to avoid any php overflow weirdness
+        $newYear   = $this->year + floor(($this->month + $value) / 12);
+        $newMonth = ($this->month + $value) % 12;
+        $newDate = self::create($newYear, $newMonth, $this->day, $this->hour, $this->minute, $this->second, $this->getTimeZone());
+
+        if(($newDate->day != $this->day)) {
+            // it seems like this would be dependent on whether the value is
+            // positive or negative, but because of how we set the month above,
+            // we should always zero out and subtract a month
+            $newDate->day(1)->subMonth();
+            $newDate->day($newDate->daysInMonth);
+        }
+
+        return $newDate;
+    }
+
+    /**
+     * Add a month with no overflow to the instance
+     *
+     * @return static
+     */
+    public function addMonthNoOverflow()
+    {
+        return $this->addMonthsNoOverflow(1);
+    }
+
+    /**
+     * Remove a month with no overflow from the instance
+     *
+     * @return static
+     */
+    public function subMonthNoOverflow()
+    {
+        return $this->addMonthsNoOverflow(-1);
+    }
+
+    /**
+     * Remove months with no overflow from the instance
+     *
+     * @param integer $value
+     *
+     * @return static
+     */
+    public function subMonthsNoOverflow($value)
+    {
+        return $this->addMonthsNoOverflow(-1 * $value);
+    }
+
+    /**
      * Add days to the instance. Positive $value travels forward while
      * negative $value travels into the past.
      *

--- a/tests/AddTest.php
+++ b/tests/AddTest.php
@@ -58,6 +58,27 @@ class AddTest extends TestFixture
         $this->assertSame(3, Carbon::createFromDate(2012, 1, 31)->addMonth()->month);
     }
 
+    public function testAddMonthsNoOverflowPositive()
+    {
+        $this->assertSame('2012-02-29', Carbon::createFromDate(2012, 1, 31)->addMonthNoOverflow()->toDateString());
+        $this->assertSame('2012-03-31', Carbon::createFromDate(2012, 1, 31)->addMonthsNoOverflow(2)->toDateString());
+        $this->assertSame('2012-03-29', Carbon::createFromDate(2012, 2, 29)->addMonthNoOverflow()->toDateString());
+        $this->assertSame('2012-02-29', Carbon::createFromDate(2011, 12, 31)->addMonthsNoOverflow(2)->toDateString());
+    }
+
+    public function testAddMonthsNoOverflowZero()
+    {
+        $this->assertSame(12, Carbon::createFromDate(1975, 12)->addMonths(0)->month);
+    }
+
+    public function testAddMonthsNoOverflowNegative()
+    {
+        $this->assertSame('2012-01-29', Carbon::createFromDate(2012, 2, 29)->addMonthsNoOverflow(-1)->toDateString());
+        $this->assertSame('2012-01-31', Carbon::createFromDate(2012, 3, 31)->addMonthsNoOverflow(-2)->toDateString());
+        $this->assertSame('2012-02-29', Carbon::createFromDate(2012, 3, 31)->addMonthsNoOverflow(-1)->toDateString());
+        $this->assertSame('2011-12-31', Carbon::createFromDate(2012, 1, 31)->addMonthsNoOverflow(-1)->toDateString());
+    }
+
     public function testAddDaysPositive()
     {
         $this->assertSame(1, Carbon::createFromDate(1975, 5, 31)->addDays(1)->day);

--- a/tests/DiffTest.php
+++ b/tests/DiffTest.php
@@ -602,8 +602,10 @@ class DiffTest extends TestFixture
 
     public function testDiffForHumansNowAndFutureMonths()
     {
+        Carbon::setTestNow(Carbon::create(2012, 1, 1));
         $d = Carbon::now()->addMonths(2);
         $this->assertSame('2 months from now', $d->diffForHumans());
+        Carbon::setTestNow();
     }
 
     public function testDiffForHumansNowAndNearlyFutureYear()
@@ -724,8 +726,10 @@ class DiffTest extends TestFixture
 
     public function testDiffForHumansOtherAndMonths()
     {
+        Carbon::setTestNow(Carbon::create(2012, 1, 1));
         $d = Carbon::now()->addMonths(2);
         $this->assertSame('2 months before', Carbon::now()->diffForHumans($d));
+        Carbon::setTestNow();
     }
 
     public function testDiffForHumansOtherAndNearlyYear()


### PR DESCRIPTION
This PR answers both issues #236 and #217 - in order for the tests to all pass on Travis, it depends on another PR I submitted this morning fixing a `diffForHumans` issue that popped up after the new year.

Although this is influenced by the default PHP behavior, I also think it is worth considering adding an argument flag to the "base" add and subtract methods - the behavior seems counter-intuitive as it is, and it doesn't feel nearly as semantically satisfying to preserve it.

Just a thought - perhaps something like the following, where the overflow method would be protected:

```
public function addMonths($value, $useDefault = false)
{
    return $useDefault ? $this->modify((int) $value . ' month') : $this->addMonthsNoOverflow($value);
}

Carbon::now()->addMonths(2); // intuitive behavior
Carbon::now()->addMonths(2, true); // PHP default behavior
```