### PR TITLE
Composer will use the caret operator when using requiring a package.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ $ composer require nesbot/carbon
 ```json
 {
     "require": {
-        "nesbot/carbon": "~1.14"
+        "nesbot/carbon": "^1.20"
     }
 }
 ```


### PR DESCRIPTION
Composer will use the caret sign in newer versions.

```bash
$ composer require nesbot/carbon
Using version ^1.20 for nesbot/carbon
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
  - Installing nesbot/carbon (1.20.0)
    Downloading: 100%         
```

```bash
$ cat composer.json 
{
    "require": {
        "nesbot/carbon": "^1.20"
    }
}
```
