### PR TITLE
Remove CarbonInterval suffix

### DIFF
--- a/tests/CarbonInterval/AddTest.php
+++ b/tests/CarbonInterval/AddTest.php
@@ -16,7 +16,7 @@ use Carbon\Carbon;
 use DateInterval;
 use Tests\AbstractTestCase;
 
-class CarbonIntervalAddTest extends AbstractTestCase
+class AddTest extends AbstractTestCase
 {
     public function testAdd()
     {

--- a/tests/CarbonInterval/ConstructTest.php
+++ b/tests/CarbonInterval/ConstructTest.php
@@ -16,7 +16,7 @@ use Carbon\Carbon;
 use DateInterval;
 use Tests\AbstractTestCase;
 
-class CarbonIntervalConstructTest extends AbstractTestCase
+class ConstructTest extends AbstractTestCase
 {
     public function testDefaults()
     {

--- a/tests/CarbonInterval/ForHumansTest.php
+++ b/tests/CarbonInterval/ForHumansTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Translation\Translator;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 use Tests\AbstractTestCase;
 
-class CarbonIntervalForHumansTest extends AbstractTestCase
+class ForHumansTest extends AbstractTestCase
 {
     public function testGetTranslator()
     {

--- a/tests/CarbonInterval/GettersTest.php
+++ b/tests/CarbonInterval/GettersTest.php
@@ -14,7 +14,7 @@ namespace Tests\CarbonInterval;
 use Carbon\CarbonInterval;
 use Tests\AbstractTestCase;
 
-class CarbonIntervalGettersTest extends AbstractTestCase
+class GettersTest extends AbstractTestCase
 {
     public function testGettersThrowExceptionOnUnknownGetter()
     {

--- a/tests/CarbonInterval/SettersTest.php
+++ b/tests/CarbonInterval/SettersTest.php
@@ -14,7 +14,7 @@ namespace Tests\CarbonInterval;
 use Carbon\CarbonInterval;
 use Tests\AbstractTestCase;
 
-class CarbonIntervalSettersTest extends AbstractTestCase
+class SettersTest extends AbstractTestCase
 {
     public function testYearsSetter()
     {


### PR DESCRIPTION
The CarbonInterval suffix is not useful anymore as the test class is in its own folder