### PR TITLE
Add getter to test for "long years"

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1576,6 +1576,16 @@ class Carbon extends DateTime
     }
 
     /**
+     * Determines if the instance is a long year
+     *
+     * @return bool
+     */
+    public function isLongYear()
+    {
+        return static::create($this->year, 12, 28, 0, 0, 0, $this->tz)->weekOfYear === 53;
+    }
+
+    /**
      * Checks if the passed in date is the same day as the instance current day.
      *
      * @param \Carbon\Carbon $dt

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1578,6 +1578,8 @@ class Carbon extends DateTime
     /**
      * Determines if the instance is a long year
      *
+     * @see https://en.wikipedia.org/wiki/ISO_8601#Week_dates
+     *
      * @return bool
      */
     public function isLongYear()

--- a/tests/Carbon/GettersTest.php
+++ b/tests/Carbon/GettersTest.php
@@ -236,6 +236,16 @@ class GettersTest extends AbstractTestCase
         $this->assertFalse(Carbon::createFromDate(2011, 1, 1)->isLeapYear());
     }
 
+    public function testIsLongYearTrue()
+    {
+        $this->assertTrue(Carbon::createFromDate(2015, 1, 1)->isLongYear());
+    }
+
+    public function testIsLongYearFalse()
+    {
+        $this->assertFalse(Carbon::createFromDate(2016, 1, 1)->isLongYear());
+    }
+
     public function testWeekOfMonth()
     {
         $this->assertSame(5, Carbon::createFromDate(2012, 9, 30)->weekOfMonth);


### PR DESCRIPTION
I've had trouble with my date math in a project because 2015 has 53 weeks in it, not 52. I would like to add a method to check and see if this year is a "long year", [according to the ISO standard](https://en.wikipedia.org/wiki/ISO_week_date#Weeks_per_year).

According to [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Week_dates), "28 December is always in the last week of its year." So I just made a new Carbon instance on the 28 of December for the year, and check if the week number is 53.

I fully tested the method according to your standards. It's an easy method to add, and one that would be very helpful in our project. Please merge :)

(P.S. I got this idea from [Glavić's post on StackOverflow](http://stackoverflow.com/a/21480444/2916818)).