### PR TITLE
Fixed issue #891 - getLastErrors

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -289,6 +289,7 @@ class Carbon extends DateTime
         }
 
         parent::__construct($time, static::safeCreateDateTimeZone($tz));
+        static::setLastErrors(parent::getLastErrors());
     }
 
     /**
@@ -573,10 +574,13 @@ class Carbon extends DateTime
             $dt = parent::createFromFormat($format, $time);
         }
 
-        static::setLastErrors($lastErrors = parent::getLastErrors());
+        $lastErrors = parent::getLastErrors();
 
         if ($dt instanceof DateTime) {
-            return static::instance($dt);
+            $instance = static::instance($dt);
+            $instance::setLastErrors($lastErrors);
+
+            return $instance;
         }
 
         throw new InvalidArgumentException(implode(PHP_EOL, $lastErrors['errors']));

--- a/tests/Carbon/LastErrorTest.php
+++ b/tests/Carbon/LastErrorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Carbon;
+
+use Carbon\Carbon;
+use DateTime;
+use Tests\AbstractTestCase;
+
+class LastErrorTest extends AbstractTestCase
+{
+    /**
+     * @var array
+     */
+    protected $lastErrors;
+
+    /**
+     * @var array
+     */
+    protected $noErrors;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->noErrors = array(
+            'warning_count' => 0,
+            'warnings' => array(),
+            'error_count' => 0,
+            'errors' => array(),
+        );
+
+        $this->lastErrors = array(
+            'warning_count' => 1,
+            'warnings' => array('11' => 'The parsed date was invalid'),
+            'error_count' => 0,
+            'errors' => array(),
+        );
+    }
+
+    public function testCreateHandlesLastErrors()
+    {
+        $carbon = new Carbon('2017-02-30');
+        $datetime = new DateTime('2017-02-30');
+
+        $this->assertSame($this->lastErrors, $carbon->getLastErrors());
+        $this->assertSame($carbon->getLastErrors(), $datetime->getLastErrors());
+
+        $carbon = new Carbon('2017-02-15');
+        $datetime = new DateTime('2017-02-15');
+
+        $this->assertSame($this->noErrors, $carbon->getLastErrors());
+        $this->assertSame($carbon->getLastErrors(), $datetime->getLastErrors());
+    }
+
+    public function testCreateLastErrors()
+    {
+        $carbon = new Carbon('2017-02-30');
+        $this->assertSame($this->lastErrors, $carbon->getLastErrors());
+
+        $carbon = new Carbon('2017-02-15');
+        $this->assertSame($this->noErrors, $carbon->getLastErrors());
+    }
+}


### PR DESCRIPTION
getLastErrors returnes null when create Carbon with __constructor