### PR TITLE
Tr translate fix

### DIFF
--- a/src/Carbon/Lang/tr.php
+++ b/src/Carbon/Lang/tr.php
@@ -22,7 +22,7 @@ return array(
     'minute'    => ':count dakika',
     'second'    => ':count saniye',
     'ago'       => ':time önce',
-    'from_now'  => ':time andan itibaren',
+    'from_now'  => ':time sonra',
     'after'     => ':time sonra',
     'before'    => ':time önce',
 );

--- a/tests/Localization/TrTest.php
+++ b/tests/Localization/TrTest.php
@@ -65,7 +65,7 @@ class TrTest extends AbstractTestCase
             $scope->assertSame('2 yıl önce', $d->diffForHumans());
 
             $d = Carbon::now()->addSecond();
-            $scope->assertSame('1 saniye andan itibaren', $d->diffForHumans());
+            $scope->assertSame('1 saniye sonra', $d->diffForHumans());
 
             $d = Carbon::now()->addSecond();
             $d2 = Carbon::now();


### PR DESCRIPTION
Meaning of "from now" on dictionary is not suitable for the usage of package like the example; "3 yıl andan itibaren" (translation of 3 years from now) doesn't make sense. It should be "sonra" as both Google translate and jenssegers/date use it.