### PR TITLE
Adding support for not overflowing months when adding a year

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -2080,7 +2080,7 @@ class Carbon extends DateTime
      */
     public function subYearsNoOverflow($value)
     {
-        return $this->addMonthsNoOverflow(-1 * $value);
+        return $this->subMonthsNoOverflow($value * static::MONTHS_PER_YEAR);
     }
 
     /**
@@ -2104,7 +2104,7 @@ class Carbon extends DateTime
      */
     public function subYearsWithOverflow($value)
     {
-        return $this->addYears(-1 * $value);
+        return $this->subMonthsWithOverflow($value * static::MONTHS_PER_YEAR);
     }
 
     /**

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1968,11 +1968,7 @@ class Carbon extends DateTime
      */
     public function addYears($value)
     {
-        if (static::shouldOverflowMonths()) {
-            return $this->modify((int) $value.' year');
-        }
-
-        return $this->addMonthsNoOverflow($value * 12);
+        return $this->modify((int) $value.' year');
     }
 
     /**
@@ -1985,6 +1981,58 @@ class Carbon extends DateTime
     public function addYear($value = 1)
     {
         return $this->addYears($value);
+    }
+
+    /**
+     * Add years to the instance with no overflow of months
+     * Positive $value travel forward while
+     * negative $value travel into the past.
+     *
+     * @param int $value
+     *
+     * @return static
+     */
+    public function addYearsNoOverflow($value)
+    {
+        return $this->addMonthsNoOverflow($value * static::MONTHS_PER_YEAR);
+    }
+
+    /**
+     * Add year with overflow months set to false
+     *
+     * @param $value
+     *
+     * @return static
+     */
+    public function addYearNoOverflow($value = 1)
+    {
+        return $this->addYearsNoOverflow($value);
+    }
+
+    /**
+     * Add years to the instance.
+     * Positive $value travel forward while
+     * negative $value travel into the past.
+     *
+     * @param int $value
+     *
+     * @return static
+     */
+    public function addYearsWithOverflow($value)
+    {
+        return $this->addYears($value);
+    }
+
+    /**
+     * Add year with overflow.
+     *
+     * @param $value
+     *
+     * @return static
+     */
+    public function addYearWithOverflow($value = 1)
+    {
+        return $this->addYearsWithOverflow($value);
     }
 
     /**
@@ -2007,6 +2055,54 @@ class Carbon extends DateTime
      * @return static
      */
     public function subYears($value)
+    {
+        return $this->addYears(-1 * $value);
+    }
+
+    /**
+     * Remove year from the instance with no month overflow
+     *
+     * @param int $value
+     *
+     * @return static
+     */
+    public function subYearNoOverflow($value = 1)
+    {
+        return $this->subYearsNoOverflow($value);
+    }
+
+    /**
+     * Remove years from the instance with no month overflow.
+     *
+     * @param int $value
+     *
+     * @return static
+     */
+    public function subYearsNoOverflow($value)
+    {
+        return $this->addMonthsNoOverflow(-1 * $value);
+    }
+
+    /**
+     * Remove year from the instance.
+     *
+     * @param int $value
+     *
+     * @return static
+     */
+    public function subYearWithOverflow($value = 1)
+    {
+        return $this->subYearsWithOverflow($value);
+    }
+
+    /**
+     * Remove years from the instance.
+     *
+     * @param int $value
+     *
+     * @return static
+     */
+    public function subYearsWithOverflow($value)
     {
         return $this->addYears(-1 * $value);
     }

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1968,7 +1968,11 @@ class Carbon extends DateTime
      */
     public function addYears($value)
     {
-        return $this->modify((int) $value.' year');
+        if (static::shouldOverflowMonths()) {
+            return $this->modify((int) $value.' year');
+        }
+
+        return $this->addMonthsNoOverflow($value * 12);
     }
 
     /**

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -2000,7 +2000,7 @@ class Carbon extends DateTime
     /**
      * Add year with overflow months set to false
      *
-     * @param $value
+     * @param int $value
      *
      * @return static
      */
@@ -2026,7 +2026,7 @@ class Carbon extends DateTime
     /**
      * Add year with overflow.
      *
-     * @param $value
+     * @param int $value
      *
      * @return static
      */

--- a/tests/Carbon/AddTest.php
+++ b/tests/Carbon/AddTest.php
@@ -265,4 +265,68 @@ class AddTest extends AbstractTestCase
         $this->assertSame(2075, Carbon::createFromDate(1975)->subCenturies(-1)->year);
         $this->assertSame(2175, Carbon::createFromDate(1975)->subCenturies(-2)->year);
     }
