### PR TITLE
Added methods startOfHour and startOfMinute

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -2876,6 +2876,26 @@ class Carbon extends DateTime
     ///////////////////////////////////////////////////////////////////
 
     /**
+     * Resets the seconds to 00
+     *
+     * @return static
+     */
+    public function startOfMinute()
+    {
+        return $this->setTime($this->hour, $this->minute, 0);
+    }
+
+    /**
+     * Resets the Minutes and seconds to 00:00
+     *
+     * @return static
+     */
+    public function startOfHour()
+    {
+        return $this->setTime($this->hour, 0, 0);
+    }
+
+    /**
      * Resets the time to 00:00:00
      *
      * @return static


### PR DESCRIPTION
I frequently need those methods (and others probably aswell) so i thought it would be nice to have them in the original carbon. 
Please accept this pull request.