### PR TITLE
Allow latest Carbon to be installed with symfony/translation 2.7 or later when it become available.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": ">=5.3.0",
-    "symfony/translation": "2.6.*"
+    "symfony/translation": "~2.6"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
This would avoid Laravel 5.1 (development) to resolved to Carbon 1.17
since it require symfony/translation 2.7

Signed-off-by: crynobone <crynobone@gmail.com>