### PR TITLE
Add createSafe

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -454,7 +454,7 @@ class Carbon extends DateTime
                 continue;
             }
 
-            if ($value < $element['range'][0] || $value > $element['range'][1]) {
+            if (!is_int($value) || $value < $element['range'][0] || $value > $element['range'][1]) {
                 throw new InvalidDateException($field, $value);
             }
         }

--- a/src/Carbon/Exceptions/InvalidDateException.php
+++ b/src/Carbon/Exceptions/InvalidDateException.php
@@ -26,7 +26,7 @@ class InvalidDateException extends InvalidArgumentException
     /**
      * The invalid value.
      *
-     * @var int
+     * @var mixed
      */
     private $value;
 
@@ -34,7 +34,7 @@ class InvalidDateException extends InvalidArgumentException
      * Constructor.
      *
      * @param string          $field
-     * @param int             $value
+     * @param mixed           $value
      * @param int             $code
      * @param \Exception|null $previous
      */
@@ -46,6 +46,8 @@ class InvalidDateException extends InvalidArgumentException
     }
 
     /**
+     * Set the invalid field.
+     *
      * @param string $field
      *
      * @return $this
@@ -58,6 +60,8 @@ class InvalidDateException extends InvalidArgumentException
     }
 
     /**
+     * Get the invalid field.
+     *
      * @return string
      */
     public function getField()
@@ -66,7 +70,9 @@ class InvalidDateException extends InvalidArgumentException
     }
 
     /**
-     * @param int $value
+     * Set the invalid value.
+     *
+     * @param mixed $value
      *
      * @return $this
      */
