### PR TITLE
Add new isNext- / isLast- methods

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1693,6 +1693,66 @@ class Carbon extends DateTime
     }
 
     /**
+     * Determines if the instance is within the next week
+     *
+     * @return bool
+     */
+    public function isNextWeek()
+    {
+        return $this->weekOfYear === static::now($this->getTimezone())->addWeek()->weekOfYear;
+    }
+
+    /**
+     * Determines if the instance is within the last week
+     *
+     * @return bool
+     */
+    public function isLastWeek()
+    {
+        return $this->weekOfYear === static::now($this->getTimezone())->subWeek()->weekOfYear;
+    }
+
+    /**
+     * Determines if the instance is within the next month
+     *
+     * @return bool
+     */
+    public function isNextMonth()
+    {
+        return $this->month === static::now($this->getTimezone())->addMonth()->month;
+    }
+
+    /**
+     * Determines if the instance is within the last month
+     *
+     * @return bool
+     */
+    public function isLastMonth()
+    {
+        return $this->month === static::now($this->getTimezone())->subMonth()->month;
+    }
+
+    /**
+     * Determines if the instance is within next year
+     *
+     * @return bool
+     */
+    public function isNextYear()
+    {
+        return $this->year === static::now($this->getTimezone())->addYear()->year;
+    }
+
+    /**
+     * Determines if the instance is within the previous year
+     *
+     * @return bool
+     */
+    public function isLastYear()
+    {
+        return $this->year === static::now($this->getTimezone())->subYear()->year;
+    }
+
+    /**
      * Determines if the instance is in the future, ie. greater (after) than now
      *
      * @return bool

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1719,7 +1719,7 @@ class Carbon extends DateTime
      */
     public function isNextMonth()
     {
-        return $this->month === static::now($this->getTimezone())->addMonth()->month;
+        return $this->month === static::now($this->getTimezone())->addMonthNoOverflow()->month;
     }
 
     /**
@@ -1729,7 +1729,7 @@ class Carbon extends DateTime
      */
     public function isLastMonth()
     {
-        return $this->month === static::now($this->getTimezone())->subMonth()->month;
+        return $this->month === static::now($this->getTimezone())->subMonthNoOverflow()->month;
     }
 
     /**

--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -56,6 +56,66 @@ class IsTest extends AbstractTestCase
         $this->assertTrue(Carbon::now()->isToday());
     }
 
+    public function testIsNextWeekTrue()
+    {
+        $this->assertTrue(Carbon::now()->addWeek()->isNextWeek());
+    }
+
+    public function testIsLastWeekTrue()
+    {
+        $this->assertTrue(Carbon::now()->subWeek()->isLastWeek());
+    }
+
+    public function testIsNextWeekFalse()
+    {
+        $this->assertFalse(Carbon::now()->addWeek(2)->isNextWeek());
+    }
+
+    public function testIsLastWeekFalse()
+    {
+        $this->assertFalse(Carbon::now()->subWeek(2)->isLastWeek());
+    }
+
+    public function testIsNextMonthTrue()
+    {
+        $this->assertTrue(Carbon::now()->addMonth()->isNextMonth());
+    }
+
+    public function testIsLastMonthTrue()
+    {
+        $this->assertTrue(Carbon::now()->subMonth()->isLastMonth());
+    }
+
+    public function testIsNextMonthFalse()
+    {
+        $this->assertFalse(Carbon::now()->addMonth(2)->isNextMonth());
+    }
+
+    public function testIsLastMonthFalse()
+    {
+        $this->assertFalse(Carbon::now()->subMonth(2)->isLastMonth());
+    }
+
+    public function testIsNextYearTrue()
+    {
+        $this->assertTrue(Carbon::now()->addYear()->isNextYear());
+    }
+
+    public function testIsLastYearTrue()
+    {
+        $this->assertTrue(Carbon::now()->subYear()->isLastYear());
+    }
+
+    public function testIsNextYearFalse()
+    {
+        $this->assertFalse(Carbon::now()->addYear(2)->isNextYear());
+    }
+
+    public function testIsLastYearFalse()
+    {
+        $this->assertFalse(Carbon::now()->subYear(2)->isLastYear());
+    }
+
     public function testIsTodayFalseWithYesterday()
     {
         $this->assertFalse(Carbon::now()->subDay()->endOfDay()->isToday());


### PR DESCRIPTION
Added the new methods `isNextWeek, isLastWeek, isNextMonth, isLastMonth, isNextYear, isLastYear`

Use case was to has a quick method when sorting data into last, current and next week segments, so seemed sensible to have it for month and year also.

---


Closes https://github.com/briannesbitt/Carbon/pull/752