### PR TITLE
Dynamic first/last day of week and weekend days

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -141,7 +141,7 @@ class Carbon extends DateTime
      *
      * @var array
      */
-    protected static $weekendDays = [self::SATURDAY, self::SUNDAY];
+    protected static $weekendDays = array(self::SATURDAY, self::SUNDAY);
 
     /**
      * A test Carbon instance to be returned when now instances are created

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -121,6 +121,28 @@ class Carbon extends DateTime
      */
     protected static $toStringFormat = self::DEFAULT_TO_STRING_FORMAT;
 
+
+    /**
+     * First day of week
+     *
+     * @var int
+     */
+    protected static $weekStartsAt = self::MONDAY;
+
+    /**
+     * Last day of week
+     *
+     * @var int
+     */
+    protected static $weekEndsAt = self::SUNDAY;
+
+    /**
+     * Days of weekend
+     *
+     * @var array
+     */
+    protected static $weekendDays = [self::SATURDAY, self::SUNDAY];
+
     /**
      * A test Carbon instance to be returned when now instances are created
      *
@@ -715,6 +737,73 @@ class Carbon extends DateTime
         return $this;
     }
 
+
+
+    ///////////////////////////////////////////////////////////////////
+    /////////////////////// WEEK SPECIAL DAYS /////////////////////////
+    ///////////////////////////////////////////////////////////////////
+
+    /**
+     * Get the first day of week
+     *
+     * @return int
+     */
+    public static function getWeekStartsAt()
+    {
+        return static::$weekStartsAt;
+    }
+
+    /**
+     * Set the first day of week
+     *
+     * @param int
+     */
+    public static function setWeekStartsAt($day)
+    {
+        static::$weekStartsAt = $day;
+    }
+
+    /**
+     * Get the last day of week
+     *
+     * @return int
+     */
+    public static function getWeekEndsAt()
+    {
+        return static::$weekEndsAt;
+    }
+
+    /**
+     * Set the first day of week
+     *
+     * @param int
+     */
+    public static function setWeekEndsAt($day)
+    {
+        static::$weekEndsAt = $day;
+    }
+
+    /**
+     * Get weekend days
+     *
+     * @return array
+     */
+    public static function getWeekendDays()
+    {
+        return static::$weekendDays;
+    }
+
+    /**
+     * Set weekend days
+     *
+     * @param array
+     */
+    public static function setWeekendDays($days)
+    {
+        static::$weekendDays = $days;
+    }
+
+
     ///////////////////////////////////////////////////////////////////
     ///////////////////////// TESTING AIDS ////////////////////////////
     ///////////////////////////////////////////////////////////////////
@@ -1194,7 +1283,7 @@ class Carbon extends DateTime
      */
     public function isWeekday()
     {
-        return ($this->dayOfWeek != static::SUNDAY && $this->dayOfWeek != static::SATURDAY);
+        return !$this->isWeekend();
     }
 
     /**
@@ -1204,7 +1293,7 @@ class Carbon extends DateTime
      */
     public function isWeekend()
     {
-        return !$this->isWeekDay();
+        return in_array($this->dayOfWeek, self::$weekendDays);
     }
 
     /**
@@ -2105,28 +2194,28 @@ class Carbon extends DateTime
     }
 
     /**
-     * Resets the date to the first day of the ISO-8601 week (Monday) and the time to 00:00:00
+     * Resets the date to the first day of week (defined in $weekStartsAt) and the time to 00:00:00
      *
      * @return static
      */
     public function startOfWeek()
     {
-        if ($this->dayOfWeek != static::MONDAY) {
-            $this->previous(static::MONDAY);
+        if ($this->dayOfWeek != static::$weekStartsAt) {
+            $this->previous(static::$weekStartsAt);
         }
 
         return $this->startOfDay();
     }
 
     /**
-     * Resets the date to end of the ISO-8601 week (Sunday) and time to 23:59:59
+     * Resets the date to end of week (defined in $weekEndsAt) and time to 23:59:59
      *
      * @return static
      */
     public function endOfWeek()
     {
-        if ($this->dayOfWeek != static::SUNDAY) {
-            $this->next(static::SUNDAY);
+        if ($this->dayOfWeek != static::$weekEndsAt) {
+            $this->next(static::$weekEndsAt);
         }
 
         return $this->endOfDay();


### PR DESCRIPTION
In Israel, week starts at Sunday and ends at Saturday, weekend days are Friday and Saturday
and many other countries has their own weekends and weird calendars.. so I think it might help others

Added:
protected static $weekStartsAt integer (use Carbon::DAYCONST)
protected static $weekEndsAt integer (use Carbon::DAYCONST)
protected static $weekendDays array (array of Carbon::DAYCONST)
public static function getWeekStartsAt()
public static function setWeekStartsAt($day)
public static function getWeekEndsAt()
public static function setWeekEndsAt($day)
public static function getWeekendDays()
public static function setWeekendDays($days)

Updated:
isWeekday() - to use !$this->isWeekend()
isWeekend() - to check if current day is in static::$weekendDays
startOfWeek() - to use static::$weekStartsAt
endOfWeek() - to use static::$weekEndsAt