### PR TITLE
Workaround for PHP bug

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -695,6 +695,25 @@ class Carbon extends DateTime
     }
 
     /**
+     * Sets the current date of the DateTime object to a different date.
+     * Calls modify as a workaround for a php bug
+     *
+     * @param int $year
+     * @param int $month
+     * @param int $day
+     * @return Carbon
+     *
+     * @see https://github.com/briannesbitt/Carbon/issues/539
+     * @see https://bugs.php.net/bug.php?id=63863
+     *
+     */
+    public function setDate ($year, $month, $day) {
+        $this->modify('+0 day');
+
+        return parent::setDate($year, $month, $day);
+    }
+
+    /**
      * Set the date and time all together
      *
      * @param int $year

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -701,13 +701,14 @@ class Carbon extends DateTime
      * @param int $year
      * @param int $month
      * @param int $day
+     *
      * @return Carbon
      *
      * @see https://github.com/briannesbitt/Carbon/issues/539
      * @see https://bugs.php.net/bug.php?id=63863
-     *
      */
-    public function setDate ($year, $month, $day) {
+    public function setDate($year, $month, $day)
+    {
         $this->modify('+0 day');
 
         return parent::setDate($year, $month, $day);

--- a/tests/Carbon/SettersTest.php
+++ b/tests/Carbon/SettersTest.php
@@ -138,6 +138,16 @@ class SettersTest extends AbstractTestCase
         $this->assertCarbon($d, 2014, 10, 25, 18, 5, 30);
     }
 
+    /**
+     * @link https://github.com/briannesbitt/Carbon/issues/539
+     */
+    public function testSetDateAfterStringCreation(){
+        $d = new Carbon('first day of this month');
+        $this->assertEquals(1, $d->day);
+        $d->setDate($d->year, $d->month, 12);
+        $this->assertEquals(12, $d->day);
+    }
+
     public function testSecondSetterWithWrap()
     {
         $d = Carbon::now();

--- a/tests/Carbon/SettersTest.php
+++ b/tests/Carbon/SettersTest.php
@@ -141,7 +141,8 @@ class SettersTest extends AbstractTestCase
     /**
      * @link https://github.com/briannesbitt/Carbon/issues/539
      */
-    public function testSetDateAfterStringCreation(){
+    public function testSetDateAfterStringCreation()
+    {
         $d = new Carbon('first day of this month');
         $this->assertEquals(1, $d->day);
         $d->setDate($d->year, $d->month, 12);


### PR DESCRIPTION
https://github.com/briannesbitt/Carbon/issues/539

Calling modify before setDate releases whatever is locking the day.