### PR TITLE
Update Carbon.php: Update minValue() and maxValue() for 64bit systems

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -299,7 +299,7 @@ class Carbon extends DateTime
             return static::createFromTimestamp(~PHP_INT_MAX);
         } else {
             // 64 bit
-            return static::create(1000, 1, 1, 0, 0, 0);
+            return static::create(1, 1, 1, 0, 0, 0);
         } 
     }
 

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -299,7 +299,7 @@ class Carbon extends DateTime
             return static::createFromTimestamp(~PHP_INT_MAX);
         } else {
             // 64 bit
-            return static::create(1001, 1, 1, 0, 0, 0);
+            return static::create(1000, 1, 1, 0, 0, 0);
         } 
     }
 

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -278,7 +278,13 @@ class Carbon extends DateTime
      */
     public static function maxValue()
     {
-        return static::createFromTimestamp(PHP_INT_MAX);
+        if (PHP_INT_SIZE == 4) {
+            // 32 bit (and additionally Windows 64 bit)
+            return static::createFromTimestamp(PHP_INT_MAX);
+        } else {
+            // 64 bit
+            return static::create(9999, 12, 31, 23, 59, 59);
+        }
     }
 
     /**
@@ -288,7 +294,13 @@ class Carbon extends DateTime
      */
     public static function minValue()
     {
-        return static::createFromTimestamp(~PHP_INT_MAX);
+        if (PHP_INT_SIZE == 4) {
+            // 32 bit (and additionally Windows 64 bit)
+            return static::createFromTimestamp(~PHP_INT_MAX);
+        } else {
+            // 64 bit
+            return static::create(1001, 1, 1, 0, 0, 0);
+        } 
     }
 
     /**


### PR DESCRIPTION
On 64 bit systems `maxValue()` and `minValue` produce akward dates (see end for examples) that can not be used for database or html date input fields (see bottom for examples).

I propose to use more common max and min values in the case, that integer values are 64 bit, ie '1001-01-01 00:00:00' to '9999-12-31 23:59:59'.

It is possible to use these values for an html date input field as well as in MySQL for DATE, DATETIME ([MySQL 5.0 Reference Manual: 11.3.1 The DATE, DATETIME, and TIMESTAMP Types](https://dev.mysql.com/doc/refman/5.0/en/datetime.html)). MySQL TIMESTAMP only supports a range of '1970-01-01 00:00:01' UTC to '2038-01-19 03:14:07' UTC.

Examples
=======

64 bit
------
64 bit `maxValue()`  

    //PHP_INT_MAX = 9223372036854775807
    Carbon {
      +"date": "-292277022657-01-27 09:29:51.000000"
      +"timezone_type": 3
      +"timezone": "Europe/Vienna"
    }
    
64 bit `minValue()`    

    //~PHP_INT_MAX = 9223372036854775807 (same as PHP_INT_MAX)
    Carbon {
      +"date": "-292277022657-01-27 09:29:52.000000"
      +"timezone_type": 3
      +"timezone": "Europe/Vienna"
    }
    
32 bit
------
32 bit `maxValue()`

    //PHP_INT_MAX = 4294967295
    Carbon {
      +"date": "2106-02-07 07:28:15.000000"
      +"timezone_type": 3
      +"timezone": "Europe/Vienna"
    }
    
32 bit `minValue()`

    //~PHP_INT_MAX = -4294967296
    Carbon {
      +"date": "1833-11-24 18:31:44.000000"
      +"timezone_type": 3
      +"timezone": "Europe/Vienna"
    }