### PR TITLE
Add test for add and sub weekdays during weekend

### DIFF
--- a/tests/AddTest.php
+++ b/tests/AddTest.php
@@ -119,6 +119,11 @@ class AddTest extends TestFixture
         $this->assertSame(9, Carbon::createFromDate(2012, 1, 6)->addWeekday()->day);
     }
 
+    public function testAddWeekdayDuringWeekend()
+    {
+        $this->assertSame(9, Carbon::createFromDate(2012, 1, 7)->addWeekday()->day);
+    }
+
     public function testAddWeeksPositive()
     {
         $this->assertSame(28, Carbon::createFromDate(1975, 5, 21)->addWeeks(1)->day);

--- a/tests/SubTest.php
+++ b/tests/SubTest.php
@@ -93,6 +93,11 @@ class SubTest extends TestFixture
         $this->assertSame(6, Carbon::createFromDate(2012, 1, 9)->subWeekday()->day);
     }
 
+    public function testSubWeekdayDuringWeekend()
+    {
+        $this->assertSame(6, Carbon::createFromDate(2012, 1, 8)->subWeekday()->day);
+    }
+
     public function testSubWeeksPositive()
     {
         $this->assertSame(14, Carbon::createFromDate(1975, 5, 21)->subWeeks(1)->day);


### PR DESCRIPTION
Test for attempts to add or subtract weekdays on a weekend. For when someone tries to make an attempt to change add and sub weekends functionality (planning on doing this).