### PR TITLE
Created extensions adding business day functions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,22 @@ echo Carbon::now()->subMinutes(2)->diffForHumans(); // '2 minutes ago'
 // rolling up to seconds, minutes, hours, days, months, years
 
 $daysSinceEpoch = Carbon::createFromTimestamp(0)->diffInDays();
+
+// Check to see if a date is a business day defaulting to a Monday
+// through Friday work week
+$today = Carbon::now();
+CarbonExtensions::isBusinessDay($today);
+
+// Use a custom operating schedule by implementing the BusinessSchedule
+// interface
+$schedule = new OperatingSchedule();
+CarbonExtensions::isBusinessDay($today, $schedule);
+
+// Create custom holiday schedules by implementing the HolidaySchedule
+// interface so that observed holidays can be excluded as business days
+$holidays = new Holidays($today->year);
+CarbonExtensions::isBusinessDay($today, $holidays);
+
 ```
 
 ## Installation

--- a/src/Carbon/BusinessSchedule.php
+++ b/src/Carbon/BusinessSchedule.php
@@ -1,0 +1,16 @@
+<?php
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Carbon;
+
+interface BusinessSchedule
+{
+    public function isBusinessDay(Carbon $date);
+}

--- a/src/Carbon/CarbonExtensions.php
+++ b/src/Carbon/CarbonExtensions.php
@@ -1,0 +1,160 @@
+<?php
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Carbon;
+
+/**
+ * Class CarbonExtensions
+ */
+class CarbonExtensions
+{
+    /**
+     * Checks the date to see if it is a business day
+     *
+     * @author Christopher McGinnis <cmcginnis@tuition.io>
+     *
+     * @param Carbon                                $date
+     * @param HolidaySchedule|BusinessSchedule|null $schedule
+     *
+     * @return bool
+     */
+    public static function isBusinessDay(Carbon $date, $schedule = null)
+    {
+        $isHoliday = $schedule instanceof HolidaySchedule
+            ? $schedule->isHoliday($date)
+            : false
+        ;
+
+        $isBusinessDay = $schedule instanceof BusinessSchedule
+            ? $schedule->isBusinessDay($date)
+            : $date->isWeekday()
+        ;
+
+        return $isBusinessDay && !$isHoliday;
+    }
+
+    /**
+     * Sets the date to the next business day
+     *
+     * @author Christopher McGinnis <cmcginnis@tuition.io>
+     *
+     * @param Carbon                                $date
+     * @param HolidaySchedule|BusinessSchedule|null $schedule
+     *
+     * @return Carbon
+     */
+    public static function nextBusinessDay(Carbon $date, $schedule = null)
+    {
+        do {
+            $date->addDay();
+        } while (!self::isBusinessDay($date, $schedule));
+
+        return $date;
+    }
+
+    /**
+     * Sets the date to the current or next business day
+     *
+     * @author Christopher McGinnis <cmcginnis@tuition.io>
+     *
+     * @param Carbon                                $date
+     * @param HolidaySchedule|BusinessSchedule|null $schedule
+     *
+     * @return Carbon
+     */
+    public static function currentOrNextBusinessDay(Carbon $date, $schedule = null)
+    {
+        if (!self::isBusinessDay($date, $schedule)) {
+            self::nextBusinessDay($date, $schedule);
+        }
+
+        return $date;
+    }
+
+    /**
+     * Sets the date to the previous business day
+     *
+     * @author Christopher McGinnis <cmcginnis@tuition.io>
+     *
+     * @param Carbon                                $date
+     * @param HolidaySchedule|BusinessSchedule|null $schedule
+     *
+     * @return Carbon
+     */
+    public static function previousBusinessDay(Carbon $date, $schedule = null)
+    {
+        do {
+            $date->subDay();
+        } while (!self::isBusinessDay($date, $schedule));
+
+        return $date;
+    }
+
+    /**
+     * Sets the date to the current or previous business day
+     *
+     * @author Christopher McGinnis <cmcginnis@tuition.io>
+     *
+     * @param Carbon                                $date
+     * @param HolidaySchedule|BusinessSchedule|null $schedule
+     *
+     * @return Carbon
+     */
+    public static function currentOrPreviousBusinessDay(Carbon $date, $schedule = null)
+    {
+        if (!self::isBusinessDay($date, $schedule)) {
+            self::previousBusinessDay($date, $schedule);
+        }
+
+        return $date;
+    }
+
+    /**
+     * Sets the date to that corresponds to the number of business days after the starting date
+     *
+     * @author Christopher McGinnis <cmcginnis@tuition.io>
+     *
+     * @param Carbon                                $date
+     * @param int                                   $days
+     * @param HolidaySchedule|BusinessSchedule|null $schedule
+     *
+     * @return Carbon
+     */
+    public static function addBusinessDays(Carbon $date, $days, $schedule = null)
+    {
+        while ($days != 0) {
+            if ($days > 0) {
+                $date = self::nextBusinessDay($date, $schedule);
+                $days--;
+            } else {
+                $date = self::previousBusinessDay($date, $schedule);
+                $days++;
+            }
+        }
+
+        return $date;
+    }
+
+    /**
+     * Sets the date to that corresponds to the number of business days prior the starting date
+     *
+     * @author Christopher McGinnis <cmcginnis@tuition.io>
+     *
+     * @param Carbon                                $date
+     * @param int                                   $days
+     * @param HolidaySchedule|BusinessSchedule|null $schedule
+     *
+     * @return Carbon
+     */
+    public static function subBusinessDays(Carbon $date, $days, $schedule = null)
+    {
+        return self::addBusinessDays($date, -$days, $schedule);
+    }
+}

--- a/src/Carbon/HolidaySchedule.php
+++ b/src/Carbon/HolidaySchedule.php
@@ -1,0 +1,16 @@
+<?php
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Carbon;
+
+interface HolidaySchedule
+{
+    public function isHoliday(Carbon $date);
+}

--- a/tests/CarbonExtensions/BusinessDayTest.php
+++ b/tests/CarbonExtensions/BusinessDayTest.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Carbon;
+
+use Carbon\Carbon;
+use Carbon\CarbonExtensions;
+use Tests\AbstractTestCase;
+use Tests\CarbonExtensions\Fixtures\FederalHolidays;
+use Tests\CarbonExtensions\Fixtures\FederalHolidaysObserved;
+use Tests\CarbonExtensions\Fixtures\OperatingSchedule;
+
+class BusinessDayTest extends AbstractTestCase
+{
+    public function testIsBusinessDay()
+    {
+        $date = Carbon::create(2016, 7, 4, 0, 0, 0);
+        $this->assertTrue(CarbonExtensions::isBusinessDay($date));
+
+        $date = Carbon::create(2016, 7, 9, 0, 0, 0);
+        $this->assertFalse(CarbonExtensions::isBusinessDay($date));
+
+        $schedule = new OperatingSchedule(2016);
+        $this->assertFalse(CarbonExtensions::isBusinessDay($date->copy()->subDay(2), $schedule));
+        $this->assertTrue(CarbonExtensions::isBusinessDay($date->copy()->subDay(), $schedule));
+        $this->assertTrue(CarbonExtensions::isBusinessDay($date, $schedule));
+        $this->assertTrue(CarbonExtensions::isBusinessDay($date->copy()->addDay(), $schedule));
+        $this->assertTrue(CarbonExtensions::isBusinessDay($date->copy()->addDay(2), $schedule));
+        $this->assertFalse(CarbonExtensions::isBusinessDay($date->copy()->addDay(3), $schedule));
+    }
+
+    public function testIsBusinessDayObservingHolidays()
+    {
+        $year = 2016;
+        $holidays = new FederalHolidays($year);
+        $observedHolidays = new FederalHolidaysObserved($year);
+
+        $this->assertTrue($holidays->christmasDay->isSunday());
+        $this->assertFalse(CarbonExtensions::isBusinessDay($holidays->christmasDay));
+        $this->assertFalse(CarbonExtensions::isBusinessDay($holidays->christmasDay->copy()->addDay(), $observedHolidays));
+        $this->assertTrue(CarbonExtensions::isBusinessDay($holidays->christmasDay->copy()->addDay(2), $observedHolidays));
+
+        $this->assertTrue($holidays->independenceDay->isMonday());
+        $this->assertFalse(CarbonExtensions::isBusinessDay($holidays->independenceDay, $holidays));
+        $this->assertTrue(CarbonExtensions::isBusinessDay($holidays->independenceDay->copy()->addDay(), $observedHolidays));
+        $this->assertTrue(CarbonExtensions::isBusinessDay($holidays->independenceDay->copy()->addDay(2), $observedHolidays));
+
+        $this->assertTrue($holidays->veteransDay->isFriday());
+        $this->assertFalse(CarbonExtensions::isBusinessDay($holidays->veteransDay, $holidays));
+        $this->assertFalse(CarbonExtensions::isBusinessDay($holidays->veteransDay->copy()->addDay(), $observedHolidays));
+        $this->assertFalse(CarbonExtensions::isBusinessDay($holidays->veteransDay->copy()->addDay(2), $observedHolidays));
+        $this->assertTrue(CarbonExtensions::isBusinessDay($holidays->veteransDay->copy()->addDay(3), $observedHolidays));
+    }
+
+    public function testIsBusinessDayExcludingSomeHolidays()
+    {
+        $year = 2016;
+        $holidays = new FederalHolidays($year);
+        $excludedHolidays = new FederalHolidays($year);
+        $excludedHolidays->observedHolidays = FederalHolidays::ALL_HOLIDAYS ^ FederalHolidays::COLUMBUS_DAY;
+
+        $this->assertFalse(CarbonExtensions::isBusinessDay($holidays->columbusDay, $holidays));
+        $this->assertTrue(CarbonExtensions::isBusinessDay($holidays->columbusDay, $excludedHolidays));
+    }
+
+    public function testGetNextBusinessDay()
+    {
+        $year = 2016;
+        $holidays = new FederalHolidays($year);
+        $observedHolidays = new FederalHolidaysObserved($year);
+
+        $date = $holidays->christmasDay->copy()->subDay();
+        $this->assertTrue($date->isSaturday());
+        CarbonExtensions::nextBusinessDay($date, $holidays);
+        $this->assertTrue($date->isMonday());
+        $this->assertTrue($date->isSameDay(Carbon::create($year, 12, 26, 0, 0, 0)));
+
+        $date = $holidays->christmasDay->copy()->subDay();
+        CarbonExtensions::nextBusinessDay($date, $observedHolidays);
+        $this->assertTrue($date->isTuesday());
+        $this->assertTrue($date->isSameDay(Carbon::create($year, 12, 27, 0, 0, 0)));
+
+        $date = $holidays->veteransDay->copy()->subDay();
+        $this->assertTrue($date->isThursday());
+        CarbonExtensions::nextBusinessDay($date, $holidays);
+        $this->assertTrue($date->isMonday());
+        $this->assertTrue($date->isSameDay(Carbon::create($year, 11, 14, 0, 0, 0)));
+
+        $date = $holidays->veteransDay->copy()->subDay();
+        $this->assertTrue($date->isThursday());
+        CarbonExtensions::nextBusinessDay($date, $observedHolidays);
+        $this->assertTrue($date->isMonday());
+        $this->assertTrue($date->isSameDay(Carbon::create($year, 11, 14, 0, 0, 0)));
+
+        $date = $holidays->thanksgivingDay->copy()->subDay();
+        $this->assertTrue($date->isWednesday());
+        CarbonExtensions::nextBusinessDay($date, $holidays);
+        $this->assertTrue($date->isFriday());
+        $this->assertTrue($date->isSameDay(Carbon::create($year, 11, 25, 0, 0, 0)));
+    }
+
+    public function testGetPreviousBusinessDay()
+    {
+        $year = 2016;
+        $holidays = new FederalHolidays($year);
+        $observedHolidays = new FederalHolidaysObserved($year);
+
+        $date = $holidays->christmasDay->copy()->addDay();
+        $this->assertTrue($date->isMonday());
+        CarbonExtensions::previousBusinessDay($date, $holidays);
+        $this->assertTrue($date->isFriday());
+        $this->assertTrue($date->isSameDay(Carbon::create($year, 12, 23, 0, 0, 0)));
+
+        $date = $holidays->christmasDay->copy()->addDay();
+        CarbonExtensions::previousBusinessDay($date, $observedHolidays);
+        $this->assertTrue($date->isFriday());
+        $this->assertTrue($date->isSameDay(Carbon::create($year, 12, 23, 0, 0, 0)));
+
+        $date = $holidays->veteransDay->copy()->addDay();
+        $this->assertTrue($date->isSaturday());
+        CarbonExtensions::previousBusinessDay($date, $holidays);
+        $this->assertTrue($date->isThursday());
+        $this->assertTrue($date->isSameDay(Carbon::create($year, 11, 10, 0, 0, 0)));
+
+        $date = $holidays->veteransDay->copy()->addDay();
+        $this->assertTrue($date->isSaturday());
+        CarbonExtensions::previousBusinessDay($date, $observedHolidays);
+        $this->assertTrue($date->isThursday());
+        $this->assertTrue($date->isSameDay(Carbon::create($year, 11, 10, 0, 0, 0)));
+
+        $date = $holidays->thanksgivingDay->copy()->addDay();
+        $this->assertTrue($date->isFriday());
+        CarbonExtensions::previousBusinessDay($date, $holidays);
+        $this->assertTrue($date->isWednesday());
+        $this->assertTrue($date->isSameDay(Carbon::create($year, 11, 23, 0, 0, 0)));
+    }
+}

--- a/tests/CarbonExtensions/Fixtures/FederalHolidays.php
+++ b/tests/CarbonExtensions/Fixtures/FederalHolidays.php
@@ -1,0 +1,206 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonExtensions\Fixtures;
+
+use Carbon\Carbon;
+use Carbon\HolidaySchedule;
+
+/**
+ * Class FederalHolidays
+ *
+ * @property-read int $year;
+ * @property int $observedHolidays;
+ * @property-read Carbon $newYearsDay;
+ * @property-read Carbon $martinLutherKingsBirthday;
+ * @property-read Carbon $washingtonsBirthday;
+ * @property-read Carbon $memorialDay;
+ * @property-read Carbon $independenceDay;
+ * @property-read Carbon $laborDay;
+ * @property-read Carbon $columbusDay;
+ * @property-read Carbon $veteransDay;
+ * @property-read Carbon $thanksgivingDay;
+ * @property-read Carbon $christmasDay;
+ */
+class FederalHolidays implements HolidaySchedule
+{
+    const NEW_YEARS_DAY = 0x0001;
+    const MARTIN_LUTHER_KINGS_BIRTHDAY = 0x0002;
+    const WASHINGTONS_BIRTHDAY = 0x0004;
+    const MEMORIAL_DAY = 0x0008;
+    const INDEPENDENCE_DAY = 0x0010;
+    const LABOR_DAY = 0x0020;
+    const COLUMBUS_DAY = 0x0040;
+    const VETERANS_DAY = 0x0080;
+    const THANKSGIVING_DAY = 0x0100;
+    const CHRISTMAS_DAY = 0x0200;
+    const ALL_HOLIDAYS = 0x03ff;
+
+    public $year;
+
+    public $observedHolidays;
+
+    public $newYearsDay;
+
+    public $martinLutherKingsBirthday;
+
+    public $washingtonsBirthday;
+
+    public $memorialDay;
+
+    public $independenceDay;
+
+    public $laborDay;
+
+    public $columbusDay;
+
+    public $veteransDay;
+
+    public $thanksgivingDay;
+
+    public $christmasDay;
+
+    /**
+     * FederalHolidays constructor.
+     *
+     * @param int $year
+     * @param int $observedHolidays
+     */
+    public function __construct($year, $observedHolidays = self::ALL_HOLIDAYS)
+    {
+        $this->year = $year;
+        $this->observedHolidays = $observedHolidays;
+
+        $this->newYearsDay = $this->getNewYearsDay();
+        $this->martinLutherKingsBirthday = $this->getMartinLutherKingsBirthday();
+        $this->washingtonsBirthday = $this->getWashingtonsBirthday();
+        $this->memorialDay = $this->getMemorialDay();
+        $this->independenceDay = $this->getIndependenceDay();
+        $this->laborDay = $this->getLaborDay();
+        $this->columbusDay = $this->getColumbusDay();
+        $this->veteransDay = $this->getVeteransDay();
+        $this->thanksgivingDay = $this->getThanksgivingDay();
+        $this->christmasDay = $this->getChristmasDay();
+    }
+
+    /**
+     * @param Carbon $date
+     *
+     * @returns bool
+     */
+    public function isHoliday(Carbon $date)
+    {
+        // created a copy of the datetime object to we can remove the time values without affecting
+        // the passed in instance
+
+        return ($this->newYearsDay->isSameDay($date) && $this->isObserved(self::NEW_YEARS_DAY))
+            || ($this->martinLutherKingsBirthday->isSameDay($date) && $this->isObserved(self::MARTIN_LUTHER_KINGS_BIRTHDAY))
+            || ($this->washingtonsBirthday->isSameDay($date) && $this->isObserved(self::WASHINGTONS_BIRTHDAY))
+            || ($this->memorialDay->isSameDay($date) && $this->isObserved(self::MEMORIAL_DAY))
+            || ($this->independenceDay->isSameDay($date) && $this->isObserved(self::INDEPENDENCE_DAY))
+            || ($this->laborDay->isSameDay($date) && $this->isObserved(self::LABOR_DAY))
+            || ($this->columbusDay->isSameDay($date) && $this->isObserved(self::COLUMBUS_DAY))
+            || ($this->veteransDay->isSameDay($date) && $this->isObserved(self::VETERANS_DAY))
+            || ($this->thanksgivingDay->isSameDay($date) && $this->isObserved(self::THANKSGIVING_DAY))
+            || ($this->christmasDay->isSameDay($date) && $this->isObserved(self::CHRISTMAS_DAY))
+            ;
+    }
+
+    /**
+     * @param $holiday
+     *
+     * @return bool
+     */
+    public function isObserved($holiday)
+    {
+        return ($holiday & $this->observedHolidays) == $holiday;
+    }
+
+    /**
+     * @return Carbon
+     */
+    protected function getNewYearsDay()
+    {
+        return Carbon::create($this->year, 1, 1, 0, 0, 0);
+    }
+
+    /**
+     * @return Carbon
+     */
+    protected function getMartinLutherKingsBirthday()
+    {
+        return Carbon::create($this->year, 1, 1, 0, 0, 0)->nthOfMonth(3, Carbon::MONDAY);
+    }
+
+    /**
+     * @return Carbon
+     */
+    protected function getWashingtonsBirthday()
+    {
+        return Carbon::create($this->year, 2, 1, 0, 0, 0)->nthOfMonth(3, Carbon::MONDAY);
+    }
+
+    /**
+     * @return Carbon
+     */
+    protected function getMemorialDay()
+    {
+        return Carbon::create($this->year, 5, 1, 0, 0, 0) ->lastOfMonth(Carbon::MONDAY);
+    }
+
+    /**
+     * @return Carbon
+     */
+    protected function getIndependenceDay()
+    {
+        return Carbon::create($this->year, 7, 4, 0, 0, 0);
+    }
+
+    /**
+     * @return Carbon
+     */
+    protected function getLaborDay()
+    {
+        return Carbon::create($this->year, 9, 1, 0, 0, 0)->firstOfMonth(Carbon::MONDAY);
+    }
+
+    /**
+     * @return Carbon
+     */
+    protected function getColumbusDay()
+    {
+        return Carbon::create($this->year, 10, 1, 0, 0, 0)->nthOfMonth(2, Carbon::MONDAY);
+    }
+
+    /**
+     * @return Carbon
+     */
+    protected function getVeteransDay()
+    {
+        return Carbon::create($this->year, 11, 11, 0, 0, 0);
+    }
+
+    /**
+     * @return Carbon
+     */
+    protected function getThanksgivingDay()
+    {
+        return Carbon::create($this->year, 11, 1, 0, 0, 0)->nthOfMonth(4, Carbon::THURSDAY);
+    }
+
+    /**
+     * @return Carbon
+     */
+    protected function getChristmasDay()
+    {
+        return Carbon::create($this->year, 12, 25, 0, 0, 0);
+    }
+}

--- a/tests/CarbonExtensions/Fixtures/FederalHolidaysObserved.php
+++ b/tests/CarbonExtensions/Fixtures/FederalHolidaysObserved.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonExtensions\Fixtures;
+
+use Carbon\Carbon;
+
+class FederalHolidaysObserved extends FederalHolidays
+{
+    /**
+     * @return Carbon
+     */
+    protected function getNewYearsDay()
+    {
+        return $this->observedOn(parent::getNewYearsDay());
+    }
+
+    /**
+     * @return Carbon
+     */
+    protected function getIndependenceDay()
+    {
+        return $this->observedOn(parent::getIndependenceDay());
+    }
+
+    /**
+     * @return Carbon
+     */
+    protected function getVeteransDay()
+    {
+        return $this->observedOn(parent::getVeteransDay());
+    }
+
+    /**
+     * @return Carbon
+     */
+    protected function getChristmasDay()
+    {
+        return $this->observedOn(parent::getChristmasDay());
+    }
+
+    /**
+     * @param Carbon $date
+     *
+     * @return Carbon
+     */
+    protected function observedOn(Carbon $date)
+    {
+        if ($date->isWeekend()) {
+            $date->next(Carbon::MONDAY);
+        }
+
+        return $date;
+    }
+}

--- a/tests/CarbonExtensions/Fixtures/OperatingSchedule.php
+++ b/tests/CarbonExtensions/Fixtures/OperatingSchedule.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonExtensions\Fixtures;
+
+use Carbon\Carbon;
+use Carbon\BusinessSchedule;
+
+class OperatingSchedule extends FederalHolidaysObserved implements BusinessSchedule
+{
+    public function __construct($year)
+    {
+        parent::__construct($year, self::ALL_HOLIDAYS ^ self::MEMORIAL_DAY);
+    }
+
+    public function isBusinessDay(Carbon $date)
+    {
+        $operatingDays = array(Carbon::FRIDAY, Carbon::SATURDAY, Carbon::SUNDAY, Carbon::MONDAY);
+
+        return in_array($date->dayOfWeek, $operatingDays);
+    }
+}


### PR DESCRIPTION
I created a set of extension methods which provides a flexible set of
methods that allow the determination if a date is a business day as
well as determining the next or previous business day. Custom holiday
and business schedules can be supplies to the methods to allow an
end-user to determine what holidays, if any, are to be observed and the
days that fit operating schedule of the business being modeled.

**NOTE:** I know that this functionality has been asked for before but it seemed that you didn't want to include the functionality into the Carbon class. I felt that extending Carbon would be a bad idea because it would lock implementations to a certain subclass and created a hierarchical mess if there were multiple subclasses with some users wanting functionality that was contained in 2 or more subclasses. Because of those reasons I opted to create an extension class where other contributors could add in functionality to extend Carbon while keeping the Carbon class pure. If that functionality is deemed worthy enough to be promoted to the Carbon class it can be done easily without breaking backwards compatibility and without having duplication of code.
