### PR TITLE
Reorganize localizations tests

### DIFF
--- a/tests/Carbon/LocalizationTest.php
+++ b/tests/Carbon/LocalizationTest.php
@@ -25,539 +25,90 @@ class LocalizationTest extends AbstractTestCase
         $this->assertSame('en', $t->getLocale());
     }
 
-    public function testSetTranslator()
+    /**
+     * @see \Tests\Carbon\LocalizationTest::testSetLocale
+     * @see \Tests\Carbon\LocalizationTest::testSetTranslator
+     *
+     * @return array
+     */
+    public function providerLocales()
     {
-        $t = new Translator('fr');
+        return array(
+            array('af'),
+            array('ar'),
+            array('az'),
+            array('bg'),
+            array('bn'),
+            array('ca'),
+            array('cs'),
+            array('da'),
+            array('de'),
+            array('el'),
+            array('en'),
+            array('eo'),
+            array('es'),
+            array('et'),
+            array('eu'),
+            array('fa'),
+            array('fi'),
+            array('fo'),
+            array('fr'),
+            array('he'),
+            array('hr'),
+            array('hu'),
+            array('id'),
+            array('it'),
+            array('ja'),
+            array('ko'),
+            array('lt'),
+            array('lv'),
+            array('ms'),
+            array('nl'),
+            array('no'),
+            array('pl'),
+            array('pt'),
+            array('pt_BR'),
+            array('ro'),
+            array('ru'),
+            array('sk'),
+            array('sl'),
+            array('sq'),
+            array('sr'),
+            array('sv'),
+            array('th'),
+            array('tr'),
+            array('uk'),
+            array('uz'),
+            array('vi'),
+            array('zh'),
+            array('zh-TW'),
+        );
+    }
+
+    /**
+     * @dataProvider \Tests\Carbon\LocalizationTest::providerLocales
+     *
+     * @param string $locale
+     */
+    public function testSetLocale($locale)
+    {
+        Carbon::setLocale($locale);
+        $this->assertSame($locale, Carbon::getLocale());
+    }
+
+    /**
+     * @dataProvider \Tests\Carbon\LocalizationTest::providerLocales
+     *
+     * @param string $locale
+     */
+    public function testSetTranslator($locale)
+    {
+        $t = new Translator($locale);
         $t->addLoader('array', new ArrayLoader());
         Carbon::setTranslator($t);
 
         $t = Carbon::getTranslator();
         $this->assertNotNull($t);
-        $this->assertSame('fr', $t->getLocale());
-    }
-
-    public function testGetLocale()
-    {
-        Carbon::setLocale('en');
-        $this->assertSame('en', Carbon::getLocale());
-    }
-
-    public function testSetLocale()
-    {
-        Carbon::setLocale('en');
-        $this->assertSame('en', Carbon::getLocale());
-        Carbon::setLocale('fr');
-        $this->assertSame('fr', Carbon::getLocale());
-    }
-
-    /**
-     * The purpose of these tests aren't to test the validitity of the translation
-     * but more so to test that the language file exists.
-     */
-    public function testDiffForHumansLocalizedInFrench()
-    {
-        Carbon::setLocale('fr');
-
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-
-            $d = Carbon::now()->subSecond();
-            $scope->assertSame('il y a 1 seconde', $d->diffForHumans());
-
-            $d = Carbon::now()->subSeconds(2);
-            $scope->assertSame('il y a 2 secondes', $d->diffForHumans());
-
-            $d = Carbon::now()->subMinute();
-            $scope->assertSame('il y a 1 minute', $d->diffForHumans());
-
-            $d = Carbon::now()->subMinutes(2);
-            $scope->assertSame('il y a 2 minutes', $d->diffForHumans());
-
-            $d = Carbon::now()->subHour();
-            $scope->assertSame('il y a 1 heure', $d->diffForHumans());
-
-            $d = Carbon::now()->subHours(2);
-            $scope->assertSame('il y a 2 heures', $d->diffForHumans());
-
-            $d = Carbon::now()->subDay();
-            $scope->assertSame('il y a 1 jour', $d->diffForHumans());
-
-            $d = Carbon::now()->subDays(2);
-            $scope->assertSame('il y a 2 jours', $d->diffForHumans());
-
-            $d = Carbon::now()->subWeek();
-            $scope->assertSame('il y a 1 semaine', $d->diffForHumans());
-
-            $d = Carbon::now()->subWeeks(2);
-            $scope->assertSame('il y a 2 semaines', $d->diffForHumans());
-
-            $d = Carbon::now()->subMonth();
-            $scope->assertSame('il y a 1 mois', $d->diffForHumans());
-
-            $d = Carbon::now()->subMonths(2);
-            $scope->assertSame('il y a 2 mois', $d->diffForHumans());
-
-            $d = Carbon::now()->subYear();
-            $scope->assertSame('il y a 1 an', $d->diffForHumans());
-
-            $d = Carbon::now()->subYears(2);
-            $scope->assertSame('il y a 2 ans', $d->diffForHumans());
-
-            $d = Carbon::now()->addSecond();
-            $scope->assertSame('dans 1 seconde', $d->diffForHumans());
-
-            $d = Carbon::now()->addSecond();
-            $d2 = Carbon::now();
-            $scope->assertSame('1 seconde après', $d->diffForHumans($d2));
-            $scope->assertSame('1 seconde avant', $d2->diffForHumans($d));
-
-            $scope->assertSame('1 seconde', $d->diffForHumans($d2, true));
-            $scope->assertSame('2 secondes', $d2->diffForHumans($d->addSecond(), true));
-        });
-    }
-
-    public function testDiffForHumansLocalizedInSpanish()
-    {
-        Carbon::setLocale('es');
-
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $d = Carbon::now()->subSecond();
-            $scope->assertSame('hace 1 segundo', $d->diffForHumans());
-
-            $d = Carbon::now()->subSeconds(3);
-            $scope->assertSame('hace 3 segundos', $d->diffForHumans());
-
-            $d = Carbon::now()->subMinute();
-            $scope->assertSame('hace 1 minuto', $d->diffForHumans());
-
-            $d = Carbon::now()->subMinutes(2);
-            $scope->assertSame('hace 2 minutos', $d->diffForHumans());
-
-            $d = Carbon::now()->subHour();
-            $scope->assertSame('hace 1 hora', $d->diffForHumans());
-
-            $d = Carbon::now()->subHours(2);
-            $scope->assertSame('hace 2 horas', $d->diffForHumans());
-
-            $d = Carbon::now()->subDay();
-            $scope->assertSame('hace 1 día', $d->diffForHumans());
-
-            $d = Carbon::now()->subDays(2);
-            $scope->assertSame('hace 2 días', $d->diffForHumans());
-
-            $d = Carbon::now()->subWeek();
-            $scope->assertSame('hace 1 semana', $d->diffForHumans());
-
-            $d = Carbon::now()->subWeeks(2);
-            $scope->assertSame('hace 2 semanas', $d->diffForHumans());
-
-            $d = Carbon::now()->subMonth();
-            $scope->assertSame('hace 1 mes', $d->diffForHumans());
-
-            $d = Carbon::now()->subMonths(2);
-            $scope->assertSame('hace 2 meses', $d->diffForHumans());
-
-            $d = Carbon::now()->subYear();
-            $scope->assertSame('hace 1 año', $d->diffForHumans());
-
-            $d = Carbon::now()->subYears(2);
-            $scope->assertSame('hace 2 años', $d->diffForHumans());
-
-            $d = Carbon::now()->addSecond();
-            $scope->assertSame('dentro de 1 segundo', $d->diffForHumans());
-
-            $d = Carbon::now()->addSecond();
-            $d2 = Carbon::now();
-            $scope->assertSame('1 segundo después', $d->diffForHumans($d2));
-            $scope->assertSame('1 segundo antes', $d2->diffForHumans($d));
-
-            $scope->assertSame('1 segundo', $d->diffForHumans($d2, true));
-            $scope->assertSame('2 segundos', $d2->diffForHumans($d->addSecond(), true));
-        });
-    }
-
-    public function testDiffForHumansLocalizedInItalian()
-    {
-        Carbon::setLocale('it');
-
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $d = Carbon::now()->addYear();
-            $scope->assertSame('1 anno da adesso', $d->diffForHumans());
-
-            $d = Carbon::now()->addYears(2);
-            $scope->assertSame('2 anni da adesso', $d->diffForHumans());
-        });
-    }
-
-    public function testDiffForHumansLocalizedInGerman()
-    {
-        Carbon::setLocale('de');
-
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $d = Carbon::now()->addYear();
-            $scope->assertSame('in 1 Jahr', $d->diffForHumans());
-
-            $d = Carbon::now()->addYears(2);
-            $scope->assertSame('in 2 Jahren', $d->diffForHumans());
-
-            $d = Carbon::now()->subYear();
-            $scope->assertSame('1 Jahr später', Carbon::now()->diffForHumans($d));
-
-            $d = Carbon::now()->subYears(2);
-            $scope->assertSame('2 Jahre später', Carbon::now()->diffForHumans($d));
-
-            $d = Carbon::now()->addYear();
-            $scope->assertSame('1 Jahr zuvor', Carbon::now()->diffForHumans($d));
-
-            $d = Carbon::now()->addYears(2);
-            $scope->assertSame('2 Jahre zuvor', Carbon::now()->diffForHumans($d));
-
-            $d = Carbon::now()->subYear();
-            $scope->assertSame('vor 1 Jahr', $d->diffForHumans());
-
-            $d = Carbon::now()->subYears(2);
-            $scope->assertSame('vor 2 Jahren', $d->diffForHumans());
-        });
-    }
-
-    public function testDiffForHumansLocalizedInTurkish()
-    {
-        Carbon::setLocale('tr');
-
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $d = Carbon::now()->subSecond();
-            $scope->assertSame('1 saniye önce', $d->diffForHumans());
-
-            $d = Carbon::now()->subSeconds(2);
-            $scope->assertSame('2 saniye önce', $d->diffForHumans());
-
-            $d = Carbon::now()->subMinute();
-            $scope->assertSame('1 dakika önce', $d->diffForHumans());
-
-            $d = Carbon::now()->subMinutes(2);
-            $scope->assertSame('2 dakika önce', $d->diffForHumans());
-
-            $d = Carbon::now()->subHour();
-            $scope->assertSame('1 saat önce', $d->diffForHumans());
-
-            $d = Carbon::now()->subHours(2);
-            $scope->assertSame('2 saat önce', $d->diffForHumans());
-
-            $d = Carbon::now()->subDay();
-            $scope->assertSame('1 gün önce', $d->diffForHumans());
-
-            $d = Carbon::now()->subDays(2);
-            $scope->assertSame('2 gün önce', $d->diffForHumans());
-
-            $d = Carbon::now()->subWeek();
-            $scope->assertSame('1 hafta önce', $d->diffForHumans());
-
-            $d = Carbon::now()->subWeeks(2);
-            $scope->assertSame('2 hafta önce', $d->diffForHumans());
-
-            $d = Carbon::now()->subMonth();
-            $scope->assertSame('1 ay önce', $d->diffForHumans());
-
-            $d = Carbon::now()->subMonths(2);
-            $scope->assertSame('2 ay önce', $d->diffForHumans());
-
-            $d = Carbon::now()->subYear();
-            $scope->assertSame('1 yıl önce', $d->diffForHumans());
-
-            $d = Carbon::now()->subYears(2);
-            $scope->assertSame('2 yıl önce', $d->diffForHumans());
-
-            $d = Carbon::now()->addSecond();
-            $scope->assertSame('1 saniye andan itibaren', $d->diffForHumans());
-
-            $d = Carbon::now()->addSecond();
-            $d2 = Carbon::now();
-            $scope->assertSame('1 saniye sonra', $d->diffForHumans($d2));
-            $scope->assertSame('1 saniye önce', $d2->diffForHumans($d));
-
-            $scope->assertSame('1 saniye', $d->diffForHumans($d2, true));
-            $scope->assertSame('2 saniye', $d2->diffForHumans($d->addSecond(), true));
-        });
-    }
-
-    public function testDiffForHumansLocalizedInDanish()
-    {
-        Carbon::setLocale('da');
-
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $d = Carbon::now()->subSecond();
-            $scope->assertSame('1 sekund siden', $d->diffForHumans());
-
-            $d = Carbon::now()->subSeconds(2);
-            $scope->assertSame('2 sekunder siden', $d->diffForHumans());
-
-            $d = Carbon::now()->subMinute();
-            $scope->assertSame('1 minut siden', $d->diffForHumans());
-
-            $d = Carbon::now()->subMinutes(2);
-            $scope->assertSame('2 minutter siden', $d->diffForHumans());
-
-            $d = Carbon::now()->subHour();
-            $scope->assertSame('1 time siden', $d->diffForHumans());
-
-            $d = Carbon::now()->subHours(2);
-            $scope->assertSame('2 timer siden', $d->diffForHumans());
-
-            $d = Carbon::now()->subDay();
-            $scope->assertSame('1 dag siden', $d->diffForHumans());
-
-            $d = Carbon::now()->subDays(2);
-            $scope->assertSame('2 dage siden', $d->diffForHumans());
-
-            $d = Carbon::now()->subWeek();
-            $scope->assertSame('1 uge siden', $d->diffForHumans());
-
-            $d = Carbon::now()->subWeeks(2);
-            $scope->assertSame('2 uger siden', $d->diffForHumans());
-
-            $d = Carbon::now()->subMonth();
-            $scope->assertSame('1 måned siden', $d->diffForHumans());
-
-            $d = Carbon::now()->subMonths(2);
-            $scope->assertSame('2 måneder siden', $d->diffForHumans());
-
-            $d = Carbon::now()->subYear();
-            $scope->assertSame('1 år siden', $d->diffForHumans());
-
-            $d = Carbon::now()->subYears(2);
-            $scope->assertSame('2 år siden', $d->diffForHumans());
-
-            $d = Carbon::now()->addSecond();
-            $scope->assertSame('om 1 sekund', $d->diffForHumans());
-
-            $d = Carbon::now()->addSecond();
-            $d2 = Carbon::now();
-            $scope->assertSame('1 sekund efter', $d->diffForHumans($d2));
-            $scope->assertSame('1 sekund før', $d2->diffForHumans($d));
-
-            $scope->assertSame('1 sekund', $d->diffForHumans($d2, true));
-            $scope->assertSame('2 sekunder', $d2->diffForHumans($d->addSecond(), true));
-        });
-    }
-
-    public function testDiffForHumansLocalizedInLithuanian()
-    {
-        Carbon::setLocale('lt');
-
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $d = Carbon::now()->addYear();
-            $scope->assertSame('už 1 metus', $d->diffForHumans());
-
-            $d = Carbon::now()->addYears(2);
-            $scope->assertSame('už 2 metus', $d->diffForHumans());
-        });
-    }
-
-    public function testDiffForHumansLocalizedInKorean()
-    {
-        Carbon::setLocale('ko');
-
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $d = Carbon::now()->addYear();
-            $scope->assertSame('1 년 후', $d->diffForHumans());
-
-            $d = Carbon::now()->addYears(2);
-            $scope->assertSame('2 년 후', $d->diffForHumans());
-        });
-    }
-
-    public function testDiffForHumansLocalizedInFarsi()
-    {
-        Carbon::setLocale('fa');
-
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $d = Carbon::now()->subSecond();
-            $scope->assertSame('1 ثانیه پیش', $d->diffForHumans());
-
-            $d = Carbon::now()->subSeconds(2);
-            $scope->assertSame('2 ثانیه پیش', $d->diffForHumans());
-
-            $d = Carbon::now()->subMinute();
-            $scope->assertSame('1 دقیقه پیش', $d->diffForHumans());
-
-            $d = Carbon::now()->subMinutes(2);
-            $scope->assertSame('2 دقیقه پیش', $d->diffForHumans());
-
-            $d = Carbon::now()->subHour();
-            $scope->assertSame('1 ساعت پیش', $d->diffForHumans());
-
-            $d = Carbon::now()->subHours(2);
-            $scope->assertSame('2 ساعت پیش', $d->diffForHumans());
-
-            $d = Carbon::now()->subDay();
-            $scope->assertSame('1 روز پیش', $d->diffForHumans());
-
-            $d = Carbon::now()->subDays(2);
-            $scope->assertSame('2 روز پیش', $d->diffForHumans());
-
-            $d = Carbon::now()->subWeek();
-            $scope->assertSame('1 هفته پیش', $d->diffForHumans());
-
-            $d = Carbon::now()->subWeeks(2);
-            $scope->assertSame('2 هفته پیش', $d->diffForHumans());
-
-            $d = Carbon::now()->subMonth();
-            $scope->assertSame('1 ماه پیش', $d->diffForHumans());
-
-            $d = Carbon::now()->subMonths(2);
-            $scope->assertSame('2 ماه پیش', $d->diffForHumans());
-
-            $d = Carbon::now()->subYear();
-            $scope->assertSame('1 سال پیش', $d->diffForHumans());
-
-            $d = Carbon::now()->subYears(2);
-            $scope->assertSame('2 سال پیش', $d->diffForHumans());
-
-            $d = Carbon::now()->addSecond();
-            $scope->assertSame('1 ثانیه بعد', $d->diffForHumans());
-
-            $d = Carbon::now()->addSecond();
-            $d2 = Carbon::now();
-            $scope->assertSame('1 ثانیه پیش از', $d->diffForHumans($d2));
-            $scope->assertSame('1 ثانیه پس از', $d2->diffForHumans($d));
-
-            $d = Carbon::now()->addSecond();
-            $d2 = Carbon::now();
-            $scope->assertSame('1 ثانیه پیش از', $d->diffForHumans($d2));
-            $scope->assertSame('1 ثانیه پس از', $d2->diffForHumans($d));
-
-            $scope->assertSame('1 ثانیه', $d->diffForHumans($d2, true));
-            $scope->assertSame('2 ثانیه', $d2->diffForHumans($d->addSecond(), true));
-        });
-    }
-
-    public function testDiffForHumansLocalizedInFaroese()
-    {
-        Carbon::setLocale('fo');
-
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $d = Carbon::now()->subSecond();
-            $scope->assertSame('1 sekund síðan', $d->diffForHumans());
-
-            $d = Carbon::now()->subSeconds(2);
-            $scope->assertSame('2 sekundir síðan', $d->diffForHumans());
-
-            $d = Carbon::now()->subMinute();
-            $scope->assertSame('1 minutt síðan', $d->diffForHumans());
-
-            $d = Carbon::now()->subMinutes(2);
-            $scope->assertSame('2 minuttir síðan', $d->diffForHumans());
-
-            $d = Carbon::now()->subHour();
-            $scope->assertSame('1 tími síðan', $d->diffForHumans());
-
-            $d = Carbon::now()->subHours(2);
-            $scope->assertSame('2 tímar síðan', $d->diffForHumans());
-
-            $d = Carbon::now()->subDay();
-            $scope->assertSame('1 dag síðan', $d->diffForHumans());
-
-            $d = Carbon::now()->subDays(2);
-            $scope->assertSame('2 dagar síðan', $d->diffForHumans());
-
-            $d = Carbon::now()->subWeek();
-            $scope->assertSame('1 vika síðan', $d->diffForHumans());
-
-            $d = Carbon::now()->subWeeks(2);
-            $scope->assertSame('2 vikur síðan', $d->diffForHumans());
-
-            $d = Carbon::now()->subMonth();
-            $scope->assertSame('1 mánaður síðan', $d->diffForHumans());
-
-            $d = Carbon::now()->subMonths(2);
-            $scope->assertSame('2 mánaðir síðan', $d->diffForHumans());
-
-            $d = Carbon::now()->subYear();
-            $scope->assertSame('1 ár síðan', $d->diffForHumans());
-
-            $d = Carbon::now()->subYears(2);
-            $scope->assertSame('2 ár síðan', $d->diffForHumans());
-
-            $d = Carbon::now()->addSecond();
-            $scope->assertSame('um 1 sekund', $d->diffForHumans());
-
-            $d = Carbon::now()->addSecond();
-            $d2 = Carbon::now();
-            $scope->assertSame('1 sekund aftaná', $d->diffForHumans($d2));
-            $scope->assertSame('1 sekund áðrenn', $d2->diffForHumans($d));
-
-            $scope->assertSame('1 sekund', $d->diffForHumans($d2, true));
-            $scope->assertSame('2 sekundir', $d2->diffForHumans($d->addSecond(), true));
-        });
-    }
-
-    public function testDiffForHumansLocalizedInJapanese()
-    {
-        Carbon::setLocale('ja');
-
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $d = Carbon::now()->subSecond();
-            $scope->assertSame('1 秒 前', $d->diffForHumans());
-
-            $d = Carbon::now()->subSeconds(2);
-            $scope->assertSame('2 秒 前', $d->diffForHumans());
-
-            $d = Carbon::now()->subMinute();
-            $scope->assertSame('1 分 前', $d->diffForHumans());
-
-            $d = Carbon::now()->subMinutes(2);
-            $scope->assertSame('2 分 前', $d->diffForHumans());
-
-            $d = Carbon::now()->subHour();
-            $scope->assertSame('1 時間 前', $d->diffForHumans());
-
-            $d = Carbon::now()->subHours(2);
-            $scope->assertSame('2 時間 前', $d->diffForHumans());
-
-            $d = Carbon::now()->subDay();
-            $scope->assertSame('1 日 前', $d->diffForHumans());
-
-            $d = Carbon::now()->subDays(2);
-            $scope->assertSame('2 日 前', $d->diffForHumans());
-
-            $d = Carbon::now()->subWeek();
-            $scope->assertSame('1 週間 前', $d->diffForHumans());
-
-            $d = Carbon::now()->subWeeks(2);
-            $scope->assertSame('2 週間 前', $d->diffForHumans());
-
-            $d = Carbon::now()->subMonth();
-            $scope->assertSame('1 ヶ月 前', $d->diffForHumans());
-
-            $d = Carbon::now()->subMonths(2);
-            $scope->assertSame('2 ヶ月 前', $d->diffForHumans());
-
-            $d = Carbon::now()->subYear();
-            $scope->assertSame('1 年 前', $d->diffForHumans());
-
-            $d = Carbon::now()->subYears(2);
-            $scope->assertSame('2 年 前', $d->diffForHumans());
-
-            $d = Carbon::now()->addSecond();
-            $scope->assertSame('今から 1 秒', $d->diffForHumans());
-
-            $d = Carbon::now()->addSecond();
-            $d2 = Carbon::now();
-            $scope->assertSame('1 秒 後', $d->diffForHumans($d2));
-            $scope->assertSame('1 秒 前', $d2->diffForHumans($d));
-
-            $scope->assertSame('1 秒', $d->diffForHumans($d2, true));
-            $scope->assertSame('2 秒', $d2->diffForHumans($d->addSecond(), true));
-        });
+        $this->assertSame($locale, $t->getLocale());
     }
 }

