### PR TITLE
[WIP] Fix interval tests

### DIFF
--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -116,4 +116,9 @@ abstract class AbstractTestCase extends PHPUnit_Framework_TestCase
         $func();
         Carbon::setTestNow();
     }
+
+    protected function wrapWithNonDstDate(Closure $func)
+    {
+        static::wrapWithTestNow($func, Carbon::now()->startOfYear());
+    }
 }

--- a/tests/Localization/DaTest.php
+++ b/tests/Localization/DaTest.php
@@ -21,7 +21,7 @@ class DaTest extends AbstractTestCase
         Carbon::setLocale('da');
 
         $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
+        $this->wrapWithNonDstDate(function () use ($scope) {
             $d = Carbon::now()->subSecond();
             $scope->assertSame('1 sekund siden', $d->diffForHumans());
 

--- a/tests/Localization/DeTest.php
+++ b/tests/Localization/DeTest.php
@@ -21,7 +21,7 @@ class DeTest extends AbstractTestCase
         Carbon::setLocale('de');
 
         $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
+        $this->wrapWithNonDstDate(function () use ($scope) {
             $d = Carbon::now()->addYear();
             $scope->assertSame('in 1 Jahr', $d->diffForHumans());
 

--- a/tests/Localization/EsTest.php
+++ b/tests/Localization/EsTest.php
@@ -21,7 +21,7 @@ class EsTest extends AbstractTestCase
         Carbon::setLocale('es');
 
         $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
+        $this->wrapWithNonDstDate(function () use ($scope) {
             $d = Carbon::now()->subSecond();
             $scope->assertSame('hace 1 segundo', $d->diffForHumans());
 

--- a/tests/Localization/FaTest.php
+++ b/tests/Localization/FaTest.php
@@ -21,7 +21,7 @@ class FaTest extends AbstractTestCase
         Carbon::setLocale('fa');
 
         $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
+        $this->wrapWithNonDstDate(function () use ($scope) {
             $d = Carbon::now()->subSecond();
             $scope->assertSame('1 ثانیه پیش', $d->diffForHumans());
 

--- a/tests/Localization/FoTest.php
+++ b/tests/Localization/FoTest.php
@@ -21,7 +21,7 @@ class FoTest extends AbstractTestCase
         Carbon::setLocale('fo');
 
         $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
+        $this->wrapWithNonDstDate(function () use ($scope) {
             $d = Carbon::now()->subSecond();
             $scope->assertSame('1 sekund síðan', $d->diffForHumans());
 

--- a/tests/Localization/FrTest.php
+++ b/tests/Localization/FrTest.php
@@ -21,7 +21,7 @@ class FrTest extends AbstractTestCase
         Carbon::setLocale('fr');
 
         $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
+        $this->wrapWithNonDstDate(function () use ($scope) {
             $d = Carbon::now()->subSecond();
             $scope->assertSame('il y a 1 seconde', $d->diffForHumans());
 

--- a/tests/Localization/GlTest.php
+++ b/tests/Localization/GlTest.php
@@ -21,7 +21,7 @@ class GlTest extends AbstractTestCase
         Carbon::setLocale('gl');
 
         $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
+        $this->wrapWithNonDstDate(function () use ($scope) {
             $d = Carbon::now()->subSecond();
             $scope->assertSame('fai 1 segundo', $d->diffForHumans());
 

--- a/tests/Localization/HyTest.php
+++ b/tests/Localization/HyTest.php
@@ -21,7 +21,7 @@ class HyTest extends AbstractTestCase
         Carbon::setLocale('hy');
 
         $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
+        $this->wrapWithNonDstDate(function () use ($scope) {
             $d = Carbon::now()->subSecond();
             $scope->assertSame('1 վայրկյան առաջ', $d->diffForHumans());
 

--- a/tests/Localization/ItTest.php
+++ b/tests/Localization/ItTest.php
@@ -21,7 +21,7 @@ class ItTest extends AbstractTestCase
         Carbon::setLocale('it');
 
         $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
+        $this->wrapWithNonDstDate(function () use ($scope) {
             $d = Carbon::now()->addYear();
             $scope->assertSame('1 anno da adesso', $d->diffForHumans());
 

--- a/tests/Localization/JaTest.php
+++ b/tests/Localization/JaTest.php
@@ -21,7 +21,7 @@ class JaTest extends AbstractTestCase
         Carbon::setLocale('ja');
 
         $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
+        $this->wrapWithNonDstDate(function () use ($scope) {
             $d = Carbon::now()->subSecond();
             $scope->assertSame('1 秒 前', $d->diffForHumans());
 

--- a/tests/Localization/KaTest.php
+++ b/tests/Localization/KaTest.php
@@ -21,7 +21,7 @@ class KaTest extends AbstractTestCase
         Carbon::setLocale('ka');
 
         $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
+        $this->wrapWithNonDstDate(function () use ($scope) {
             $d = Carbon::now()->subSecond();
             $scope->assertSame('1 წამის უკან', $d->diffForHumans());
 

--- a/tests/Localization/KoTest.php
+++ b/tests/Localization/KoTest.php
@@ -21,7 +21,7 @@ class KoTest extends AbstractTestCase
         Carbon::setLocale('ko');
 
         $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
+        $this->wrapWithNonDstDate(function () use ($scope) {
             $d = Carbon::now()->addYear();
             $scope->assertSame('1 년 후', $d->diffForHumans());
 

--- a/tests/Localization/MkTest.php
+++ b/tests/Localization/MkTest.php
@@ -21,7 +21,7 @@ class MkTest extends AbstractTestCase
         Carbon::setLocale('mk');
 
         $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
+        $this->wrapWithNonDstDate(function () use ($scope) {
             $d = Carbon::now()->subSecond();
             $scope->assertSame('пред 1 секунда', $d->diffForHumans());
 

--- a/tests/Localization/NlTest.php
+++ b/tests/Localization/NlTest.php
@@ -21,7 +21,7 @@ class NlTest extends AbstractTestCase
         Carbon::setLocale('nl');
 
         $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
+        $this->wrapWithNonDstDate(function () use ($scope) {
             $d = Carbon::now()->subSecond();
             $scope->assertSame('1 seconde geleden', $d->diffForHumans());
 

--- a/tests/Localization/PtTest.php
+++ b/tests/Localization/PtTest.php
@@ -21,7 +21,7 @@ class PtTest extends AbstractTestCase
         Carbon::setLocale('pt');
 
         $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
+        $this->wrapWithNonDstDate(function () use ($scope) {
             $d = Carbon::now()->subSecond();
             $scope->assertSame('1 segundo atrás', $d->diffForHumans());
         });
@@ -32,7 +32,7 @@ class PtTest extends AbstractTestCase
         Carbon::setLocale('pt-BR');
 
         $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
+        $this->wrapWithNonDstDate(function () use ($scope) {
             $d = Carbon::now()->subSecond();
             $scope->assertSame('há 1 segundo', $d->diffForHumans());
         });
@@ -43,7 +43,7 @@ class PtTest extends AbstractTestCase
         Carbon::setLocale('pt_BR');
 
         $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
+        $this->wrapWithNonDstDate(function () use ($scope) {
             $d = Carbon::now()->subSecond();
             $scope->assertSame('há 1 segundo', $d->diffForHumans());
         });

--- a/tests/Localization/TrTest.php
+++ b/tests/Localization/TrTest.php
@@ -21,7 +21,7 @@ class TrTest extends AbstractTestCase
         Carbon::setLocale('tr');
 
         $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
+        $this->wrapWithNonDstDate(function () use ($scope) {
             $d = Carbon::now()->subSecond();
             $scope->assertSame('1 saniye önce', $d->diffForHumans());
 

--- a/tests/Localization/UrTest.php
+++ b/tests/Localization/UrTest.php
@@ -21,7 +21,7 @@ class UrTest extends AbstractTestCase
         Carbon::setLocale('ur');
 
         $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
+        $this->wrapWithNonDstDate(function () use ($scope) {
             $d = Carbon::now()->subSecond();
             $scope->assertSame('1 سیکنڈ پہلے', $d->diffForHumans());
 

--- a/tests/Localization/ZhTest.php
+++ b/tests/Localization/ZhTest.php
@@ -21,7 +21,7 @@ class ZhTest extends AbstractTestCase
         Carbon::setLocale('zh');
 
         $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
+        $this->wrapWithNonDstDate(function () use ($scope) {
             $d = Carbon::now()->subSecond();
             $scope->assertSame('1秒前', $d->diffForHumans());
 


### PR DESCRIPTION
In some occassions, interval tests fail when they are run on a month when a DST change happens: a non-DST date should always be used for these tests.