### PR TITLE
Fixed Dutch translation for hours.

### DIFF
--- a/src/Carbon/Lang/nl.php
+++ b/src/Carbon/Lang/nl.php
@@ -17,7 +17,7 @@ return array(
     'month'     => '1 maand|:count maanden',
     'week'      => '1 week|:count weken',
     'day'       => '1 dag|:count dagen',
-    'hour'      => '1 uur|:count uren',
+    'hour'      => ':count uur',
     'minute'    => '1 minuut|:count minuten',
     'second'    => '1 seconde|:count seconden',
     'ago'       => ':time geleden',


### PR DESCRIPTION
The plural of "uur" (hour) is "uren" (hours), but only used when describing clock faces. When describing (relative) time, there's no plural use.