### PR TITLE
Always Carbon::setTestNow

### DIFF
--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -18,6 +18,14 @@ use PHPUnit_Framework_TestCase;
 
 abstract class AbstractTestCase extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @var \Carbon\Carbon
+     */
+    protected $now;
+
+    /**
+     * @var string
+     */
     private $saveTz;
 
     protected function setUp()
@@ -26,6 +34,8 @@ abstract class AbstractTestCase extends PHPUnit_Framework_TestCase
         $this->saveTz = date_default_timezone_get();
 
         date_default_timezone_set('America/Toronto');
+
+        Carbon::setTestNow($this->now = Carbon::now());
     }
 
     protected function tearDown()

--- a/tests/Carbon/ConstructTest.php
+++ b/tests/Carbon/ConstructTest.php
@@ -38,12 +38,14 @@ class ConstructTest extends AbstractTestCase
 
     public function testWithFancyString()
     {
+        Carbon::setTestNow(Carbon::today());
         $c = new Carbon('first day of January 2008');
         $this->assertCarbon($c, 2008, 1, 1, 0, 0, 0);
     }
 
     public function testParseWithFancyString()
     {
+        Carbon::setTestNow(Carbon::today());
         $c = Carbon::parse('first day of January 2008');
         $this->assertCarbon($c, 2008, 1, 1, 0, 0, 0);
     }

--- a/tests/Carbon/CreateTest.php
+++ b/tests/Carbon/CreateTest.php
@@ -25,9 +25,8 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateWithDefaults()
     {
-        Carbon::setTestNow($now = Carbon::now());
         $d = Carbon::create();
-        $this->assertSame($d->getTimestamp(), $now->getTimestamp());
+        $this->assertSame($d->getTimestamp(), Carbon::now()->getTimestamp());
     }
 
     public function testCreateWithYear()

--- a/tests/Carbon/SettersTest.php
+++ b/tests/Carbon/SettersTest.php
@@ -291,7 +291,6 @@ class SettersTest extends AbstractTestCase
         Carbon::setTestNow(Carbon::create(2016, 2, 12, 1, 2, 3));
         $d = Carbon::now()->setTimeFromTimeString($time);
         $this->assertCarbon($d, 2016, 2, 12, $hour, $minute, $second);
-        Carbon::setTestNow();
     }
 
     public function dataProviderTestSetTimeFromTimeString()

--- a/tests/Carbon/TestingAidsTest.php
+++ b/tests/Carbon/TestingAidsTest.php
@@ -26,11 +26,10 @@ class TestingAidsTest extends AbstractTestCase
 
     public function testTestingAidsWithTestNowSet()
     {
-        $testNow = Carbon::yesterday();
-        Carbon::setTestNow($testNow);
+        Carbon::setTestNow($yesterday = Carbon::yesterday());
 
         $this->assertTrue(Carbon::hasTestNow());
-        $this->assertSame($testNow, Carbon::getTestNow());
+        $this->assertSame($yesterday, Carbon::getTestNow());
     }
 
     public function testTestingAidsWithTestNowSetToString()
@@ -42,21 +41,19 @@ class TestingAidsTest extends AbstractTestCase
 
     public function testConstructorWithTestValueSet()
     {
-        $testNow = Carbon::yesterday();
-        Carbon::setTestNow($testNow);
+        Carbon::setTestNow($yesterday = Carbon::yesterday());
 
-        $this->assertEquals($testNow, new Carbon());
-        $this->assertEquals($testNow, new Carbon(null));
-        $this->assertEquals($testNow, new Carbon(''));
-        $this->assertEquals($testNow, new Carbon('now'));
+        $this->assertEquals($yesterday, new Carbon());
+        $this->assertEquals($yesterday, new Carbon(null));
+        $this->assertEquals($yesterday, new Carbon(''));
+        $this->assertEquals($yesterday, new Carbon('now'));
     }
 
     public function testNowWithTestValueSet()
     {
-        $testNow = Carbon::yesterday();
-        Carbon::setTestNow($testNow);
+        Carbon::setTestNow($yesterday = Carbon::yesterday());
 
-        $this->assertEquals($testNow, Carbon::now());
+        $this->assertEquals($yesterday, Carbon::now());
     }
 
     public function testParseWithTestValueSet()


### PR DESCRIPTION
Always Carbon::setTestNow

---

This allows to avoid errors on timestamp comparisons when TravisCI tests are a bit slow