### PR TITLE
Use type hinting for DateTimeInterface

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -16,6 +16,7 @@ use Closure;
 use DatePeriod;
 use DateTime;
 use DateTimeZone;
+use DateTimeInterface;
 use InvalidArgumentException;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Translator;
@@ -298,7 +299,7 @@ class Carbon extends DateTime
      *
      * @return static
      */
-    public static function instance(DateTime $dt)
+    public static function instance(DateTimeInterface $dt)
     {
         if ($dt instanceof static) {
             return clone $dt;


### PR DESCRIPTION
Use DateTimeInterface so that both DateTime and DateTimeImmutable can be used in the `instance()` method.