### PR TITLE
Add overflow behaviour

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -171,6 +171,45 @@ class Carbon extends DateTime
     private static $lastErrors;
 
     /**
+     * Indicates if months should be calculated with overflow.
+     *
+     * @var bool
+     */
+    protected static $monthsOverflow = true;
+
+    /**
+     * Indicates if months should be calculated with overflow.
+     *
+     * @param bool $monthsOverflow
+     *
+     * @return void
+     */
+    public static function useMonthsOverflow($monthsOverflow = true)
+    {
+        static::$monthsOverflow = $monthsOverflow;
+    }
+
+    /**
+     * Reset the month overflow behavior.
+     *
+     * @return void
+     */
+    public static function resetMonthsOverflow()
+    {
+        static::$monthsOverflow = true;
+    }
+
+    /**
+     * Get the month overflow behavior.
+     *
+     * @return bool
+     */
+    public static function shouldOverflowMonths()
+    {
+        return static::$monthsOverflow;
+    }
+
+    /**
      * Creates a DateTimeZone from a string, DateTimeZone or integer offset.
      *
      * @param \DateTimeZone|string|int|null $object
@@ -1996,7 +2035,11 @@ class Carbon extends DateTime
      */
     public function addMonths($value)
     {
-        return $this->modify((int) $value.' month');
+        if (static::shouldOverflowMonths()) {
+            return $this->addMonthsWithOverflow($value);
+        }
+
+        return $this->addMonthsNoOverflow($value);
     }
 
     /**
@@ -2036,6 +2079,55 @@ class Carbon extends DateTime
     }
 
     /**
+     * Add months to the instance. Positive $value travels forward while
+     * negative $value travels into the past.
+     *
+     * @param int $value
+     *
+     * @return static
+     */
+    public function addMonthsWithOverflow($value)
+    {
+        return $this->modify((int) $value.' month');
+    }
+
+    /**
+     * Add a month to the instance
+     *
+     * @param int $value
+     *
+     * @return static
+     */
+    public function addMonthWithOverflow($value = 1)
+    {
+        return $this->addMonthsWithOverflow($value);
+    }
+
+    /**
+     * Remove a month from the instance
+     *
+     * @param int $value
+     *
+     * @return static
+     */
+    public function subMonthWithOverflow($value = 1)
+    {
+        return $this->subMonthsWithOverflow($value);
+    }
+
+    /**
+     * Remove months from the instance
+     *
+     * @param int $value
+     *
+     * @return static
+     */
+    public function subMonthsWithOverflow($value)
+    {
+        return $this->addMonthsWithOverflow(-1 * $value);
+    }
+
+    /**
      * Add months without overflowing to the instance. Positive $value
      * travels forward while negative $value travels into the past.
      *
@@ -2047,7 +2139,7 @@ class Carbon extends DateTime
     {
         $day = $this->day;
 
-        $this->addMonths($value);
+        $this->modify((int) $value.' month');
 
         if ($day !== $this->day) {
             $this->modify('last day of previous month');

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -32,6 +32,7 @@ abstract class AbstractTestCase extends PHPUnit_Framework_TestCase
     {
         date_default_timezone_set($this->saveTz);
         Carbon::setTestNow();
+        Carbon::resetMonthsOverflow();
     }
 
     protected function assertCarbon(Carbon $d, $year, $month, $day, $hour = null, $minute = null, $second = null)

--- a/tests/Carbon/AddMonthsTest.php
+++ b/tests/Carbon/AddMonthsTest.php
@@ -1,0 +1,316 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Carbon;
+
+use Carbon\Carbon;
+use Tests\AbstractTestCase;
+
+class AddMonthsTest extends AbstractTestCase
+{
+    /**
+     * @var \Carbon\Carbon
+     */
+    private $carbon;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->carbon = Carbon::create(2016, 1, 31);
+    }
+
+    public function providerTestAddMonthNoOverflow()
+    {
+        return array(
+            array(- 2, 2015, 11, 30),
+            array(- 1, 2015, 12, 31),
+            array(0, 2016, 1, 31),
+            array(1, 2016, 2, 29),
+            array(2, 2016, 3, 31),
+        );
+    }
+
+    /**
+     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthNoOverflow
+     *
+     * @param $months
+     * @param int $y
+     * @param int $m
+     * @param int $d
+     */
+    public function testAddMonthNoOverflow($months, $y, $m, $d)
+    {
+        $this->assertCarbon($this->carbon->addMonthNoOverflow($months), $y, $m, $d);
+    }
+
+    /**
+     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthNoOverflow
+     *
+     * @param $months
+     * @param int $y
+     * @param int $m
+     * @param int $d
+     */
+    public function testAddMonthsNoOverflow($months, $y, $m, $d)
+    {
+        $this->assertCarbon($this->carbon->addMonthsNoOverflow($months), $y, $m, $d);
+    }
+
+    public function providerTestSubMonthNoOverflow()
+    {
+        return array(
+            array(- 2, 2016, 3, 31),
+            array(- 1, 2016, 2, 29),
+            array(0, 2016, 1, 31),
+            array(1, 2015, 12, 31),
+            array(2, 2015, 11, 30),
+        );
+    }
+
+    /**
+     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthNoOverflow
+     *
+     * @param $months
+     * @param int $y
+     * @param int $m
+     * @param int $d
+     */
+    public function testSubMonthNoOverflow($months, $y, $m, $d)
+    {
+        $this->assertCarbon($this->carbon->subMonthNoOverflow($months), $y, $m, $d);
+    }
+
+    /**
+     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthNoOverflow
+     *
+     * @param $months
+     * @param int $y
+     * @param int $m
+     * @param int $d
+     */
+    public function testSubMonthsNoOverflow($months, $y, $m, $d)
+    {
+        $this->assertCarbon($this->carbon->subMonthsNoOverflow($months), $y, $m, $d);
+    }
+
+    public function providerTestAddMonthWithOverflow()
+    {
+        return array(
+            array(- 2, 2015, 12, 1),
+            array(- 1, 2015, 12, 31),
+            array(0, 2016, 1, 31),
+            array(1, 2016, 3, 2),
+            array(2, 2016, 3, 31),
+        );
+    }
+
+    /**
+     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthWithOverflow
+     *
+     * @param $months
+     * @param int $y
+     * @param int $m
+     * @param int $d
+     */
+    public function testAddMonthWithOverflow($months, $y, $m, $d)
+    {
+        $this->assertCarbon($this->carbon->addMonthWithOverflow($months), $y, $m, $d);
+    }
+
+    /**
+     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthWithOverflow
+     *
+     * @param $months
+     * @param int $y
+     * @param int $m
+     * @param int $d
+     */
+    public function testAddMonthsWithOverflow($months, $y, $m, $d)
+    {
+        $this->assertCarbon($this->carbon->addMonthsWithOverflow($months), $y, $m, $d);
+    }
+
+    public function providerTestSubMonthWithOverflow()
+    {
+        return array(
+            array(- 2, 2016, 3, 31),
+            array(- 1, 2016, 3, 2),
+            array(0, 2016, 1, 31),
+            array(1, 2015, 12, 31),
+            array(2, 2015, 12, 1),
+        );
+    }
+
+    /**
+     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthWithOverflow
+     *
+     * @param $months
+     * @param int $y
+     * @param int $m
+     * @param int $d
+     */
+    public function testSubMonthWithOverflow($months, $y, $m, $d)
+    {
+        $this->assertCarbon($this->carbon->subMonthWithOverflow($months), $y, $m, $d);
+    }
+
+    /**
+     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthWithOverflow
+     *
+     * @param $months
+     * @param int $y
+     * @param int $m
+     * @param int $d
+     */
+    public function testSubMonthsWithOverflow($months, $y, $m, $d)
+    {
+        $this->assertCarbon($this->carbon->subMonthsWithOverflow($months), $y, $m, $d);
+    }
+
+    public function testSetOverflowIsTrue()
+    {
+        Carbon::useMonthsOverflow(true);
+        $this->assertTrue(Carbon::shouldOverflowMonths());
+    }
+
+    public function testSetOverflowIsFalse()
+    {
+        Carbon::useMonthsOverflow(false);
+        $this->assertFalse(Carbon::shouldOverflowMonths());
+    }
+
+    public function testSetOverflowIsResetInTests()
+    {
+        $this->assertTrue(Carbon::shouldOverflowMonths());
+    }
+
+    public function testSetOverflowIsReset()
+    {
+        Carbon::useMonthsOverflow(false);
+        $this->assertFalse(Carbon::shouldOverflowMonths());
+
+        Carbon::resetMonthsOverflow();
+        $this->assertTrue(Carbon::shouldOverflowMonths());
+    }
+
+    /**
+     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthWithOverflow
+     *
+     * @param $months
+     * @param int $y
+     * @param int $m
+     * @param int $d
+     */
+    public function testUseOverflowAddMonth($months, $y, $m, $d)
+    {
+        Carbon::useMonthsOverflow(true);
+        $this->assertCarbon($this->carbon->addMonth($months), $y, $m, $d);
+    }
+
+    /**
+     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthWithOverflow
+     *
+     * @param $months
+     * @param int $y
+     * @param int $m
+     * @param int $d
+     */
+    public function testUseOverflowAddMonths($months, $y, $m, $d)
+    {
+        Carbon::useMonthsOverflow(true);
+        $this->assertCarbon($this->carbon->addMonths($months), $y, $m, $d);
+    }
+
+    /**
+     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthWithOverflow
+     *
+     * @param $months
+     * @param int $y
+     * @param int $m
+     * @param int $d
+     */
+    public function testUseOverflowSubMonth($months, $y, $m, $d)
+    {
+        Carbon::useMonthsOverflow(true);
+        $this->assertCarbon($this->carbon->subMonth($months), $y, $m, $d);
+    }
+
+    /**
+     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthWithOverflow
+     *
+     * @param $months
+     * @param int $y
+     * @param int $m
+     * @param int $d
+     */
+    public function testUseOverflowSubMonths($months, $y, $m, $d)
+    {
+        Carbon::useMonthsOverflow(true);
+        $this->assertCarbon($this->carbon->subMonths($months), $y, $m, $d);
+    }
+
+    /**
+     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthNoOverflow
+     *
+     * @param $months
+     * @param int $y
+     * @param int $m
+     * @param int $d
+     */
+    public function testSkipOverflowAddMonth($months, $y, $m, $d)
+    {
+        Carbon::useMonthsOverflow(false);
+        $this->assertCarbon($this->carbon->addMonth($months), $y, $m, $d);
+    }
+
+    /**
+     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthNoOverflow
+     *
+     * @param $months
+     * @param int $y
+     * @param int $m
+     * @param int $d
+     */
+    public function testSkipOverflowAddMonths($months, $y, $m, $d)
+    {
+        Carbon::useMonthsOverflow(false);
+        $this->assertCarbon($this->carbon->addMonths($months), $y, $m, $d);
+    }
+
+    /**
+     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthNoOverflow
+     *
+     * @param $months
+     * @param int $y
+     * @param int $m
+     * @param int $d
+     */
+    public function testSkipOverflowSubMonth($months, $y, $m, $d)
+    {
+        Carbon::useMonthsOverflow(false);
+        $this->assertCarbon($this->carbon->subMonth($months), $y, $m, $d);
+    }
+
+    /**
+     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthNoOverflow
+     *
+     * @param $months
+     * @param int $y
+     * @param int $m
+     * @param int $d
+     */
+    public function testSkipOverflowSubMonths($months, $y, $m, $d)
+    {
+        Carbon::useMonthsOverflow(false);
+        $this->assertCarbon($this->carbon->subMonths($months), $y, $m, $d);
+    }
+}

