### PR TITLE
Added toHttpDateString()

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1392,6 +1392,16 @@ class Carbon extends DateTime
         return $this->format(static::W3C);
     }
 
+    /**
+     * Format the instance as HTTP Date (IMF-fixdate)
+     *
+     * @return string
+     */
+    public function toHttpDateString()
+    {
+        return $this->copy()->tz('GMT')->format('D, d M Y H:m:s T');
+    }
+    
     ///////////////////////////////////////////////////////////////////
     ////////////////////////// COMPARISONS ////////////////////////////
     ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Added function to get a Carbon instance as a HTTP Date formatted string, as used in HTTP Headers such as `Expires`.

The HTTP Date is the colloquial name for IMF-fixdate, as defined in [RFC 7321](https://tools.ietf.org/html/rfc7231#section-7.1.1.1). It is similar to existing Carbon handy output formats, such as `toRssString()` except that the format must always be in the GMT timezone (see [MDN description of the format](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date)) rather than an offset.

The copy is made so that there is no change to the original `Carbon` instance.