### PR TITLE
Remove system ignore items and suffix vendor.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-.idea
-*.iml
+vendor/
 .php_cs.cache
-vendor
-composer.phar
 composer.lock


### PR DESCRIPTION
Some ignored files are system-wide ignored files.
Note : `vendor/` can be suffixed. The behavior is the same, but IDE understand it better.