### PR TITLE
Only one return statement

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1950,19 +1950,20 @@ class Carbon extends DateTime
 
         $time = static::translator()->transChoice($unit, $count, array(':count' => $count));
 
-        if ($absolute) {
-            return $time;
+        if (! $absolute) {
+
+            $params = array(':time' => $time);
+    
+            if ($isNow) {
+                $transId = $isFuture ? 'from_now' : 'ago';
+            } else {
+                $transId = $isFuture ? 'after' : 'before';
+            }
+            
+            $time = static::translator()->trans($transId, $params);
         }
 
-        $params = array(':time' => $time);
-
-        if ($isNow) {
-            $transId = $isFuture ? 'from_now' : 'ago';
-        } else {
-            $transId = $isFuture ? 'after' : 'before';
-        }
-
-        return static::translator()->trans($transId, $params);
+        return $time;
     }
 
     ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Best-pratice: have only one return statement at the end of the method.