### PR TITLE
Corrects improper handling of daylight savings time

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -3323,7 +3323,6 @@ class Carbon extends DateTime
      */
     public function modify($modify)
     {
-
         $timezone = $this->getTimezone();
         $this->setTimezone('UTC');
         $instance = parent::modify($modify);

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -688,9 +688,6 @@ class Carbon extends DateTime
             case $name === 'dst':
                 return $this->format('I') === '1';
 
-            case $name === 'local':
-                return $this->getOffset() === $this->copy()->setTimezone(date_default_timezone_get())->getOffset();
-
             case $name === 'utc':
                 return $this->getOffset() === 0;
 
@@ -3326,9 +3323,6 @@ class Carbon extends DateTime
      */
     public function modify($modify)
     {
-        if ($this->local) {
-            return parent::modify($modify);
-        }
 
         $timezone = $this->getTimezone();
         $this->setTimezone('UTC');


### PR DESCRIPTION
Corrects this error, which revealed a mishandling of daylight savings time:
```>>> use Carbon\Carbon
=> null
>>> $time = Carbon::now();
=> Carbon\Carbon {#1201
     +"date": "2017-03-10 13:34:52.000000",
     +"timezone_type": 3,
     +"timezone": "America/New_York",
   }
>>> $time->addHours(47);
=> Carbon\Carbon {#1201
     +"date": "2017-03-12 12:34:52.000000",
     +"timezone_type": 3,
     +"timezone": "America/New_York",
   }```