### PR TITLE
Add __set_state() method, fixes issue with Laravel's config cache

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -3367,4 +3367,16 @@ class Carbon extends DateTime
 
         return $instance;
     }
+
+    /**
+     * The __set_state handler.
+     *
+     * @param array $array
+     *
+     * @return static
+     */
+    public static function __set_state($array)
+    {
+        return static::instance(parent::__set_state($array));
+    }
 }

--- a/tests/Carbon/InstanceTest.php
+++ b/tests/Carbon/InstanceTest.php
@@ -65,6 +65,6 @@ class InstanceTest extends AbstractTestCase
             'timezone_type' => 3,
             'timezone' => 'UTC',
         ));
-        $this->assertInstanceOf(Carbon::class, $carbon);
+        $this->assertInstanceOf('Carbon\Carbon', $carbon);
     }
 }

--- a/tests/Carbon/InstanceTest.php
+++ b/tests/Carbon/InstanceTest.php
@@ -60,11 +60,11 @@ class InstanceTest extends AbstractTestCase
 
     public function testInstanceStateSetBySetStateMethod()
     {
-        $carbon = Carbon::__set_state([
+        $carbon = Carbon::__set_state(array(
             'date' => '2017-05-18 13:02:15.273420',
             'timezone_type' => 3,
             'timezone' => 'UTC',
-        ]);
+        ));
         $this->assertInstanceOf(Carbon::class, $carbon);
     }
 }

--- a/tests/Carbon/InstanceTest.php
+++ b/tests/Carbon/InstanceTest.php
@@ -57,4 +57,14 @@ class InstanceTest extends AbstractTestCase
         $carbon = Carbon::instance($carbon);
         $this->assertSame($micro, $carbon->micro);
     }
+
+    public function testInstanceStateSetBySetStateMethod()
+    {
+        $carbon = Carbon::__set_state([
+            'date' => '2017-05-18 13:02:15.273420',
+            'timezone_type' => 3,
+            'timezone' => 'UTC',
+        ]);
+        $this->assertInstanceOf(Carbon::class, $carbon);
+    }
 }


### PR DESCRIPTION
Laravel uses __set_state() to set the value of config items when retrieving them from its config cache. Without the method being implemented in Carbon, the DateTime::__set_state() is used and so any Carbon instances defined in the config are converted to DateTime if the cache is used.