### PR TITLE
Update Carbon.php

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1038,7 +1038,7 @@ class Carbon extends DateTime
             $format = preg_replace('#(?<!%)((?:%%)*)%e#', '\1%#d', $format);
         }
 
-        return strftime($format, strtotime($this));
+        return utf8_encode(strftime($format, strtotime($this)));
     }
 
     /**


### PR DESCRIPTION
using my setlocale(LC_TIME, 'es') and formating my date with "formatLocalized", the output is not well (mi�rcoles, 06 de enero de 2016), so I googled and found this solution:
http://stackoverflow.com/questions/8993971/php-strftime-french-characters

Now is working properly: miércoles, 06 de enero de 2016

This problem will occur for all those languages with special characters.

A better solution will be using setlocale(LC_TIME, 'es.UTF-8') but strftime don't understand that.  Any suggestions?
