### PR TITLE
Fix start/end of century.

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -2286,7 +2286,7 @@ class Carbon extends DateTime
      */
     public function startOfCentury()
     {
-        return $this->startOfYear()->year($this->year - $this->year % static::YEARS_PER_CENTURY + 1);
+        return $this->startOfYear()->year(($this->year - 1) - ($this->year - 1) % static::YEARS_PER_CENTURY + 1);
     }
 
     /**
@@ -2296,7 +2296,7 @@ class Carbon extends DateTime
      */
     public function endOfCentury()
     {
-        return $this->endOfYear()->year($this->year - $this->year % static::YEARS_PER_CENTURY + static::YEARS_PER_CENTURY);
+        return $this->endOfYear()->year(($this->year - 1) - ($this->year - 1) % static::YEARS_PER_CENTURY + static::YEARS_PER_CENTURY);
     }
 
     /**

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -2286,7 +2286,7 @@ class Carbon extends DateTime
      */
     public function startOfCentury()
     {
-        return $this->startOfYear()->year($this->year - $this->year % static::YEARS_PER_CENTURY);
+        return $this->startOfYear()->year($this->year - $this->year % static::YEARS_PER_CENTURY + 1);
     }
 
     /**
@@ -2296,7 +2296,7 @@ class Carbon extends DateTime
      */
     public function endOfCentury()
     {
-        return $this->endOfYear()->year($this->year - $this->year % static::YEARS_PER_CENTURY + static::YEARS_PER_CENTURY - 1);
+        return $this->endOfYear()->year($this->year - $this->year % static::YEARS_PER_CENTURY + static::YEARS_PER_CENTURY);
     }
 
     /**

--- a/tests/StartEndOfTest.php
+++ b/tests/StartEndOfTest.php
@@ -167,20 +167,21 @@ class StartEndOfTest extends TestFixture
 
     public function testStartOfCenturyFromNow()
     {
+        $now = Carbon::now();
         $dt = Carbon::now()->startOfCentury();
-        $this->assertCarbon($dt, $dt->year - $dt->year % 100, 1, 1, 0, 0, 0);
+        $this->assertCarbon($dt, $now->year - $now->year % 100 + 1, 1, 1, 0, 0, 0);
     }
 
     public function testStartOfCenturyFromFirstDay()
     {
         $dt = Carbon::create(2000, 1, 1, 1, 1, 1)->startOfCentury();
-        $this->assertCarbon($dt, 2000, 1, 1, 0, 0, 0);
+        $this->assertCarbon($dt, 2001, 1, 1, 0, 0, 0);
     }
 
     public function testStartOfCenturyFromLastDay()
     {
         $dt = Carbon::create(2009, 12, 31, 23, 59, 59)->startOfCentury();
-        $this->assertCarbon($dt, 2000, 1, 1, 0, 0, 0);
+        $this->assertCarbon($dt, 2001, 1, 1, 0, 0, 0);
     }
 
     public function testEndOfCenturyIsFluid()
@@ -191,20 +192,21 @@ class StartEndOfTest extends TestFixture
 
     public function testEndOfCenturyFromNow()
     {
+        $now = Carbon::now();
         $dt = Carbon::now()->endOfCentury();
-        $this->assertCarbon($dt, $dt->year - $dt->year % 100 + 99, 12, 31, 23, 59, 59);
+        $this->assertCarbon($dt, $now->year - $now->year % 100 + 100, 12, 31, 23, 59, 59);
     }
 
     public function testEndOfCenturyFromFirstDay()
     {
         $dt = Carbon::create(2000, 1, 1, 1, 1, 1)->endOfCentury();
-        $this->assertCarbon($dt, 2099, 12, 31, 23, 59, 59);
+        $this->assertCarbon($dt, 2100, 12, 31, 23, 59, 59);
     }
 
     public function testEndOfCenturyFromLastDay()
     {
         $dt = Carbon::create(2099, 12, 31, 23, 59, 59)->endOfCentury();
-        $this->assertCarbon($dt, 2099, 12, 31, 23, 59, 59);
+        $this->assertCarbon($dt, 2100, 12, 31, 23, 59, 59);
     }
 
     public function testAverageIsFluid()

--- a/tests/StartEndOfTest.php
+++ b/tests/StartEndOfTest.php
@@ -174,13 +174,13 @@ class StartEndOfTest extends TestFixture
 
     public function testStartOfCenturyFromFirstDay()
     {
-        $dt = Carbon::create(2000, 1, 1, 1, 1, 1)->startOfCentury();
+        $dt = Carbon::create(2001, 1, 1, 1, 1, 1)->startOfCentury();
         $this->assertCarbon($dt, 2001, 1, 1, 0, 0, 0);
     }
 
     public function testStartOfCenturyFromLastDay()
     {
-        $dt = Carbon::create(2009, 12, 31, 23, 59, 59)->startOfCentury();
+        $dt = Carbon::create(2100, 12, 31, 23, 59, 59)->startOfCentury();
         $this->assertCarbon($dt, 2001, 1, 1, 0, 0, 0);
     }
 
@@ -199,13 +199,13 @@ class StartEndOfTest extends TestFixture
 
     public function testEndOfCenturyFromFirstDay()
     {
-        $dt = Carbon::create(2000, 1, 1, 1, 1, 1)->endOfCentury();
+        $dt = Carbon::create(2001, 1, 1, 1, 1, 1)->endOfCentury();
         $this->assertCarbon($dt, 2100, 12, 31, 23, 59, 59);
     }
 
     public function testEndOfCenturyFromLastDay()
     {
-        $dt = Carbon::create(2099, 12, 31, 23, 59, 59)->endOfCentury();
+        $dt = Carbon::create(2100, 12, 31, 23, 59, 59)->endOfCentury();
         $this->assertCarbon($dt, 2100, 12, 31, 23, 59, 59);
     }
 


### PR DESCRIPTION
The 1st century AD/CE started on January 1, 1 and ended on December 31, 100. 
https://en.wikipedia.org/wiki/Century