### PR TITLE
Added unit tests for Bulgarian and Catalan languages

### DIFF
--- a/tests/CarbonIntervalForHumansTest.php
+++ b/tests/CarbonIntervalForHumansTest.php
@@ -90,4 +90,18 @@ class CarbonIntervalForHumansTest extends TestFixture
         $this->assertSame('1 Jahr 1 Monat', CarbonInterval::create(1, 1)->forHumans());
         $this->assertSame('2 Jahre 1 Monat', CarbonInterval::create(2, 1)->forHumans());
     }
+	
+	public function testYearsAndMonthInBulgarian() 
+	{
+		CarbonInterval::setLocale('bg');
+		$this->assertSame('1 година 1 месец', CarbonInterval::create(1, 1)->forHumans());
+		$this->assetSame('години 1 месец', CarbonInterval::create(2, 1)->forHumans());
+	}
+	
+	public function testYearsAndMonthInCatalan() 
+	{
+		CarbonInterval::setLocale('ca');
+		$this->assertSame('1 any 1 mes', CarbonInterval::create(1, 1)->forHumans());
+		$this->assertSame('2 anys 1 mes', CarbonInterval::create(2, 1)->forHumans());
+	}
 }


### PR DESCRIPTION
New unit tests to cover Bulgarian and Catalan languages, testing months and years. This adds the code coverage to language files a bit more.