### PR TITLE
Update Carbon.php

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1232,9 +1232,9 @@ class Carbon extends DateTime
      *
      * @return static
      */
-    public function addYear()
+    public function addYear($value = 1)
     {
-        return $this->addYears(1);
+        return $this->addYears($value);
     }
 
     /**
@@ -1242,9 +1242,9 @@ class Carbon extends DateTime
      *
      * @return static
      */
-    public function subYear()
+    public function subYear($value = -1)
     {
-        return $this->addYears(-1);
+        return $this->addYears($value);
     }
 
     /**
@@ -1277,9 +1277,9 @@ class Carbon extends DateTime
      *
      * @return static
      */
-    public function addMonth()
+    public function addMonth($value = 1)
     {
-        return $this->addMonths(1);
+        return $this->addMonths($value);
     }
 
     /**
@@ -1287,9 +1287,9 @@ class Carbon extends DateTime
      *
      * @return static
      */
-    public function subMonth()
+    public function subMonth($value = -1)
     {
-        return $this->addMonths(-1);
+        return $this->addMonths($value);
     }
 
     /**
@@ -1328,9 +1328,9 @@ class Carbon extends DateTime
      *
      * @return static
      */
-    public function addMonthNoOverflow()
+    public function addMonthNoOverflow($value = 1)
     {
-        return $this->addMonthsNoOverflow(1);
+        return $this->addMonthsNoOverflow($value);
     }
 
     /**
@@ -1338,9 +1338,9 @@ class Carbon extends DateTime
      *
      * @return static
      */
-    public function subMonthNoOverflow()
+    public function subMonthNoOverflow($value = -1)
     {
-        return $this->addMonthsNoOverflow(-1);
+        return $this->addMonthsNoOverflow($value);
     }
 
     /**
@@ -1373,9 +1373,9 @@ class Carbon extends DateTime
      *
      * @return static
      */
-    public function addDay()
+    public function addDay($value = 1)
     {
-        return $this->addDays(1);
+        return $this->addDays($value);
     }
 
     /**
@@ -1383,9 +1383,9 @@ class Carbon extends DateTime
      *
      * @return static
      */
-    public function subDay()
+    public function subDay($value = -1)
     {
-        return $this->addDays(-1);
+        return $this->addDays($value);
     }
 
     /**
@@ -1418,9 +1418,9 @@ class Carbon extends DateTime
      *
      * @return static
      */
-    public function addWeekday()
+    public function addWeekday($value = 1)
     {
-        return $this->addWeekdays(1);
+        return $this->addWeekdays($value);
     }
 
     /**
@@ -1428,9 +1428,9 @@ class Carbon extends DateTime
      *
      * @return static
      */
-    public function subWeekday()
+    public function subWeekday($value = -1)
     {
-        return $this->addWeekdays(-1);
+        return $this->addWeekdays($value);
     }
 
     /**
@@ -1463,9 +1463,9 @@ class Carbon extends DateTime
      *
      * @return static
      */
-    public function addWeek()
+    public function addWeek($value = 1)
     {
-        return $this->addWeeks(1);
+        return $this->addWeeks($value);
     }
 
     /**
@@ -1473,9 +1473,9 @@ class Carbon extends DateTime
      *
      * @return static
      */
-    public function subWeek()
+    public function subWeek($value = -1)
     {
-        return $this->addWeeks(-1);
+        return $this->addWeeks($value = 1);
     }
 
     /**
@@ -1508,9 +1508,9 @@ class Carbon extends DateTime
      *
      * @return static
      */
-    public function addHour()
+    public function addHour($value = 1)
     {
-        return $this->addHours(1);
+        return $this->addHours($value);
     }
 
     /**
@@ -1518,9 +1518,9 @@ class Carbon extends DateTime
      *
      * @return static
      */
-    public function subHour()
+    public function subHour($value = -1)
     {
-        return $this->addHours(-1);
+        return $this->addHours($value);
     }
 
     /**
@@ -1553,9 +1553,9 @@ class Carbon extends DateTime
      *
      * @return static
      */
-    public function addMinute()
+    public function addMinute($value = 1)
     {
-        return $this->addMinutes(1);
+        return $this->addMinutes($value);
     }
 
     /**
@@ -1563,9 +1563,9 @@ class Carbon extends DateTime
      *
      * @return static
      */
-    public function subMinute()
+    public function subMinute($value = -1)
     {
-        return $this->addMinutes(-1);
+        return $this->addMinutes($value);
     }
 
     /**
@@ -1598,9 +1598,9 @@ class Carbon extends DateTime
      *
      * @return static
      */
-    public function addSecond()
+    public function addSecond($value = 1)
     {
-        return $this->addSeconds(1);
+        return $this->addSeconds($value);
     }
 
     /**
@@ -1608,9 +1608,9 @@ class Carbon extends DateTime
      *
      * @return static
      */
-    public function subSecond()
+    public function subSecond($value = -1)
     {
-        return $this->addSeconds(-1);
+        return $this->addSeconds($value);
     }
 
     /**


### PR DESCRIPTION
I think it's easy for non english people to call addYear instead of addYears.
In my case, I wrongly wrote addYear(2). 

if you call function addYear(2) actually adds one year. 


I think it should raise an exception or better, work as an alias for addYears.

It is right addYear() to add one year.
It is wrong addYear(45) to add one year.

