### PR TITLE
[docs] No approximation is used anymore.

### DIFF
--- a/docs/index.src.html
+++ b/docs/index.src.html
@@ -595,7 +595,7 @@ $littleHandRotations = $dt->diffFiltered(CarbonInterval::minute(), function(Carb
 
 <h1 id="api-humandiff">Difference for Humans</h1>
 
-<p>It is easier for humans to read <code>1 month ago</code> compared to 30 days ago.  This is a common function seen in most date libraries so I thought I would add it here as well.  It uses approximations for a month being 4 weeks. The lone argument for the function is the other Carbon instance to diff against, and of course it defaults to <code>now()</code> if not specified.</p>
+<p>It is easier for humans to read <code>1 month ago</code> compared to 30 days ago.  This is a common function seen in most date libraries so I thought I would add it here as well. The lone argument for the function is the other Carbon instance to diff against, and of course it defaults to <code>now()</code> if not specified.</p>
 
 <p>This method will add a phrase after the difference value relative to the instance and the passed in instance.  There are 4 possibilities:</p>
 


### PR DESCRIPTION
I removed a statement in the docs about approximation in `diffForHumans()` that does not hold anymore.