### PR TITLE
Fix: createFromTimestamp() vs createFromTimeStamp()

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -139,8 +139,8 @@ try { Carbon::create(1975, 5, 21, 22, -2, 0); } catch(InvalidArgumentException $
 
 <p>The final two create functions are for working with <a href="http://en.wikipedia.org/wiki/Unix_time">unix timestamps</a>.  The first will create a Carbon instance equal to the given timestamp and will set the timezone as well or default it to the current timezone.  The second, <code>createFromTimestampUTC()</code>, is different in that the timezone will remain UTC (GMT).  The second acts the same as <code>Carbon::createFromFormat('@'.$timestamp)</code> but I have just made it a little more explicit.  Negative timestamps are also allowed.</p>
 
-<p><pre><code class="php">echo Carbon::createFromTimeStamp(-1)->toDateTimeString();                        // 1969-12-31 18:59:59
-echo Carbon::createFromTimeStamp(-1, 'Europe/London')->toDateTimeString();       // 1970-01-01 00:59:59
+<p><pre><code class="php">echo Carbon::createFromTimestamp(-1)->toDateTimeString();                        // 1969-12-31 18:59:59
+echo Carbon::createFromTimestamp(-1, 'Europe/London')->toDateTimeString();       // 1970-01-01 00:59:59
 echo Carbon::createFromTimeStampUTC(-1)->toDateTimeString();                     // 1969-12-31 23:59:59
 </code></pre></p>
 

--- a/docs/index.src.html
+++ b/docs/index.src.html
@@ -92,8 +92,8 @@ $noonLondonTz = Carbon::createFromTime(12, 0, 0, 'Europe/London');
 
 <p>The final two create functions are for working with <a href="http://en.wikipedia.org/wiki/Unix_time">unix timestamps</a>.  The first will create a Carbon instance equal to the given timestamp and will set the timezone as well or default it to the current timezone.  The second, <code>createFromTimestampUTC()</code>, is different in that the timezone will remain UTC (GMT).  The second acts the same as <code>Carbon::createFromFormat('@'.$timestamp)</code> but I have just made it a little more explicit.  Negative timestamps are also allowed.</p>
 
-<p><pre><code class="php">{{createFromTimeStamp1::exec(echo Carbon::createFromTimeStamp(-1)->toDateTimeString();/*pad(80)*/)}} // {{createFromTimeStamp1_eval}}
-{{createFromTimeStamp2::exec(echo Carbon::createFromTimeStamp(-1, 'Europe/London')->toDateTimeString();/*pad(80)*/)}} // {{createFromTimeStamp2_eval}}
+<p><pre><code class="php">{{createFromTimeStamp1::exec(echo Carbon::createFromTimestamp(-1)->toDateTimeString();/*pad(80)*/)}} // {{createFromTimeStamp1_eval}}
+{{createFromTimeStamp2::exec(echo Carbon::createFromTimestamp(-1, 'Europe/London')->toDateTimeString();/*pad(80)*/)}} // {{createFromTimeStamp2_eval}}
 {{createFromTimeStampUTC::exec(echo Carbon::createFromTimeStampUTC(-1)->toDateTimeString();/*pad(80)*/)}} // {{createFromTimeStampUTC_eval}}
 </code></pre></p>
 

--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@ echo Carbon::now()->subMinutes(2)->diffForHumans(); // '2 minutes ago'
 CarbonInterval::setLocale('fr');
 echo CarbonInterval::years(2)->minutes(2); // '2 ans 2 minutes'
 
-$daysSinceEpoch = Carbon::createFromTimeStamp(0)->diffInDays();
+$daysSinceEpoch = Carbon::createFromTimestamp(0)->diffInDays();
 </code></pre>
    </div>
 </div>

--- a/jumbotron.src.html
+++ b/jumbotron.src.html
@@ -39,7 +39,7 @@ if (Carbon::now()->isWeekend()) {
 {{interval::exec(echo CarbonInterval::years(2)->minutes(2);)}} // '{{interval_eval}}'
 
 {{::lint(
-$daysSinceEpoch = Carbon::createFromTimeStamp(0)->diffInDays();
+$daysSinceEpoch = Carbon::createFromTimestamp(0)->diffInDays();
 )}}
 </code></pre>
    </div>


### PR DESCRIPTION
This PR

* [x] fixes a small thing in the docs where it is proposed to use Carbon::createFromTimeStamp(), but actually, it is Carbon::createFromTimestamp()

Related to https://github.com/briannesbitt/Carbon/pull/438.

/cc @PSmolic

:information_desk_person: This updates the `gh-pages` branch.