### PR TITLE
Zulu ISO8601 String Helper

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1361,7 +1361,7 @@ class Carbon extends DateTime
      */
     public function toIso8601ZuluString()
     {
-        return $this->setTimezone('UTC')->format('Y-m-d\TH:i:s\Z');
+        return $this->copy()->setTimezone('UTC')->format('Y-m-d\TH:i:s\Z');
     }
 
     /**

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1355,6 +1355,16 @@ class Carbon extends DateTime
     }
 
     /**
+     * Convert the instance to UTC and return as Zulu ISO8601
+     *
+     * @return string
+     */
+    public function toIso8601ZuluString()
+    {
+        return $this->setTimezone('UTC')->format('Y-m-d\TH:i:s\Z');
+    }
+
+    /**
      * Format the instance as RFC850
      *
      * @return string

--- a/tests/Carbon/StringsTest.php
+++ b/tests/Carbon/StringsTest.php
@@ -142,6 +142,12 @@ class StringsTest extends AbstractTestCase
         $this->assertSame('1975-12-25T14:15:16-05:00', $d->toIso8601String());
     }
 
+    public function testToIso8601ZuluString()
+    {
+        $d = Carbon::create(1975, 12, 25, 14, 15, 16);
+        $this->assertSame('1975-12-25T19:15:16Z', $d->toIso8601ZuluString());
+    }
+
     public function testToRC822String()
     {
         $d = Carbon::create(1975, 12, 25, 14, 15, 16);


### PR DESCRIPTION
Many times, I prefer to store my times in ISO8601 Zulu format

>Y-m-d\TH:i:s\Z

Right now, when doing `->toIso8601String()` it returns it in the current timezone.  

This PR adds a `->toIso8601ZuluString()` that will convert the current time instance to UTC and format it in the proper ISO8601 Zulu Formatted String.

A test has been written to check functionality.

reference for Zulu: https://tools.ietf.org/html/rfc3339#section-2
