### PR TITLE
Tweak \Carbon\Carbon::instance

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -243,6 +243,10 @@ class Carbon extends DateTime
      */
     public static function instance(DateTime $dt)
     {
+        if ($dt instanceof static) {
+            return clone $dt;
+        }
+
         return new static($dt->format('Y-m-d H:i:s.u'), $dt->getTimeZone());
     }
 

--- a/tests/Carbon/InstanceTest.php
+++ b/tests/Carbon/InstanceTest.php
@@ -22,9 +22,21 @@ class InstanceTest extends AbstractTestCase
         $this->assertCarbon($dating, 1975, 5, 21, 22, 32, 11);
     }
 
+    public function testInstanceFromCarbon()
+    {
+        $dating = Carbon::instance(Carbon::create(1975, 5, 21, 22, 32, 11));
+        $this->assertCarbon($dating, 1975, 5, 21, 22, 32, 11);
+    }
+
     public function testInstanceFromDateTimeKeepsTimezoneName()
     {
         $dating = Carbon::instance(\DateTime::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11')->setTimezone(new \DateTimeZone('America/Vancouver')));
+        $this->assertSame('America/Vancouver', $dating->tzName);
+    }
+
+    public function testInstanceFromCarbonKeepsTimezoneName()
+    {
+        $dating = Carbon::instance(Carbon::create(1975, 5, 21, 22, 32, 11)->setTimezone(new \DateTimeZone('America/Vancouver')));
         $this->assertSame('America/Vancouver', $dating->tzName);
     }
 
@@ -33,6 +45,14 @@ class InstanceTest extends AbstractTestCase
         $micro = 254687;
         $datetime = \DateTime::createFromFormat('Y-m-d H:i:s.u', '2014-02-01 03:45:27.'.$micro);
         $carbon = Carbon::instance($datetime);
+        $this->assertSame($micro, $carbon->micro);
+    }
+
+    public function testInstanceFromCarbonKeepsMicros()
+    {
+        $micro = 254687;
+        $carbon = Carbon::createFromFormat('Y-m-d H:i:s.u', '2014-02-01 03:45:27.'.$micro);
+        $carbon = Carbon::instance($carbon);
         $this->assertSame($micro, $carbon->micro);
     }
 }


### PR DESCRIPTION
If `$dt` is a an instance of `\Carbon\Carbon`, no need to go again into `\Carbon\Carbon::__construct` 