--- a/tests/Localization/Da.php
+++ b/tests/Localization/Da.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Localization;
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Carbon\Carbon;
+use Tests\AbstractTestCase;
+
+class Da extends AbstractTestCase
+{
+    public function testDiffForHumansLocalizedInDanish()
+    {
+        Carbon::setLocale('da');
+
+        $scope = $this;
+        $this->wrapWithTestNow(function () use ($scope) {
+            $d = Carbon::now()->subSecond();
+            $scope->assertSame('1 sekund siden', $d->diffForHumans());
+
+            $d = Carbon::now()->subSeconds(2);
+            $scope->assertSame('2 sekunder siden', $d->diffForHumans());
+
+            $d = Carbon::now()->subMinute();
+            $scope->assertSame('1 minut siden', $d->diffForHumans());
+
+            $d = Carbon::now()->subMinutes(2);
+            $scope->assertSame('2 minutter siden', $d->diffForHumans());
+
+            $d = Carbon::now()->subHour();
+            $scope->assertSame('1 time siden', $d->diffForHumans());
+
+            $d = Carbon::now()->subHours(2);
+            $scope->assertSame('2 timer siden', $d->diffForHumans());
+
+            $d = Carbon::now()->subDay();
+            $scope->assertSame('1 dag siden', $d->diffForHumans());
+
+            $d = Carbon::now()->subDays(2);
+            $scope->assertSame('2 dage siden', $d->diffForHumans());
+
+            $d = Carbon::now()->subWeek();
+            $scope->assertSame('1 uge siden', $d->diffForHumans());
+
+            $d = Carbon::now()->subWeeks(2);
+            $scope->assertSame('2 uger siden', $d->diffForHumans());
+
+            $d = Carbon::now()->subMonth();
+            $scope->assertSame('1 måned siden', $d->diffForHumans());
+
+            $d = Carbon::now()->subMonths(2);
+            $scope->assertSame('2 måneder siden', $d->diffForHumans());
+
+            $d = Carbon::now()->subYear();
+            $scope->assertSame('1 år siden', $d->diffForHumans());
+
+            $d = Carbon::now()->subYears(2);
+            $scope->assertSame('2 år siden', $d->diffForHumans());
+
+            $d = Carbon::now()->addSecond();
+            $scope->assertSame('om 1 sekund', $d->diffForHumans());
+
+            $d = Carbon::now()->addSecond();
+            $d2 = Carbon::now();
+            $scope->assertSame('1 sekund efter', $d->diffForHumans($d2));
+            $scope->assertSame('1 sekund før', $d2->diffForHumans($d));
+
+            $scope->assertSame('1 sekund', $d->diffForHumans($d2, true));
+            $scope->assertSame('2 sekunder', $d2->diffForHumans($d->addSecond(), true));
+        });
+    }
+}

