### PR TITLE
Allow Carbon::setLocale to accept long localization variants

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1138,8 +1138,8 @@ class Carbon extends DateTime
      */
     public static function setLocale($locale)
     {
-        $locale = preg_replace_callback('/([a-z]{2})[-_]([a-z]{2})/', function ($matches) {
-            return $matches[1].'_'.strtoupper($matches[2]);
+        $locale = preg_replace_callback('/\b([a-z]{2})[-_](?:([a-z]{4})[-_])?([a-z]{2})\b/', function ($matches) {
+            return $matches[1].'_'.(!empty($matches[2]) ? ucfirst($matches[2]).'_' : '').strtoupper($matches[3]);
         }, strtolower($locale));
 
         if (file_exists($filename = __DIR__.'/Lang/'.$locale.'.php')) {


### PR DESCRIPTION
As discussed in #819 there are language variants that allow script type to be passed in the format `ll-Ssss-RR` (`l` being language code, `s` being script used, `r` being the region).

According to http://symbolcodes.tlt.psu.edu/bylanguage/serbocroatian.html website, there are three variants for Montenegrin locale:
- `sr-ME` (Montenegrin, script unspecified)
- `sr-Cyrl-ME` (Montenegrin in Cyrillic)
- `sr-Latn-ME` (Montenegrin in Latin Script)

This reflects the situation in real life, as both scripts (Latin and Cyrillic) are equally used in Montenegrin, Serbian, Croatian and Bosnian languages - as far as I know.

This is a non-breaking change. 