### PR TITLE
Allow installs with symfony 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": ">=5.3.0",
-    "symfony/translation": "~2.6"
+    "symfony/translation": "~2.6|~3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
If this is working on symfony 2.7 with the BC warnings, then it must be working on Symfony 3.0.