### PR TITLE
Added createFromTimestampMs method to parse timestamps in milliseconds.

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -626,7 +626,7 @@ class Carbon extends DateTime
     public static function createFromTimestampMs($timestamp, $tz = null)
     {
         return static::createFromFormat('U.u', sprintf('%F', $timestamp / 1000))
-            ->setTimeZone(static::safeCreateDateTimeZone($tz));
+            ->setTimezone(static::safeCreateDateTimeZone($tz));
     }
 
     /**

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -616,6 +616,20 @@ class Carbon extends DateTime
     }
 
     /**
+     * Create a Carbon instance from a timestamp in milliseconds.
+     *
+     * @param int                       $timestamp
+     * @param \DateTimeZone|string|null $tz
+     *
+     * @return static
+     */
+    public static function createFromTimestampMs($timestamp, $tz = null)
+    {
+        return static::createFromFormat('U.u', sprintf('%F', $timestamp / 1000))
+            ->setTimeZone(static::safeCreateDateTimeZone($tz));
+    }
+
+    /**
      * Create a Carbon instance from an UTC timestamp.
      *
      * @param int $timestamp

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -45,7 +45,7 @@ abstract class AbstractTestCase extends PHPUnit_Framework_TestCase
         Carbon::resetMonthsOverflow();
     }
 
-    protected function assertCarbon(Carbon $d, $year, $month, $day, $hour = null, $minute = null, $second = null)
+    protected function assertCarbon(Carbon $d, $year, $month, $day, $hour = null, $minute = null, $second = null, $micro = null)
     {
         $actual = array(
             'years' => $year,
@@ -72,6 +72,11 @@ abstract class AbstractTestCase extends PHPUnit_Framework_TestCase
         if ($second !== null) {
             $expected['seconds'] = $d->second;
             $actual['seconds'] = $second;
+        }
+
+        if ($micro !== null) {
+            $expected['micro'] = $d->micro;
+            $actual['micro'] = $micro;
         }
 
         $this->assertSame($expected, $actual);

--- a/tests/Carbon/CreateFromTimestampTest.php
+++ b/tests/Carbon/CreateFromTimestampTest.php
@@ -23,6 +23,13 @@ class CreateFromTimestampTest extends AbstractTestCase
         $this->assertCarbon($d, 1975, 5, 21, 22, 32, 5);
     }
 
+    public function testCreateFromTimestampMS()
+    {
+        $timestamp = Carbon::create(1975, 5, 21, 22, 32, 5)->timestamp * 1000 + 321;
+        $d = Carbon::createFromTimestampMs($timestamp);
+        $this->assertCarbon($d, 1975, 5, 21, 22, 32, 5, 321000);
+    }
+
     public function testCreateFromTimestampUsesDefaultTimezone()
     {
         $d = Carbon::createFromTimestamp(0);


### PR DESCRIPTION
Here is simple fix for #232.  We're still extremely limited in terms of what PHP allows us to do, unfortunately.  All this does is ensure that the milliseconds will appear in the DateTime object.  I'm not thrilled with the method name, but couldn't think of anything more clever.  Feel free to suggest an alternative.