+
+    public function testAddYearNoOverflow()
+    {
+        $date = Carbon::createFromDate(2016, 2, 29)->addYearNoOverflow();
+        $this->assertSame(28, $date->day);
+        $this->assertSame(2, $date->month);
+        $this->assertSame(2017, $date->year);
+    }
+
+    public function testAddYearWithOverflow()
+    {
+        $date = Carbon::createFromDate(2016, 2, 29)->addYearWithOverflow();
+        $this->assertSame(1, $date->day);
+        $this->assertSame(3, $date->month);
+        $this->assertSame(2017, $date->year);
+    }
+
+    public function testAddYearNoOverflowPassingArg()
+    {
+        $date = Carbon::createFromDate(2016, 2, 29)->addYearsNoOverflow(2);
+        $this->assertSame(28, $date->day);
+        $this->assertSame(2, $date->month);
+        $this->assertSame(2018, $date->year);
+    }
+
+    public function testAddYearWithOverflowPassingArg()
+    {
+        $date = Carbon::createFromDate(2016, 2, 29)->addYearsWithOverflow(2);
+        $this->assertSame(1, $date->day);
+        $this->assertSame(3, $date->month);
+        $this->assertSame(2018, $date->year);
+    }
+
+    public function testSubYearNoOverflowPassingArg()
+    {
+        $date = Carbon::createFromDate(2016, 2, 29)->subYearsNoOverflow(2);
+        $this->assertSame(28, $date->day);
+        $this->assertSame(2, $date->month);
+        $this->assertSame(2014, $date->year);
+    }
+
+    public function testSubYearWithOverflowPassingArg()
+    {
+        $date = Carbon::createFromDate(2016, 2, 29)->subYearsWithOverflow(2);
+        $this->assertSame(1, $date->day);
+        $this->assertSame(3, $date->month);
+        $this->assertSame(2014, $date->year);
+    }
+
+    public function testSubYearNoOverflow()
+    {
+        $date = Carbon::createFromDate(2016, 2, 29)->subYearNoOverflow();
+        $this->assertSame(28, $date->day);
+        $this->assertSame(2, $date->month);
+        $this->assertSame(2015, $date->year);
+    }
+
+    public function testSubYearWithOverflow()
+    {
+        $date = Carbon::createFromDate(2016, 2, 29)->subYearWithOverflow();
+        $this->assertSame(1, $date->day);
+        $this->assertSame(3, $date->month);
+        $this->assertSame(2015, $date->year);
+    }
 }

--- a/tests/Carbon/AddTest.php
+++ b/tests/Carbon/AddTest.php
@@ -268,65 +268,41 @@ class AddTest extends AbstractTestCase
 
     public function testAddYearNoOverflow()
     {
-        $date = Carbon::createFromDate(2016, 2, 29)->addYearNoOverflow();
-        $this->assertSame(28, $date->day);
-        $this->assertSame(2, $date->month);
-        $this->assertSame(2017, $date->year);
+        $this->assertCarbon(Carbon::createFromDate(2016, 2, 29)->addYearNoOverflow(), 2017, 2, 28);
     }
 
     public function testAddYearWithOverflow()
     {
-        $date = Carbon::createFromDate(2016, 2, 29)->addYearWithOverflow();
-        $this->assertSame(1, $date->day);
-        $this->assertSame(3, $date->month);
-        $this->assertSame(2017, $date->year);
+        $this->assertCarbon(Carbon::createFromDate(2016, 2, 29)->addYearWithOverflow(), 2017, 3, 1);
     }
 
     public function testAddYearNoOverflowPassingArg()
     {
-        $date = Carbon::createFromDate(2016, 2, 29)->addYearsNoOverflow(2);
-        $this->assertSame(28, $date->day);
-        $this->assertSame(2, $date->month);
-        $this->assertSame(2018, $date->year);
+        $this->assertCarbon(Carbon::createFromDate(2016, 2, 29)->addYearsNoOverflow(2), 2018, 2, 28);
     }
 
     public function testAddYearWithOverflowPassingArg()
     {
-        $date = Carbon::createFromDate(2016, 2, 29)->addYearsWithOverflow(2);
-        $this->assertSame(1, $date->day);
-        $this->assertSame(3, $date->month);
-        $this->assertSame(2018, $date->year);
+        $this->assertCarbon(Carbon::createFromDate(2016, 2, 29)->addYearsWithOverflow(2), 2018, 3, 1);
     }
 
     public function testSubYearNoOverflowPassingArg()
     {
-        $date = Carbon::createFromDate(2016, 2, 29)->subYearsNoOverflow(2);
-        $this->assertSame(28, $date->day);
-        $this->assertSame(2, $date->month);
-        $this->assertSame(2014, $date->year);
+        $this->assertCarbon(Carbon::createFromDate(2016, 2, 29)->subYearsNoOverflow(2), 2014, 2, 28);
     }
 
     public function testSubYearWithOverflowPassingArg()
     {
-        $date = Carbon::createFromDate(2016, 2, 29)->subYearsWithOverflow(2);
-        $this->assertSame(1, $date->day);
-        $this->assertSame(3, $date->month);
-        $this->assertSame(2014, $date->year);
+        $this->assertCarbon(Carbon::createFromDate(2016, 2, 29)->subYearsWithOverflow(2), 2014, 3, 1);
     }
 
     public function testSubYearNoOverflow()
     {
-        $date = Carbon::createFromDate(2016, 2, 29)->subYearNoOverflow();
-        $this->assertSame(28, $date->day);
-        $this->assertSame(2, $date->month);
-        $this->assertSame(2015, $date->year);
+        $this->assertCarbon(Carbon::createFromDate(2016, 2, 29)->subYearNoOverflow(), 2015, 2, 28);
     }
 
     public function testSubYearWithOverflow()
     {
-        $date = Carbon::createFromDate(2016, 2, 29)->subYearWithOverflow();
-        $this->assertSame(1, $date->day);
-        $this->assertSame(3, $date->month);
-        $this->assertSame(2015, $date->year);
+        $this->assertCarbon(Carbon::createFromDate(2016, 2, 29)->subYearWithOverflow(), 2015, 3, 1);
     }
 }


### PR DESCRIPTION
This adds the ability to set carbon to not overflow months when adding a year. For example, see the following:
```
Carbon\Carbon::parse('2016-02-29')->addYear()->toDateString(); // 2017-03-01
```
However, you can set the option to tell carbon to not overflow months like:
```
Carbon\Carbon::useMonthsOverflow(false);
```
This means:
```
Carbon\Carbon::parse('2016-01-31')->addMonth()->toDateString(); // 2016-02-28
```
This PR adds similar functionality so that:
```
Carbon\Carbon::parse('2016-02-29')->addYear()->toDateString(); // 2017-02-28
```