### PR TITLE
PHP-CS-Fixer is unneeded and will just conflict with StyleCI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "symfony/translation": "~2.6|~3.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~1.11",
         "phpunit/phpunit": "~4.0|~5.0"
     },
     "autoload": {
@@ -44,8 +43,6 @@
         }
     },
     "scripts": {
-        "test": "./vendor/bin/phpunit; ./vendor/bin/php-cs-fixer fix -v --diff --dry-run;",
-        "phpunit": "./vendor/bin/phpunit;",
-        "phpcs": "./vendor/bin/php-cs-fixer fix -v --diff --dry-run;"
+        "test": "./vendor/bin/phpunit;"
     }
 }


### PR DESCRIPTION
One of StyleCI's key goals is to eliminate messing about with local cs dev tools.