### PR TITLE
Added a "setUtf8" method for localization

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -171,6 +171,13 @@ class Carbon extends DateTime
     private static $lastErrors;
 
     /**
+     * Is UTF8 needed to print localized date/time ?
+     *
+     * @var bool
+     */
+    protected static $utf8 = false;
+
+    /**
      * Creates a DateTimeZone from a string, DateTimeZone or integer offset.
      *
      * @param \DateTimeZone|string|int|null $object
@@ -1122,6 +1129,18 @@ class Carbon extends DateTime
         return false;
     }
 
+    /**
+     * Set if UTF8 will be used for localized date/time
+     *
+     * @param bool $useUtf8
+     *
+     * @return void
+     */
+    public static function useUtf8($useUtf8)
+    {
+        static::$utf8 = $useUtf8;
+    }
+
     ///////////////////////////////////////////////////////////////////
     /////////////////////// STRING FORMATTING /////////////////////////
     ///////////////////////////////////////////////////////////////////
@@ -1142,7 +1161,13 @@ class Carbon extends DateTime
             $format = preg_replace('#(?<!%)((?:%%)*)%e#', '\1%#d', $format);
         }
 
-        return utf8_encode(strftime($format, strtotime($this)));
+        $formatted = strftime($format, strtotime($this));
+
+        if (static::$utf8) {
+            return utf8_encode($formatted);
+        }
+
+        return $formatted;
     }
 
     /**

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1142,7 +1142,7 @@ class Carbon extends DateTime
             $format = preg_replace('#(?<!%)((?:%%)*)%e#', '\1%#d', $format);
         }
 
-        return strftime($format, strtotime($this));
+        return utf8_encode(strftime($format, strtotime($this)));
     }
 
     /**

--- a/tests/Carbon/StringsTest.php
+++ b/tests/Carbon/StringsTest.php
@@ -71,6 +71,17 @@ class StringsTest extends AbstractTestCase
          */
     }
 
+    public function testToLocalizedFormattedDateStringWhenUtf8IsNedded()
+    {
+        Carbon::useUtf8(true);
+        $cache = setlocale(LC_TIME, 0);
+        $d = Carbon::create(2016, 01, 06, 00, 00, 00);
+        setlocale(LC_TIME, 'es_ES');
+        $this->assertSame(utf8_encode('miércoles 06 enero 2016'), $d->formatLocalized('%A %d %B %Y'));
+        setlocale(LC_TIME, $cache);
+        Carbon::useUtf8(false);
+    }
+
     public function testToLocalizedFormattedTimezonedDateString()
     {
         $d = Carbon::create(1975, 12, 25, 14, 15, 16, 'Europe/London');


### PR DESCRIPTION
Completes #653 

There is not much other way to "simulate" UTF8 than actually "expecting" an UTF8 encoded string.

Ah, and because of the comments in `StringsTest::testToLocalizedFormattedDateString()`, I think my test will also have the same issue with Travis.