--- a/tests/Localization/De.php
+++ b/tests/Localization/De.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Localization;
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Carbon\Carbon;
+use Tests\AbstractTestCase;
+
+class De extends AbstractTestCase
+{
+    public function testDiffForHumansLocalizedInGerman()
+    {
+        Carbon::setLocale('de');
+
+        $scope = $this;
+        $this->wrapWithTestNow(function () use ($scope) {
+            $d = Carbon::now()->addYear();
+            $scope->assertSame('in 1 Jahr', $d->diffForHumans());
+
+            $d = Carbon::now()->addYears(2);
+            $scope->assertSame('in 2 Jahren', $d->diffForHumans());
+
+            $d = Carbon::now()->subYear();
+            $scope->assertSame('1 Jahr später', Carbon::now()->diffForHumans($d));
+
+            $d = Carbon::now()->subYears(2);
+            $scope->assertSame('2 Jahre später', Carbon::now()->diffForHumans($d));
+
+            $d = Carbon::now()->addYear();
+            $scope->assertSame('1 Jahr zuvor', Carbon::now()->diffForHumans($d));
+
+            $d = Carbon::now()->addYears(2);
+            $scope->assertSame('2 Jahre zuvor', Carbon::now()->diffForHumans($d));
+
+            $d = Carbon::now()->subYear();
+            $scope->assertSame('vor 1 Jahr', $d->diffForHumans());
+
+            $d = Carbon::now()->subYears(2);
+            $scope->assertSame('vor 2 Jahren', $d->diffForHumans());
+        });
+    }
+}

