### PR TITLE
Unalign array arrows

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -35,6 +35,7 @@ $fixers = array(
     'phpdoc_var_without_name',
     'return',
     'spaces_cast',
+    'unalign_double_arrow',
     'unalign_equals',
     'unused_use',
     'whitespacy_lines',

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -19,6 +19,7 @@ enabled:
   - phpdoc_var_without_name
   - return
   - spaces_cast
+  - unalign_double_arrow
   - unalign_equals
   - unused_use
   - whitespacy_lines


### PR DESCRIPTION
Arrows are not aligned in the code - there is no reason they should be aligned in lang files.
Plus it's adding useless noise when adding or removing an element in the array