### PR TITLE
Added Catalan and Bulgarian Unit Tests

### DIFF
--- a/tests/CarbonIntervalForHumansTest.php
+++ b/tests/CarbonIntervalForHumansTest.php
@@ -90,4 +90,18 @@ class CarbonIntervalForHumansTest extends TestFixture
         $this->assertSame('1 Jahr 1 Monat', CarbonInterval::create(1, 1)->forHumans());
         $this->assertSame('2 Jahre 1 Monat', CarbonInterval::create(2, 1)->forHumans());
     }
+	
+	public function testYearsAndMonthInBulgarian() 
+	{
+		CarbonInterval::setLocale('bg');
+		$this->assertSame('1 година 1 месец', CarbonInterval::create(1, 1)->forHumans());
+		$this->assertSame('години 1 месец', CarbonInterval::create(2, 1)->forHumans());
+	}
+	
+	public function testYearsAndMonthInCatalan() 
+	{
+		CarbonInterval::setLocale('ca');
+		$this->assertSame('1 any 1 mes', CarbonInterval::create(1, 1)->forHumans());
+		$this->assertSame('2 anys 1 mes', CarbonInterval::create(2, 1)->forHumans());
+	}
 }

--- a/tests/CarbonIntervalForHumansTest.php
+++ b/tests/CarbonIntervalForHumansTest.php
@@ -95,7 +95,7 @@ class CarbonIntervalForHumansTest extends TestFixture
 	{
 		CarbonInterval::setLocale('bg');
 		$this->assertSame('1 година 1 месец', CarbonInterval::create(1, 1)->forHumans());
-		$this->assertSame('години 1 месец', CarbonInterval::create(2, 1)->forHumans());
+		$this->assertSame('2 години 1 месец', CarbonInterval::create(2, 1)->forHumans());
 	}
 	
 	public function testYearsAndMonthInCatalan() 


### PR DESCRIPTION
Added Catalan and Bulgarian unit tests to test months and years. This should add more coverage to language files. Thank you.