--- a/tests/Localization/Es.php
+++ b/tests/Localization/Es.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Localization;
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Carbon\Carbon;
+use Tests\AbstractTestCase;
+
+class Es extends AbstractTestCase
+{
+    public function testDiffForHumansLocalizedInSpanish()
+    {
+        Carbon::setLocale('es');
+
+        $scope = $this;
+        $this->wrapWithTestNow(function () use ($scope) {
+            $d = Carbon::now()->subSecond();
+            $scope->assertSame('hace 1 segundo', $d->diffForHumans());
+
+            $d = Carbon::now()->subSeconds(3);
+            $scope->assertSame('hace 3 segundos', $d->diffForHumans());
+
+            $d = Carbon::now()->subMinute();
+            $scope->assertSame('hace 1 minuto', $d->diffForHumans());
+
+            $d = Carbon::now()->subMinutes(2);
+            $scope->assertSame('hace 2 minutos', $d->diffForHumans());
+
+            $d = Carbon::now()->subHour();
+            $scope->assertSame('hace 1 hora', $d->diffForHumans());
+
+            $d = Carbon::now()->subHours(2);
+            $scope->assertSame('hace 2 horas', $d->diffForHumans());
+
+            $d = Carbon::now()->subDay();
+            $scope->assertSame('hace 1 día', $d->diffForHumans());
+
+            $d = Carbon::now()->subDays(2);
+            $scope->assertSame('hace 2 días', $d->diffForHumans());
+
+            $d = Carbon::now()->subWeek();
+            $scope->assertSame('hace 1 semana', $d->diffForHumans());
+
+            $d = Carbon::now()->subWeeks(2);
+            $scope->assertSame('hace 2 semanas', $d->diffForHumans());
+
+            $d = Carbon::now()->subMonth();
+            $scope->assertSame('hace 1 mes', $d->diffForHumans());
+
+            $d = Carbon::now()->subMonths(2);
+            $scope->assertSame('hace 2 meses', $d->diffForHumans());
+
+            $d = Carbon::now()->subYear();
+            $scope->assertSame('hace 1 año', $d->diffForHumans());
+
+            $d = Carbon::now()->subYears(2);
+            $scope->assertSame('hace 2 años', $d->diffForHumans());
+
+            $d = Carbon::now()->addSecond();
+            $scope->assertSame('dentro de 1 segundo', $d->diffForHumans());
+
+            $d = Carbon::now()->addSecond();
+            $d2 = Carbon::now();
+            $scope->assertSame('1 segundo después', $d->diffForHumans($d2));
+            $scope->assertSame('1 segundo antes', $d2->diffForHumans($d));
+
+            $scope->assertSame('1 segundo', $d->diffForHumans($d2, true));
+            $scope->assertSame('2 segundos', $d2->diffForHumans($d->addSecond(), true));
+        });
+    }
+}

