### PR TITLE
fix: Spanish translation

### DIFF
--- a/src/Carbon/Lang/es.php
+++ b/src/Carbon/Lang/es.php
@@ -24,6 +24,6 @@ return array(
     'second'    => '1 segundo|:count segundos',
     'ago'       => 'hace :time',
     'from_now'  => 'dentro de :time',
-    'after'     => ':time antes',
-    'before'    => ':time después',
+    'after'     => ':time después',
+    'before'    => ':time antes',
 );

--- a/tests/LocalizationTest.php
+++ b/tests/LocalizationTest.php
@@ -167,8 +167,8 @@ class LocalizationTest extends TestFixture
 
             $d = Carbon::now()->addSecond();
             $d2 = Carbon::now();
-            $scope->assertSame('1 segundo antes', $d->diffForHumans($d2));
-            $scope->assertSame('1 segundo después', $d2->diffForHumans($d));
+            $scope->assertSame('1 segundo después', $d->diffForHumans($d2));
+            $scope->assertSame('1 segundo antes', $d2->diffForHumans($d));
 
             $scope->assertSame('1 segundo', $d->diffForHumans($d2, true));
             $scope->assertSame('2 segundos', $d2->diffForHumans($d->addSecond(), true));


### PR DESCRIPTION
Current translation for `after` and `before` is wrong.

`current`
```javascript
after: antes
before: después
```

`correct`
```javascript
after: después
before: antes
```