### PR TITLE
Fix: Composer installs dev dependencies by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ php:
 before_install:
   - travis_retry composer self-update
 install:
-  - travis_retry composer install --no-interaction --prefer-source --dev
+  - travis_retry composer install --no-interaction --prefer-source
 
 script:
   - vendor/bin/phpunit --verbose --coverage-text


### PR DESCRIPTION
This PR

* [x] removes the `--dev` option when installing dependencies on Travis, as dev dependencies are installed by default