--- a/tests/Localization/Fa.php
+++ b/tests/Localization/Fa.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Localization;
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Carbon\Carbon;
+use Tests\AbstractTestCase;
+
+class Fa extends AbstractTestCase
+{
+    public function testDiffForHumansLocalizedInFarsi()
+    {
+        Carbon::setLocale('fa');
+
+        $scope = $this;
+        $this->wrapWithTestNow(function () use ($scope) {
+            $d = Carbon::now()->subSecond();
+            $scope->assertSame('1 ثانیه پیش', $d->diffForHumans());
+
+            $d = Carbon::now()->subSeconds(2);
+            $scope->assertSame('2 ثانیه پیش', $d->diffForHumans());
+
+            $d = Carbon::now()->subMinute();
+            $scope->assertSame('1 دقیقه پیش', $d->diffForHumans());
+
+            $d = Carbon::now()->subMinutes(2);
+            $scope->assertSame('2 دقیقه پیش', $d->diffForHumans());
+
+            $d = Carbon::now()->subHour();
+            $scope->assertSame('1 ساعت پیش', $d->diffForHumans());
+
+            $d = Carbon::now()->subHours(2);
+            $scope->assertSame('2 ساعت پیش', $d->diffForHumans());
+
+            $d = Carbon::now()->subDay();
+            $scope->assertSame('1 روز پیش', $d->diffForHumans());
+
+            $d = Carbon::now()->subDays(2);
+            $scope->assertSame('2 روز پیش', $d->diffForHumans());
+
+            $d = Carbon::now()->subWeek();
+            $scope->assertSame('1 هفته پیش', $d->diffForHumans());
+
+            $d = Carbon::now()->subWeeks(2);
+            $scope->assertSame('2 هفته پیش', $d->diffForHumans());
+
+            $d = Carbon::now()->subMonth();
+            $scope->assertSame('1 ماه پیش', $d->diffForHumans());
+
+            $d = Carbon::now()->subMonths(2);
+            $scope->assertSame('2 ماه پیش', $d->diffForHumans());
+
+            $d = Carbon::now()->subYear();
+            $scope->assertSame('1 سال پیش', $d->diffForHumans());
+
+            $d = Carbon::now()->subYears(2);
+            $scope->assertSame('2 سال پیش', $d->diffForHumans());
+
+            $d = Carbon::now()->addSecond();
+            $scope->assertSame('1 ثانیه بعد', $d->diffForHumans());
+
+            $d = Carbon::now()->addSecond();
+            $d2 = Carbon::now();
+            $scope->assertSame('1 ثانیه پیش از', $d->diffForHumans($d2));
+            $scope->assertSame('1 ثانیه پس از', $d2->diffForHumans($d));
+
+            $d = Carbon::now()->addSecond();
+            $d2 = Carbon::now();
+            $scope->assertSame('1 ثانیه پیش از', $d->diffForHumans($d2));
+            $scope->assertSame('1 ثانیه پس از', $d2->diffForHumans($d));
+
+            $scope->assertSame('1 ثانیه', $d->diffForHumans($d2, true));
+            $scope->assertSame('2 ثانیه', $d2->diffForHumans($d->addSecond(), true));
+        });
+    }
+}

