### PR TITLE
Add compare method to CarbonInterval

### DIFF
--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -558,4 +558,26 @@ class CarbonInterval extends DateInterval
 
         return $specString === static::PERIOD_PREFIX ? 'PT0S' : $specString;
     }
+
+    /**
+     * Comparing with passed interval
+     *
+     * @param DateInterval $interval
+     *
+     * @return int
+     */
+    public function compare(DateInterval $interval)
+    {
+        $current = Carbon::now();
+        $passed = $current->copy()->add($interval);
+        $current->add($this);
+
+        if ($current < $passed) {
+            return -1;
+        } elseif ($current > $passed) {
+            return 1;
+        }
+
+        return 0;
+    }
 }

--- a/tests/CarbonInterval/CompareTest.php
+++ b/tests/CarbonInterval/CompareTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonInterval;
+
+use Carbon\CarbonInterval;
+use Tests\AbstractTestCase;
+
+class CompareTest extends AbstractTestCase
+{
+    public function testNegative()
+    {
+        $first = CarbonInterval::minute();
+        $second = CarbonInterval::minutes(2);
+        $result = $first->compare($second);
+        $this->assertEquals(-1, $result);
+    }
+
+    public function testPositive()
+    {
+        $first = CarbonInterval::day();
+        $second = CarbonInterval::hour();
+        $result = $first->compare($second);
+        $this->assertEquals(1, $result);
+    }
+
+    public function testEqual()
+    {
+        $first = CarbonInterval::year();
+        $second = CarbonInterval::year();
+        $result = $first->compare($second);
+        $this->assertEquals(0, $result);
+    }
+}


### PR DESCRIPTION
Adds simple compare method to compare current interval with another (because php does now have build-in functions for it, like for DateTime)