### PR TITLE
Removed duplicate Thai language array key

### DIFF
--- a/src/Carbon/Lang/th.php
+++ b/src/Carbon/Lang/th.php
@@ -23,7 +23,6 @@ return array(
     'hour'      => '1 ชั่วโมง|:count ชั่วโมง',
     'minute'    => '1 นาที|:count นาที',
     'second'    => '1 วินาที|:count วินาที',
-    'ago'       => ':time sitten',
     'ago'       => ':time ที่แล้ว',
     'from_now'  => ':time จากนี้',
     'after'     => 'หลัง:time',


### PR DESCRIPTION
Removed the duplicate key 'ago'. 

Google Translate translates 'ago' to:
มาแล้ว

However, the translation given is probably the correct version (that also translates to 'ago'):
ที่แล้ว

Here's the link to the translation:
https://translate.google.com/#en/th/ago