--- a/tests/Localization/Fo.php
+++ b/tests/Localization/Fo.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Localization;
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Carbon\Carbon;
+use Tests\AbstractTestCase;
+
+class Fo extends AbstractTestCase
+{
+    public function testDiffForHumansLocalizedInFaroese()
+    {
+        Carbon::setLocale('fo');
+
+        $scope = $this;
+        $this->wrapWithTestNow(function () use ($scope) {
+            $d = Carbon::now()->subSecond();
+            $scope->assertSame('1 sekund síðan', $d->diffForHumans());
+
+            $d = Carbon::now()->subSeconds(2);
+            $scope->assertSame('2 sekundir síðan', $d->diffForHumans());
+
+            $d = Carbon::now()->subMinute();
+            $scope->assertSame('1 minutt síðan', $d->diffForHumans());
+
+            $d = Carbon::now()->subMinutes(2);
+            $scope->assertSame('2 minuttir síðan', $d->diffForHumans());
+
+            $d = Carbon::now()->subHour();
+            $scope->assertSame('1 tími síðan', $d->diffForHumans());
+
+            $d = Carbon::now()->subHours(2);
+            $scope->assertSame('2 tímar síðan', $d->diffForHumans());
+
+            $d = Carbon::now()->subDay();
+            $scope->assertSame('1 dag síðan', $d->diffForHumans());
+
+            $d = Carbon::now()->subDays(2);
+            $scope->assertSame('2 dagar síðan', $d->diffForHumans());
+
+            $d = Carbon::now()->subWeek();
+            $scope->assertSame('1 vika síðan', $d->diffForHumans());
+
+            $d = Carbon::now()->subWeeks(2);
+            $scope->assertSame('2 vikur síðan', $d->diffForHumans());
+
+            $d = Carbon::now()->subMonth();
+            $scope->assertSame('1 mánaður síðan', $d->diffForHumans());
+
+            $d = Carbon::now()->subMonths(2);
+            $scope->assertSame('2 mánaðir síðan', $d->diffForHumans());
+
+            $d = Carbon::now()->subYear();
+            $scope->assertSame('1 ár síðan', $d->diffForHumans());
+
+            $d = Carbon::now()->subYears(2);
+            $scope->assertSame('2 ár síðan', $d->diffForHumans());
+
+            $d = Carbon::now()->addSecond();
+            $scope->assertSame('um 1 sekund', $d->diffForHumans());
+
+            $d = Carbon::now()->addSecond();
+            $d2 = Carbon::now();
+            $scope->assertSame('1 sekund aftaná', $d->diffForHumans($d2));
+            $scope->assertSame('1 sekund áðrenn', $d2->diffForHumans($d));
+
+            $scope->assertSame('1 sekund', $d->diffForHumans($d2, true));
+            $scope->assertSame('2 sekundir', $d2->diffForHumans($d->addSecond(), true));
+        });
+    }
+}

