### PR TITLE
Adding HE language

### DIFF
--- a/src/Carbon/Lang/he.php
+++ b/src/Carbon/Lang/he.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Translation messages.  See http://symfony.com/doc/current/book/translation.html
+ * for possible formats.
+ *
+ */
+return array(
+    'year'      => 'שנה|{2}שנתיים|:count שנים',
+    'month'     => 'חודש|{2}חודשיים|:count חודשים',
+    'week'      => 'שבוע|{2}שבועיים|:count שבועות',
+    'day'       => 'יום|{2}יומיים|:count ימים',
+    'hour'      => 'שעה|{2}שעתיים|:count שעות',
+    'minute'    => 'דקה|{2}דקותיים|:count דקות',
+    'second'    => 'שניה|:count שניות',
+    'ago'       => 'לפני :time',
+    'from_now'  => 'בעוד :time',
+    'after'     => 'אחרי :time',
+    'before'    => 'לפני :time',
+);


### PR DESCRIPTION
Adding Hebrew to Carbon, allowing ->diffForHumans() to work in hebrew as well.
Made difference between "one minute", "two minutes" and ":n minutes" in HE, as it should.