### PR TITLE
Fix typo in uk language

### DIFF
--- a/src/Carbon/Lang/uk.php
+++ b/src/Carbon/Lang/uk.php
@@ -24,7 +24,7 @@ return array(
     'min' => ':count хвилину|:count хвилини|:count хвилин',
     'second' => ':count секунду|:count секунди|:count секунд',
     's' => ':count секунду|:count секунди|:count секунд',
-    'ago' => ':time назад',
+    'ago' => ':time тому',
     'from_now' => 'через :time',
     'after' => ':time після',
     'before' => ':time до',

--- a/tests/Localization/UkTest.php
+++ b/tests/Localization/UkTest.php
@@ -23,46 +23,46 @@ class UkTest extends AbstractTestCase
         $scope = $this;
         $this->wrapWithNonDstDate(function () use ($scope) {
             $d = Carbon::now()->subSecond();
-            $scope->assertSame('1 секунду назад', $d->diffForHumans(null, false, true));
+            $scope->assertSame('1 секунду тому', $d->diffForHumans(null, false, true));
 
             $d = Carbon::now()->subSeconds(2);
-            $scope->assertSame('2 секунди назад', $d->diffForHumans(null, false, true));
+            $scope->assertSame('2 секунди тому', $d->diffForHumans(null, false, true));
 
             $d = Carbon::now()->subMinute();
-            $scope->assertSame('1 хвилину назад', $d->diffForHumans(null, false, true));
+            $scope->assertSame('1 хвилину тому', $d->diffForHumans(null, false, true));
 
             $d = Carbon::now()->subMinutes(2);
-            $scope->assertSame('2 хвилини назад', $d->diffForHumans(null, false, true));
+            $scope->assertSame('2 хвилини тому', $d->diffForHumans(null, false, true));
 
             $d = Carbon::now()->subHour();
-            $scope->assertSame('1 година назад', $d->diffForHumans(null, false, true));
+            $scope->assertSame('1 година тому', $d->diffForHumans(null, false, true));
 
             $d = Carbon::now()->subHours(2);
-            $scope->assertSame('2 години назад', $d->diffForHumans(null, false, true));
+            $scope->assertSame('2 години тому', $d->diffForHumans(null, false, true));
 
             $d = Carbon::now()->subDay();
-            $scope->assertSame('1 день назад', $d->diffForHumans(null, false, true));
+            $scope->assertSame('1 день тому', $d->diffForHumans(null, false, true));
 
             $d = Carbon::now()->subDays(2);
-            $scope->assertSame('2 дні назад', $d->diffForHumans(null, false, true));
+            $scope->assertSame('2 дні тому', $d->diffForHumans(null, false, true));
 
             $d = Carbon::now()->subWeek();
-            $scope->assertSame('1 тиждень назад', $d->diffForHumans(null, false, true));
+            $scope->assertSame('1 тиждень тому', $d->diffForHumans(null, false, true));
 
             $d = Carbon::now()->subWeeks(2);
-            $scope->assertSame('2 тижні назад', $d->diffForHumans(null, false, true));
+            $scope->assertSame('2 тижні тому', $d->diffForHumans(null, false, true));
 
             $d = Carbon::now()->subMonth();
-            $scope->assertSame('1 місяць назад', $d->diffForHumans(null, false, true));
+            $scope->assertSame('1 місяць тому', $d->diffForHumans(null, false, true));
 
             $d = Carbon::now()->subMonths(2);
-            $scope->assertSame('2 місяці назад', $d->diffForHumans(null, false, true));
+            $scope->assertSame('2 місяці тому', $d->diffForHumans(null, false, true));
 
             $d = Carbon::now()->subYear();
-            $scope->assertSame('1 рік назад', $d->diffForHumans(null, false, true));
+            $scope->assertSame('1 рік тому', $d->diffForHumans(null, false, true));
 
             $d = Carbon::now()->subYears(2);
-            $scope->assertSame('2 роки назад', $d->diffForHumans(null, false, true));
+            $scope->assertSame('2 роки тому', $d->diffForHumans(null, false, true));
 
             $d = Carbon::now()->addSecond();
             $scope->assertSame('через 1 секунду', $d->diffForHumans(null, false, true));


### PR DESCRIPTION
In Ukrainian 'ago' is 'тому', not 'назад'