--- a/tests/Localization/Fr.php
+++ b/tests/Localization/Fr.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Localization;
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Carbon\Carbon;
+use Tests\AbstractTestCase;
+
+class Fr extends AbstractTestCase
+{
+    public function testDiffForHumansLocalizedInFrench()
+    {
+        Carbon::setLocale('fr');
+
+        $scope = $this;
+        $this->wrapWithTestNow(function () use ($scope) {
+
+            $d = Carbon::now()->subSecond();
+            $scope->assertSame('il y a 1 seconde', $d->diffForHumans());
+
+            $d = Carbon::now()->subSeconds(2);
+            $scope->assertSame('il y a 2 secondes', $d->diffForHumans());
+
+            $d = Carbon::now()->subMinute();
+            $scope->assertSame('il y a 1 minute', $d->diffForHumans());
+
+            $d = Carbon::now()->subMinutes(2);
+            $scope->assertSame('il y a 2 minutes', $d->diffForHumans());
+
+            $d = Carbon::now()->subHour();
+            $scope->assertSame('il y a 1 heure', $d->diffForHumans());
+
+            $d = Carbon::now()->subHours(2);
+            $scope->assertSame('il y a 2 heures', $d->diffForHumans());
+
+            $d = Carbon::now()->subDay();
+            $scope->assertSame('il y a 1 jour', $d->diffForHumans());
+
+            $d = Carbon::now()->subDays(2);
+            $scope->assertSame('il y a 2 jours', $d->diffForHumans());
+
+            $d = Carbon::now()->subWeek();
+            $scope->assertSame('il y a 1 semaine', $d->diffForHumans());
+
+            $d = Carbon::now()->subWeeks(2);
+            $scope->assertSame('il y a 2 semaines', $d->diffForHumans());
+
+            $d = Carbon::now()->subMonth();
+            $scope->assertSame('il y a 1 mois', $d->diffForHumans());
+
+            $d = Carbon::now()->subMonths(2);
+            $scope->assertSame('il y a 2 mois', $d->diffForHumans());
+
+            $d = Carbon::now()->subYear();
+            $scope->assertSame('il y a 1 an', $d->diffForHumans());
+
+            $d = Carbon::now()->subYears(2);
+            $scope->assertSame('il y a 2 ans', $d->diffForHumans());
+
+            $d = Carbon::now()->addSecond();
+            $scope->assertSame('dans 1 seconde', $d->diffForHumans());
+
+            $d = Carbon::now()->addSecond();
+            $d2 = Carbon::now();
+            $scope->assertSame('1 seconde après', $d->diffForHumans($d2));
+            $scope->assertSame('1 seconde avant', $d2->diffForHumans($d));
+
+            $scope->assertSame('1 seconde', $d->diffForHumans($d2, true));
+            $scope->assertSame('2 secondes', $d2->diffForHumans($d->addSecond(), true));
+        });
+    }
+}

--- a/tests/Localization/It.php
+++ b/tests/Localization/It.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Localization;
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Carbon\Carbon;
+use Tests\AbstractTestCase;
+
+class It extends AbstractTestCase
+{
+    public function testDiffForHumansLocalizedInItalian()
+    {
+        Carbon::setLocale('it');
+
+        $scope = $this;
+        $this->wrapWithTestNow(function () use ($scope) {
+            $d = Carbon::now()->addYear();
+            $scope->assertSame('1 anno da adesso', $d->diffForHumans());
+
+            $d = Carbon::now()->addYears(2);
+            $scope->assertSame('2 anni da adesso', $d->diffForHumans());
+        });
+    }
+}

