### PR TITLE
Soft Fail on createFromFormat Function

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -426,12 +426,11 @@ class Carbon extends DateTime
      * @param string                    $format
      * @param string                    $time
      * @param \DateTimeZone|string|null $tz
+     * @param array                     $errors
      *
-     * @throws InvalidArgumentException
-     *
-     * @return static
+     * @return static|false
      */
-    public static function createFromFormat($format, $time, $tz = null)
+    public static function createFromFormat($format, $time, $tz = null, &$errors = [])
     {
         if ($tz !== null) {
             $dt = parent::createFromFormat($format, $time, static::safeCreateDateTimeZone($tz));
@@ -444,7 +443,7 @@ class Carbon extends DateTime
         }
 
         $errors = static::getLastErrors();
-        throw new InvalidArgumentException(implode(PHP_EOL, $errors['errors']));
+        return false;
     }
 
     /**


### PR DESCRIPTION
There are two reasons for this:
Firstly to match the core PHP createFromFormat behaviour
Secondly to work better with Laravel when MySQL timestamp columns have '0000-00-00 00:00:00' values.
Currently if you put a date column in the Eloquent model's 'dates' array and try to access it then it will automatically call Carbon's createFromFormat function to parse that column into a Carbon object. As such when the column has a '0000-00-00 00:00:00' value you get get an exception thrown, merely from trying to access the value. A soft fail in this case is a much more useful and proportionate response.

I have added the ability to return the original error(s) via a pass-by-reference argument.
