### PR TITLE
Fix: Remove duplicate array key

### DIFF
--- a/src/Carbon/Lang/th.php
+++ b/src/Carbon/Lang/th.php
@@ -23,7 +23,6 @@ return array(
     'hour'      => '1 ชั่วโมง|:count ชั่วโมง',
     'minute'    => '1 นาที|:count นาที',
     'second'    => '1 วินาที|:count วินาที',
-    'ago'       => ':time sitten',
     'ago'       => ':time ที่แล้ว',
     'from_now'  => ':time จากนี้',
     'after'     => 'หลัง:time',


### PR DESCRIPTION
This PR

* [x] removes a key-value-pair from an array where the key is a duplicate