### PR TITLE
Enhancement: Use SVG for Travis build status

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Carbon
 
-[![Latest Stable Version](https://poser.pugx.org/nesbot/carbon/v/stable.png)](https://packagist.org/packages/nesbot/carbon) [![Total Downloads](https://poser.pugx.org/nesbot/carbon/downloads.png)](https://packagist.org/packages/nesbot/carbon) [![Build Status](https://secure.travis-ci.org/briannesbitt/Carbon.png)](http://travis-ci.org/briannesbitt/Carbon)
+[![Latest Stable Version](https://poser.pugx.org/nesbot/carbon/v/stable.png)](https://packagist.org/packages/nesbot/carbon) [![Total Downloads](https://poser.pugx.org/nesbot/carbon/downloads.png)](https://packagist.org/packages/nesbot/carbon) [![Build Status](https://travis-ci.org/briannesbitt/Carbon.svg?branch=master)](https://travis-ci.org/briannesbitt/Carbon)
 
 A simple PHP API extension for DateTime. [http://carbon.nesbot.com](http://carbon.nesbot.com)
 


### PR DESCRIPTION
This PR

* [x] updates the Travis build badge to use SVG, which pleases the eye on Retina displays

### Before

![screen shot 2015-05-10 at 11 11 43](https://cloud.githubusercontent.com/assets/605483/7553657/6e7c70ee-f705-11e4-9fc8-34a8dcbe9a6e.png)

### After

![screen shot 2015-05-10 at 11 11 26](https://cloud.githubusercontent.com/assets/605483/7553656/68c4a39c-f705-11e4-951e-0875099ddd9b.png)
