### PR TITLE
Fix: createFromTimestamp() vs createFromTimeStamp()

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ echo Carbon::now()->subMinutes(2)->diffForHumans(); // '2 minutes ago'
 // ... but also does 'from now', 'after' and 'before'
 // rolling up to seconds, minutes, hours, days, months, years
 
-$daysSinceEpoch = Carbon::createFromTimeStamp(0)->diffInDays();
+$daysSinceEpoch = Carbon::createFromTimestamp(0)->diffInDays();
 ```
 
 ## Installation


### PR DESCRIPTION
This PR

* [x] fixes a small thing in `README.md` where it is proposed to use `Carbon::createFromTimeStamp()`, but actually, it is `Carbon::createFromTimestamp()`

