### PR TITLE
create a new carbon when passing a datetime

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -461,6 +461,18 @@ class Carbon extends DateTime
     }
 
     /**
+     * Create a Carbon instance for readability purposes
+     *
+     * @param string $timestamp
+     *
+     * @return static
+     */
+    public static function createFromDateTime($timestamp)
+    {
+        return static::parse($timestamp);
+    }
+
+    /**
      * Create a Carbon instance from an UTC timestamp.
      *
      * @param int $timestamp

--- a/tests/Carbon/CreateFromTimestampTest.php
+++ b/tests/Carbon/CreateFromTimestampTest.php
@@ -23,6 +23,12 @@ class CreateFromTimestampTest extends AbstractTestCase
         $this->assertCarbon($d, 1975, 5, 21, 22, 32, 5);
     }
 
+    public function testCreateFromDateTime()
+    {
+        $d = Carbon::createFromDateTime(date('Y-m-d H:i:s', time()));
+        $this->assertInstanceOf('Carbon\Carbon', $d);
+    }
+
     public function testCreateFromTimestampUsesDefaultTimezone()
     {
         $d = Carbon::createFromTimestamp(0);


### PR DESCRIPTION
I find myself having to do this quite often when not working with unix timestamps, ```Carbon::parse($date)->diffForHumans();```, is there any chance of implementing the proposed changed for readability purposes, ```Carbon::createFromDateTime($date)->diffForHumans();```?

Thanks!