--- a/tests/Localization/Ja.php
+++ b/tests/Localization/Ja.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Localization;
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Carbon\Carbon;
+use Tests\AbstractTestCase;
+
+class Ja extends AbstractTestCase
+{
+    public function testDiffForHumansLocalizedInJapanese()
+    {
+        Carbon::setLocale('ja');
+
+        $scope = $this;
+        $this->wrapWithTestNow(function () use ($scope) {
+            $d = Carbon::now()->subSecond();
+            $scope->assertSame('1 秒 前', $d->diffForHumans());
+
+            $d = Carbon::now()->subSeconds(2);
+            $scope->assertSame('2 秒 前', $d->diffForHumans());
+
+            $d = Carbon::now()->subMinute();
+            $scope->assertSame('1 分 前', $d->diffForHumans());
+
+            $d = Carbon::now()->subMinutes(2);
+            $scope->assertSame('2 分 前', $d->diffForHumans());
+
+            $d = Carbon::now()->subHour();
+            $scope->assertSame('1 時間 前', $d->diffForHumans());
+
+            $d = Carbon::now()->subHours(2);
+            $scope->assertSame('2 時間 前', $d->diffForHumans());
+
+            $d = Carbon::now()->subDay();
+            $scope->assertSame('1 日 前', $d->diffForHumans());
+
+            $d = Carbon::now()->subDays(2);
+            $scope->assertSame('2 日 前', $d->diffForHumans());
+
+            $d = Carbon::now()->subWeek();
+            $scope->assertSame('1 週間 前', $d->diffForHumans());
+
+            $d = Carbon::now()->subWeeks(2);
+            $scope->assertSame('2 週間 前', $d->diffForHumans());
+
+            $d = Carbon::now()->subMonth();
+            $scope->assertSame('1 ヶ月 前', $d->diffForHumans());
+
+            $d = Carbon::now()->subMonths(2);
+            $scope->assertSame('2 ヶ月 前', $d->diffForHumans());
+
+            $d = Carbon::now()->subYear();
+            $scope->assertSame('1 年 前', $d->diffForHumans());
+
+            $d = Carbon::now()->subYears(2);
+            $scope->assertSame('2 年 前', $d->diffForHumans());
+
+            $d = Carbon::now()->addSecond();
+            $scope->assertSame('今から 1 秒', $d->diffForHumans());
+
+            $d = Carbon::now()->addSecond();
+            $d2 = Carbon::now();
+            $scope->assertSame('1 秒 後', $d->diffForHumans($d2));
+            $scope->assertSame('1 秒 前', $d2->diffForHumans($d));
+
+            $scope->assertSame('1 秒', $d->diffForHumans($d2, true));
+            $scope->assertSame('2 秒', $d2->diffForHumans($d->addSecond(), true));
+        });
+    }
+}

--- a/tests/Localization/Ko.php
+++ b/tests/Localization/Ko.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Localization;
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Carbon\Carbon;
+use Tests\AbstractTestCase;
+
+class Ko extends AbstractTestCase
+{
+    public function testDiffForHumansLocalizedInKorean()
+    {
+        Carbon::setLocale('ko');
+
+        $scope = $this;
+        $this->wrapWithTestNow(function () use ($scope) {
+            $d = Carbon::now()->addYear();
+            $scope->assertSame('1 년 후', $d->diffForHumans());
+
+            $d = Carbon::now()->addYears(2);
+            $scope->assertSame('2 년 후', $d->diffForHumans());
+        });
+    }
+}

--- a/tests/Localization/Lt.php
+++ b/tests/Localization/Lt.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Localization;
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Carbon\Carbon;
+use Tests\AbstractTestCase;
+
+class Lt extends AbstractTestCase
+{
+    public function testDiffForHumansLocalizedInLithuanian()
+    {
+        Carbon::setLocale('lt');
+
+        $scope = $this;
+        $this->wrapWithTestNow(function () use ($scope) {
+            $d = Carbon::now()->addYear();
+            $scope->assertSame('už 1 metus', $d->diffForHumans());
+
+            $d = Carbon::now()->addYears(2);
+            $scope->assertSame('už 2 metus', $d->diffForHumans());
+        });
+    }
+}

--- a/tests/Localization/Tr.php
+++ b/tests/Localization/Tr.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Localization;
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Carbon\Carbon;
+use Tests\AbstractTestCase;
+
+class Tr extends AbstractTestCase
+{
+    public function testDiffForHumansLocalizedInTurkish()
+    {
+        Carbon::setLocale('tr');
+
+        $scope = $this;
+        $this->wrapWithTestNow(function () use ($scope) {
+            $d = Carbon::now()->subSecond();
+            $scope->assertSame('1 saniye önce', $d->diffForHumans());
+
+            $d = Carbon::now()->subSeconds(2);
+            $scope->assertSame('2 saniye önce', $d->diffForHumans());
+
+            $d = Carbon::now()->subMinute();
+            $scope->assertSame('1 dakika önce', $d->diffForHumans());
+
+            $d = Carbon::now()->subMinutes(2);
+            $scope->assertSame('2 dakika önce', $d->diffForHumans());
+
+            $d = Carbon::now()->subHour();
+            $scope->assertSame('1 saat önce', $d->diffForHumans());
+
+            $d = Carbon::now()->subHours(2);
+            $scope->assertSame('2 saat önce', $d->diffForHumans());
+
+            $d = Carbon::now()->subDay();
+            $scope->assertSame('1 gün önce', $d->diffForHumans());
+
+            $d = Carbon::now()->subDays(2);
+            $scope->assertSame('2 gün önce', $d->diffForHumans());
+
+            $d = Carbon::now()->subWeek();
+            $scope->assertSame('1 hafta önce', $d->diffForHumans());
+
+            $d = Carbon::now()->subWeeks(2);
+            $scope->assertSame('2 hafta önce', $d->diffForHumans());
+
+            $d = Carbon::now()->subMonth();
+            $scope->assertSame('1 ay önce', $d->diffForHumans());
+
+            $d = Carbon::now()->subMonths(2);
+            $scope->assertSame('2 ay önce', $d->diffForHumans());
+
+            $d = Carbon::now()->subYear();
+            $scope->assertSame('1 yıl önce', $d->diffForHumans());
+
+            $d = Carbon::now()->subYears(2);
+            $scope->assertSame('2 yıl önce', $d->diffForHumans());
+
+            $d = Carbon::now()->addSecond();
+            $scope->assertSame('1 saniye andan itibaren', $d->diffForHumans());
+
+            $d = Carbon::now()->addSecond();
+            $d2 = Carbon::now();
+            $scope->assertSame('1 saniye sonra', $d->diffForHumans($d2));
+            $scope->assertSame('1 saniye önce', $d2->diffForHumans($d));
+
+            $scope->assertSame('1 saniye', $d->diffForHumans($d2, true));
+            $scope->assertSame('2 saniye', $d2->diffForHumans($d->addSecond(), true));
+        });
+    }
+}


### PR DESCRIPTION
Reorganize localizations tests.

`\Tests\Carbon\LocalizationTest` takes care of checking file presence, setting locale and setting translator

Each language has its own test file in `Tests\Localization` namespace.