--- a/tests/Carbon/AddTest.php
+++ b/tests/Carbon/AddTest.php
@@ -36,52 +36,6 @@ class AddTest extends AbstractTestCase
         $this->assertSame(1976, Carbon::createFromDate(1975)->addYear()->year);
     }
 
-    public function testAddMonthsPositive()
-    {
-        $this->assertSame(1, Carbon::createFromDate(1975, 12)->addMonths(1)->month);
-    }
-
-    public function testAddMonthsZero()
-    {
-        $this->assertSame(12, Carbon::createFromDate(1975, 12)->addMonths(0)->month);
-    }
-
-    public function testAddMonthsNegative()
-    {
-        $this->assertSame(11, Carbon::createFromDate(1975, 12, 1)->addMonths(-1)->month);
-    }
-
-    public function testAddMonth()
-    {
-        $this->assertSame(1, Carbon::createFromDate(1975, 12)->addMonth()->month);
-    }
-
-    public function testAddMonthWithOverflow()
-    {
-        $this->assertSame(3, Carbon::createFromDate(2012, 1, 31)->addMonth()->month);
-    }
-
-    public function testAddMonthsNoOverflowPositive()
-    {
-        $this->assertCarbon(Carbon::create(2012, 1, 31, 1, 1, 1)->addMonthNoOverflow(), 2012, 2, 29, 1, 1, 1);
-        $this->assertCarbon(Carbon::create(2012, 1, 31, 1, 1, 1)->addMonthsNoOverflow(2), 2012, 3, 31, 1, 1, 1);
-        $this->assertCarbon(Carbon::create(2012, 2, 29, 1, 1, 1)->addMonthNoOverflow(), 2012, 3, 29, 1, 1, 1);
-        $this->assertCarbon(Carbon::create(2011, 12, 31, 1, 1, 1)->addMonthNoOverflow(2), 2012, 2, 29, 1, 1, 1);
-    }
-
-    public function testAddMonthsNoOverflowZero()
-    {
-        $this->assertSame(12, Carbon::createFromDate(1975, 12)->addMonths(0)->month);
-    }
-
-    public function testAddMonthsNoOverflowNegative()
-    {
-        $this->assertCarbon(Carbon::create(2012, 2, 29, 1, 1, 1)->addMonthsNoOverflow(-1), 2012, 1, 29, 1, 1, 1);
-        $this->assertCarbon(Carbon::create(2012, 3, 31, 1, 1, 1)->addMonthsNoOverflow(-2), 2012, 1, 31, 1, 1, 1);
-        $this->assertCarbon(Carbon::create(2012, 3, 31, 1, 1, 1)->addMonthsNoOverflow(-1), 2012, 2, 29, 1, 1, 1);
-        $this->assertCarbon(Carbon::create(2012, 1, 31, 1, 1, 1)->addMonthsNoOverflow(-1), 2011, 12, 31, 1, 1, 1);
-    }
-
     public function testAddDaysPositive()
     {
         $this->assertSame(1, Carbon::createFromDate(1975, 5, 31)->addDays(1)->day);
@@ -220,16 +174,6 @@ class AddTest extends AbstractTestCase
     public function testAddYearPassingArg()
     {
         $this->assertSame(1977, Carbon::createFromDate(1975)->addYear(2)->year);
-    }
-
-    public function testAddMonthPassingArg()
-    {
-        $this->assertSame(7, Carbon::createFromDate(1975, 5, 1)->addMonth(2)->month);
-    }
-
-    public function testAddMonthNoOverflowPassingArg()
-    {
-        $this->assertCarbon(Carbon::create(2010, 12, 31, 1, 1, 1, 1)->addMonthNoOverflow(2), 2011, 2, 28, 1, 1, 1);
     }
 
     public function testAddDayPassingArg()


### PR DESCRIPTION
Add an overflow behavior.

``` php
Carbon:: useMonthsOverflow(false);
```

By default `addMonths` will work with overflow as `\DateTime` does, so that there is no breaking change.

---

Related to #37, #236, #428, #529 and #627
