### PR TITLE
Use the OS language instead of English

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -885,9 +885,12 @@ class Carbon extends DateTime
     protected static function translator()
     {
         if (static::$translator == null) {
-            static::$translator = new Translator('en');
+            // If intl extension is loaded, the OS language is used
+            $defaultLocaleLanguage = extension_loaded('intl') ? substr(locale_get_default(), 0, 2) : 'en';
+            
+            static::$translator = new Translator($defaultLocaleLanguage);
             static::$translator->addLoader('array', new ArrayLoader());
-            static::setLocale('en');
+            static::setLocale($defaultLocaleLanguage);
         }
 
         return static::$translator;


### PR DESCRIPTION
Use the default OS language instead of English if the INTL extension is loaded.

If the user's OS has the INTL extension, Carbon will use the intl.default_locale variable in the PHP configuration as default language.
