### PR TITLE
Fix comparison of dates in php >=7.1

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1412,7 +1412,7 @@ class Carbon extends DateTime
      */
     public function eq(self $dt)
     {
-        return $this == $dt;
+        return $this->format('U') === $dt->format('U');
     }
 
     /**

--- a/tests/Carbon/ComparisonTest.php
+++ b/tests/Carbon/ComparisonTest.php
@@ -245,4 +245,20 @@ class ComparisonTest extends AbstractTestCase
         $farthest = $instance->farthest($dt1, $dt2);
         $this->assertSame($dt2, $farthest);
     }
+
+    public function testEqualDatesCreatedViaInstance()
+    {
+        $dt1 = Carbon::instance(new \DateTime());
+        usleep(5);
+        $dt2 = Carbon::instance(new \DateTime());
+        $this->assertTrue($dt1->eq($dt2));
+    }
+
+    public function testEqualDatesCreatedViaNow()
+    {
+        $dt1 = Carbon::now();
+        usleep(5);
+        $dt2 = Carbon::now();
+        $this->assertTrue($dt1->eq($dt2));
+    }
 }


### PR DESCRIPTION
Switch from comparison of instances to comparison of epoch seconds.
Closes #785 