### PR TITLE
Use interface instead of concrete implementation

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -244,7 +244,7 @@ class Carbon extends DateTime
      *
      * @return static
      */
-    public static function instance(DateTime $dt)
+    public static function instance(\DateTimeInterface $dt)
     {
         if ($dt instanceof static) {
             return clone $dt;


### PR DESCRIPTION
Using `\DateTimeInterface` is far more flexible and allow one to instantiate a `Carbon` instance via a `\DateTimeImmutable` instead of a `\DateTime` instance for example.