### PR TITLE
Remove CONTRIBUTING.md from export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,5 @@
 .php_cs export-ignore
 .styleci.yml export-ignore
 .travis.yml export-ignore
-CONTRIBUTING.md export-ignore
 phpunit.xml.dist export-ignore
 tests export-ignore


### PR DESCRIPTION
Remove CONTRIBUTING.md from export-ignore: this file does not exist