### PR TITLE
Allow phpunit 5 too

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "symfony/translation": "~2.6|~3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.0"
+    "phpunit/phpunit": "~4.0|~5.0"
   },
   "autoload": {
     "psr-0": {


### PR DESCRIPTION
PHPUnit 5 is the first release to actually say that it supports php 7, so we want to run our tests on php 7, we need to use PHPUnit 5.