### PR TITLE
Fix issue #885

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=auto
+* text=auto eol=lf
 
 .codecov.yml export-ignore
 .editorconfig export-ignore


### PR DESCRIPTION
> I have a Windows 7. When i run php-cs-fixer all files marked "changed" because theirs EOL was changed from CRLF to LF.

> But why they have CRLF initially?
> It is because `* text=auto` in `.gitattributes`. It means that all files that considered as text will have system-related EOL in working directory. On windows it is CRLF.

> But php-cs-fixer dont bother what is the current system - it always make EOL = LF.