### PR TITLE
Allow for creation of a zero interval.

### DIFF
--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -48,7 +48,7 @@ use Symfony\Component\Translation\Loader\ArrayLoader;
  * @method static CarbonInterval minute($minutes = 1) Alias for minutes()
  * @method static CarbonInterval seconds($seconds = 1) Create instance specifying a number of seconds.
  * @method static CarbonInterval second($seconds = 1) Alias for seconds()
- * 
+ *
  * @method CarbonInterval years() years($years = 1) Set the years portion of the current interval.
  * @method CarbonInterval year() year($years = 1) Alias for years().
  * @method CarbonInterval months() months($months = 1) Set the months portion of the current interval.
@@ -137,6 +137,11 @@ class CarbonInterval extends DateInterval
             $spec .= $hours > 0 ? $hours.static::PERIOD_HOURS : '';
             $spec .= $minutes > 0 ? $minutes.static::PERIOD_MINUTES : '';
             $spec .= $seconds > 0 ? $seconds.static::PERIOD_SECONDS : '';
+        }
+
+        if ($spec == static::PERIOD_PREFIX) {
+            // Allow the zero interval.
+            $spec .= '0'.static::PERIOD_YEARS;
         }
 
         parent::__construct($spec);


### PR DESCRIPTION
Fixes issue https://github.com/briannesbitt/Carbon/issues/369. This also allows us to construct a new interval using method chaining, where the first method contains a zero timestamp. Example:

    CarbonInterval::days(0)->weeks(1);

Jarno