### PR TITLE
Add 'today' to RelativeKeywords

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -89,6 +89,7 @@ class Carbon extends DateTime
         'next',
         'last',
         'tomorrow',
+        'today',
         'yesterday',
         '+',
         '-',

--- a/tests/Carbon/TestingAidsTest.php
+++ b/tests/Carbon/TestingAidsTest.php
@@ -75,6 +75,7 @@ class TestingAidsTest extends AbstractTestCase
             $scope->assertSame('2013-08-25 05:15:05', Carbon::parse('1 week ago')->toDateTimeString());
 
             $scope->assertSame('2013-09-02 00:00:00', Carbon::parse('tomorrow')->toDateTimeString());
+            $scope->assertSame('2013-09-01 00:00:00', Carbon::parse('today')->toDateTimeString());
             $scope->assertSame('2013-08-31 00:00:00', Carbon::parse('yesterday')->toDateTimeString());
 
             $scope->assertSame('2013-09-02 05:15:05', Carbon::parse('+1 day')->toDateTimeString());


### PR DESCRIPTION
```
Carbon::setTestNow(Carbon::parse('2000-01-01 00:00:00'));

// 1999-12-31 00:00:00, Good!
$carbon = Carbon::parse('yesterday');
var_dump($carbon->toDateTimeString());

// 2016-03-16 00:00:00, Bad!
$carbon = Carbon::parse('today');
var_dump($carbon->toDateTimeString());

// 2000-01-01 00:00:00, Good!
$carbon = Carbon::parse('now');
var_dump($carbon->toDateTimeString());

// 2000-01-02 00:00:00, Good!
$carbon = Carbon::parse('tomorrow');
var_dump($carbon->toDateTimeString());
```