### PR TITLE
Added ability to pass offset in hours instead of timezone name

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -150,6 +150,11 @@ class Carbon extends DateTime
             return $object;
         }
 
+        if (is_numeric($object)) {
+            $timezone_offset = $object * 3600;
+            return new DateTimeZone(timezone_name_from_abbr(null, $timezone_offset, true));
+        }
+
         $tz = @timezone_open((string) $object);
 
         if ($tz === false) {

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -131,9 +131,9 @@ class Carbon extends DateTime
     protected static $testNow;
 
     /**
-     * Creates a DateTimeZone from a string or a DateTimeZone
+     * Creates a DateTimeZone from a string, a DateTimeZone or an integer offset
      *
-     * @param DateTimeZone|string|null $object
+     * @param DateTimeZone|string|integer|null $object
      *
      * @return DateTimeZone
      *

--- a/tests/GettersTest.php
+++ b/tests/GettersTest.php
@@ -256,24 +256,36 @@ class GettersTest extends TestFixture
     {
         $dt = Carbon::createFromDate(2000, 1, 1, 'America/Toronto');
         $this->assertSame('America/Toronto', $dt->timezone->getName());
+
+        $dt = Carbon::createFromDate(2000, 1, 1, -5);
+        $this->assertSame('America/Chicago', $dt->timezone->getName());
     }
 
     public function testGetTz()
     {
         $dt = Carbon::createFromDate(2000, 1, 1, 'America/Toronto');
         $this->assertSame('America/Toronto', $dt->tz->getName());
+
+        $dt = Carbon::createFromDate(2000, 1, 1, -5);
+        $this->assertSame('America/Chicago', $dt->tz->getName());
     }
 
     public function testGetTimezoneName()
     {
         $dt = Carbon::createFromDate(2000, 1, 1, 'America/Toronto');
         $this->assertSame('America/Toronto', $dt->timezoneName);
+
+        $dt = Carbon::createFromDate(2000, 1, 1, -5);
+        $this->assertSame('America/Chicago', $dt->timezoneName);
     }
 
     public function testGetTzName()
     {
         $dt = Carbon::createFromDate(2000, 1, 1, 'America/Toronto');
         $this->assertSame('America/Toronto', $dt->tzName);
+
+        $dt = Carbon::createFromDate(2000, 1, 1, -5);
+        $this->assertSame('America/Chicago', $dt->timezoneName);
     }
 
     public function testInvalidGetter()


### PR DESCRIPTION
Ability to pass offset instead of timezone name was very needed for one of my project, and I decided to create a pull request.