@@ -78,7 +84,9 @@ class InvalidDateException extends InvalidArgumentException
     }
 
     /**
-     * @return int
+     * Get the invalid value.
+     *
+     * @return mixed
      */
     public function getValue()
     {

--- a/src/Carbon/Exceptions/InvalidDateException.php
+++ b/src/Carbon/Exceptions/InvalidDateException.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Carbon\Exceptions;
+
+use Exception;
+use InvalidArgumentException;
+
+class InvalidDateException extends InvalidArgumentException
+{
+    /**
+     * The invalid field.
+     *
+     * @var string
+     */
+    private $field;
+
+    /**
+     * The invalid value.
+     *
+     * @var int
+     */
+    private $value;
+
+    /**
+     * Constructor.
+     *
+     * @param string          $field
+     * @param int             $value
+     * @param int             $code
+     * @param \Exception|null $previous
+     */
+    public function __construct($field, $value, $code = 0, Exception $previous = null)
+    {
+        $this->setField($field);
+        $this->setValue($field);
+        parent::__construct($field.' : '.$value.' is not a valid value.', $code, $previous);
+    }
+
+    /**
+     * @param string $field
+     *
+     * @return $this
+     */
+    public function setField($field)
+    {
+        $this->field = $field;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getField()
+    {
+        return $this->field;
+    }
+
+    /**
+     * @param int $value
+     *
+     * @return $this
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/tests/Carbon/CreateSafeTest.php
+++ b/tests/Carbon/CreateSafeTest.php
@@ -162,6 +162,15 @@ class CreateSafeTest extends AbstractTestCase
         Carbon::createSafe(2015, 2, 29, 17, 16, 15);
     }
 
+    /**
+     * @expectedException \Carbon\Exceptions\InvalidDateException
+     * @expectedExceptionMessage second : 15.1 is not a valid value.
+     */
+    public function testCreateSafeThrowsExceptionForWithNonIntegerValue()
+    {
+        Carbon::createSafe(2015, 2, 10, 17, 16, 15.1);
+    }
+
     public function testCreateSafePassesForFebruaryInNonLeapYear()
     {
         // 28 days in February in a non-leap year

--- a/tests/Carbon/CreateSafeTest.php
+++ b/tests/Carbon/CreateSafeTest.php
@@ -140,14 +140,14 @@ class CreateSafeTest extends AbstractTestCase
      */
     public function testCreateSafeThrowsExceptionForInvalidDayForFebruaryInLeapYear()
     {
-        // 29 days in February in a leap year
+        // 29 days in February for a leap year
         $this->assertTrue(Carbon::create(2016, 2)->isLeapYear());
         Carbon::createSafe(2016, 2, 30, 17, 16, 15);
     }
 
     public function testCreateSafePassesForFebruaryInLeapYear()
     {
-        // 29 days in February in a leap year
+        // 29 days in February for a leap year
         Carbon::createSafe(2016, 2, 29, 17, 16, 15);
     }
 
@@ -157,7 +157,7 @@ class CreateSafeTest extends AbstractTestCase
      */
     public function testCreateSafeThrowsExceptionForInvalidDayForFebruaryInNonLeapYear()
     {
-        // 28 days in February in a non-leap year
+        // 28 days in February for a non-leap year
         $this->assertFalse(Carbon::create(2015, 2)->isLeapYear());
         Carbon::createSafe(2015, 2, 29, 17, 16, 15);
     }
@@ -173,7 +173,7 @@ class CreateSafeTest extends AbstractTestCase
 
     public function testCreateSafePassesForFebruaryInNonLeapYear()
     {
-        // 28 days in February in a non-leap year
+        // 28 days in February for a non-leap year
         Carbon::createSafe(2015, 2, 28, 17, 16, 15);
     }
 

--- a/tests/Carbon/CreateSafeTest.php
+++ b/tests/Carbon/CreateSafeTest.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Carbon;
+
+use Carbon\Carbon;
+use Tests\AbstractTestCase;
+
+class CreateSafeTest extends AbstractTestCase
+{
+    /**
+     * @expectedException \Carbon\Exceptions\InvalidDateException
+     * @expectedExceptionMessage second : -1 is not a valid value.
+     */
+    public function testCreateSafeThrowsExceptionForSecondLowerThanZero()
+    {
+        Carbon::createSafe(null, null, null, null, null, - 1);
+    }
+
+    /**
+     * @expectedException \Carbon\Exceptions\InvalidDateException
+     * @expectedExceptionMessage second : 60 is not a valid value.
+     */
+    public function testCreateSafeThrowsExceptionForSecondGreaterThan59()
+    {
+        Carbon::createSafe(null, null, null, null, null, 60);
+    }
+
+    /**
+     * @expectedException \Carbon\Exceptions\InvalidDateException
+     * @expectedExceptionMessage minute : -1 is not a valid value.
+     */
+    public function testCreateSafeThrowsExceptionForMinuteLowerThanZero()
+    {
+        Carbon::createSafe(null, null, null, null, - 1);
+    }
+
+    /**
+     * @expectedException \Carbon\Exceptions\InvalidDateException
+     * @expectedExceptionMessage minute : 60 is not a valid value.
+     */
+    public function testCreateSafeThrowsExceptionForMinuteGreaterThan59()
+    {
+        Carbon::createSafe(null, null, null, null, 60, 25);
+    }
+
+    /**
+     * @expectedException \Carbon\Exceptions\InvalidDateException
+     * @expectedExceptionMessage hour : -6 is not a valid value.
+     */
+    public function testCreateSafeThrowsExceptionForHourLowerThanZero()
+    {
+        Carbon::createSafe(null, null, null, - 6);
+    }
+
+    /**
+     * @expectedException \Carbon\Exceptions\InvalidDateException
+     * @expectedExceptionMessage hour : 25 is not a valid value.
+     */
+    public function testCreateSafeThrowsExceptionForHourGreaterThan24()
+    {
+        Carbon::createSafe(null, null, null, 25, 16, 15);
+    }
+
+    /**
+     * @expectedException \Carbon\Exceptions\InvalidDateException
+     * @expectedExceptionMessage day : -5 is not a valid value.
+     */
+    public function testCreateSafeThrowsExceptionForDayLowerThanZero()
+    {
+        Carbon::createSafe(null, null, - 5);
+    }
+
+    /**
+     * @expectedException \Carbon\Exceptions\InvalidDateException
+     * @expectedExceptionMessage day : 32 is not a valid value.
+     */
+    public function testCreateSafeThrowsExceptionForDayGreaterThan31()
+    {
+        Carbon::createSafe(null, null, 32, 17, 16, 15);
+    }
+
+    /**
+     * @expectedException \Carbon\Exceptions\InvalidDateException
+     * @expectedExceptionMessage month : -4 is not a valid value.
+     */
+    public function testCreateSafeThrowsExceptionForMonthLowerThanZero()
+    {
+        Carbon::createSafe(null, - 4);
+    }
+
+    /**
+     * @expectedException \Carbon\Exceptions\InvalidDateException
+     * @expectedExceptionMessage month : 13 is not a valid value.
+     */
+    public function testCreateSafeThrowsExceptionForMonthGreaterThan12()
+    {
+        Carbon::createSafe(null, 13, 5, 17, 16, 15);
+    }
+
+    /**
+     * @expectedException \Carbon\Exceptions\InvalidDateException
+     * @expectedExceptionMessage year : -5 is not a valid value.
+     */
+    public function testCreateSafeThrowsExceptionForYearLowerThanZero()
+    {
+        Carbon::createSafe(-5);
+    }
+
+    /**
+     * @expectedException \Carbon\Exceptions\InvalidDateException
+     * @expectedExceptionMessage year : 10000 is not a valid value.
+     */
+    public function testCreateSafeThrowsExceptionForYearGreaterThan12()
+    {
+        Carbon::createSafe(10000, 12, 5, 17, 16, 15);
+    }
+
+    /**
+     * @expectedException \Carbon\Exceptions\InvalidDateException
+     * @expectedExceptionMessage day : 31 is not a valid value.
+     */
+    public function testCreateSafeThrowsExceptionForInvalidDayInShortMonth()
+    {
+        // 30 days in April
+        Carbon::createSafe(2016, 4, 31, 17, 16, 15);
+    }
+
+    /**
+     * @expectedException \Carbon\Exceptions\InvalidDateException
+     * @expectedExceptionMessage day : 30 is not a valid value.
+     */
+    public function testCreateSafeThrowsExceptionForInvalidDayForFebruaryInLeapYear()
+    {
+        // 29 days in February in a leap year
+        $this->assertTrue(Carbon::create(2016, 2)->isLeapYear());
+        Carbon::createSafe(2016, 2, 30, 17, 16, 15);
+    }
+
+    public function testCreateSafePassesForFebruaryInLeapYear()
+    {
+        // 29 days in February in a leap year
+        Carbon::createSafe(2016, 2, 29, 17, 16, 15);
+    }
+
+    /**
+     * @expectedException \Carbon\Exceptions\InvalidDateException
+     * @expectedExceptionMessage day : 29 is not a valid value.
+     */
+    public function testCreateSafeThrowsExceptionForInvalidDayForFebruaryInNonLeapYear()
+    {
+        // 28 days in February in a non-leap year
+        $this->assertFalse(Carbon::create(2015, 2)->isLeapYear());
+        Carbon::createSafe(2015, 2, 29, 17, 16, 15);
+    }
+
+    public function testCreateSafePassesForFebruaryInNonLeapYear()
+    {
+        // 28 days in February in a non-leap year
+        Carbon::createSafe(2015, 2, 28, 17, 16, 15);
+    }
+
+    public function testCreateSafePasses()
+    {
+        $sd = Carbon::createSafe(2015, 2, 15, 17, 16, 15);
+        $d = Carbon::create(2015, 2, 15, 17, 16, 15);
+        $this->assertEquals($d, $sd);
+        $this->assertCarbon($sd, 2015, 2, 15, 17, 16, 15);
+    }
+}


### PR DESCRIPTION
This is a PR concerning #583

Note:

* `createSafe`, I could not find a better name.
* `checkDate` is not reliable at the moment as we can only enter a year in of 0-9999 range, `checkDate` allows 0-32767
* We wish to indicate which argument throws an exception and with which value
* Should the `createSafe` only allows hour, minute and second arguments to be ignored (set to null) ? 

Suggestions are welcomed.

----

* [x] Add tests
* [x] Add `createSafe`


