### PR TITLE
Added resetting Carbon test time during tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,4 +21,8 @@
          <directory>tests</directory>
       </testsuite>
    </testsuites>
+
+   <listeners>
+      <listener class="Tests\ClearCarbonListener" />
+   </listeners>
 </phpunit>

--- a/tests/ClearCarbonListener.php
+++ b/tests/ClearCarbonListener.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit_Framework_BaseTestListener;
+use PHPUnit_Framework_Test;
+use Carbon\Carbon;
+
+/**
+ * Reduce side effects of unit tests with Carbon setTimeNow usage
+ *
+ * PHPUnit test listener that will reset the test time between tests for cases
+ * where a test missed clearing the test time and a following test is not
+ * expecting test time set.
+ */
+class ClearCarbonListener extends PHPUnit_Framework_BaseTestListener
+{
+    public function endTest(PHPUnit_Framework_Test $test, $time)
+    {
+        Carbon::setTestNow();
+    }
+}


### PR DESCRIPTION
From my request: #515 

In theory, could be used by consumers of the carbon library, not exclusively for Carbon tests.

Question:
As a usable outside of carbon, but still for unit tests, should it be in tests/... or src/...?