### PR TITLE
Fix issue #883, add/sub seconds/minutes/hours should handle DST correctly

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -2426,6 +2426,7 @@ class Carbon extends DateTime
     public function addHours($value)
     {
         $seconds = $value * self::SECONDS_PER_MINUTE * self::MINUTES_PER_HOUR;
+
         return $this->setTimestamp($this->getTimestamp() + $seconds);
     }
 
@@ -2476,6 +2477,7 @@ class Carbon extends DateTime
     public function addMinutes($value)
     {
         $seconds = $value * self::SECONDS_PER_MINUTE;
+
         return $this->setTimestamp($this->getTimestamp() + $seconds);
     }
 

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -2425,7 +2425,8 @@ class Carbon extends DateTime
      */
     public function addHours($value)
     {
-        return $this->modify((int) $value.' hour');
+        $seconds = $value * self::SECONDS_PER_MINUTE * self::MINUTES_PER_HOUR;
+        return $this->setTimestamp($this->getTimestamp() + $seconds);
     }
 
     /**
@@ -2474,7 +2475,8 @@ class Carbon extends DateTime
      */
     public function addMinutes($value)
     {
-        return $this->modify((int) $value.' minute');
+        $seconds = $value * self::SECONDS_PER_MINUTE;
+        return $this->setTimestamp($this->getTimestamp() + $seconds);
     }
 
     /**
@@ -2523,7 +2525,7 @@ class Carbon extends DateTime
      */
     public function addSeconds($value)
     {
-        return $this->modify((int) $value.' second');
+        return $this->setTimestamp($this->getTimestamp() + $value);
     }
 
     /**

--- a/tests/Carbon/AddTest.php
+++ b/tests/Carbon/AddTest.php
@@ -123,6 +123,16 @@ class AddTest extends AbstractTestCase
         $this->assertSame(23, Carbon::createFromTime(0)->addHours(-1)->hour);
     }
 
+    public function testAddHoursDSTSpring()
+    {
+        $this->assertSame(3, Carbon::create(2014, 3, 30, 0, 0, 0, 'Europe/London')->addHours(2)->hour);
+    }
+
+    public function testAddHoursDSTAutumn()
+    {
+        $this->assertSame(4, Carbon::create(2017, 10, 29, 0, 0, 0, 'Europe/London')->addHours(5)->hour);
+    }
+
     public function testAddHour()
     {
         $this->assertSame(1, Carbon::createFromTime(0)->addHour()->hour);
@@ -143,6 +153,16 @@ class AddTest extends AbstractTestCase
         $this->assertSame(59, Carbon::createFromTime(0, 0)->addMinutes(-1)->minute);
     }
 
+    public function testAddMinutesDSTSpring()
+    {
+        $this->assertSame(3, Carbon::create(2014, 3, 30, 0, 0, 0, 'Europe/London')->addMinutes(2 * 60)->hour);
+    }
+
+    public function testAddMinutesDSTAutumn()
+    {
+        $this->assertSame(4, Carbon::create(2017, 10, 29, 0, 0, 0, 'Europe/London')->addMinutes(5 * 60)->hour);
+    }
+
     public function testAddMinute()
     {
         $this->assertSame(1, Carbon::createFromTime(0, 0)->addMinute()->minute);
@@ -161,6 +181,16 @@ class AddTest extends AbstractTestCase
     public function testAddSecondsNegative()
     {
         $this->assertSame(59, Carbon::createFromTime(0, 0, 0)->addSeconds(-1)->second);
+    }
+
+    public function testAddSecondsDSTSpring()
+    {
+        $this->assertSame(3, Carbon::create(2014, 3, 30, 0, 0, 0, 'Europe/London')->addSeconds(2 * 3600)->hour);
+    }
+
+    public function testAddSecondsDSTAutumn()
+    {
+        $this->assertSame(4, Carbon::create(2017, 10, 29, 0, 0, 0, 'Europe/London')->addSeconds(5 * 3600)->hour);
     }
 
     public function testAddSecond()

--- a/tests/Carbon/SubTest.php
+++ b/tests/Carbon/SubTest.php
@@ -136,6 +136,16 @@ class SubTest extends AbstractTestCase
         $this->assertSame(1, Carbon::createFromTime(0)->subHours(-1)->hour);
     }
 
+    public function testSubHoursDSTSpring()
+    {
+        $this->assertSame(0, Carbon::create(2014, 3, 30, 4, 0, 0, 'Europe/London')->subHours(3)->hour);
+    }
+
+    public function testSubHoursDSTAutumn()
+    {
+        $this->assertSame(0, Carbon::create(2017, 10, 29, 4, 0, 0, 'Europe/London')->subHours(5)->hour);
+    }
+
     public function testSubHour()
     {
         $this->assertSame(23, Carbon::createFromTime(0)->subHour()->hour);
@@ -156,6 +166,16 @@ class SubTest extends AbstractTestCase
         $this->assertSame(1, Carbon::createFromTime(0, 0)->subMinutes(-1)->minute);
     }
 
+    public function testSubMinutesDSTSpring()
+    {
+        $this->assertSame(0, Carbon::create(2014, 3, 30, 4, 0, 0, 'Europe/London')->subMinutes(3 * 60)->hour);
+    }
+
+    public function testSubMinutesDSTAutumn()
+    {
+        $this->assertSame(0, Carbon::create(2017, 10, 29, 4, 0, 0, 'Europe/London')->subMinutes(5 * 60)->hour);
+    }
+
     public function testSubMinute()
     {
         $this->assertSame(59, Carbon::createFromTime(0, 0)->subMinute()->minute);
@@ -174,6 +194,16 @@ class SubTest extends AbstractTestCase
     public function testSubSecondsNegative()
     {
         $this->assertSame(1, Carbon::createFromTime(0, 0, 0)->subSeconds(-1)->second);
+    }
+
+    public function testSubSecondsDSTSpring()
+    {
+        $this->assertSame(0, Carbon::create(2014, 3, 30, 4, 0, 0, 'Europe/London')->subHours(3 * 3600)->hour);
+    }
+
+    public function testSubSecondsDSTAutumn()
+    {
+        $this->assertSame(0, Carbon::create(2017, 10, 29, 4, 0, 0, 'Europe/London')->subHours(5 * 3600)->hour);
     }
 
     public function testSubSecond()

--- a/tests/Carbon/SubTest.php
+++ b/tests/Carbon/SubTest.php
@@ -198,12 +198,12 @@ class SubTest extends AbstractTestCase
 
     public function testSubSecondsDSTSpring()
     {
-        $this->assertSame(0, Carbon::create(2014, 3, 30, 4, 0, 0, 'Europe/London')->subHours(3 * 3600)->hour);
+        $this->assertSame(0, Carbon::create(2014, 3, 30, 4, 0, 0, 'Europe/London')->subSeconds(3 * 3600)->hour);
     }
 
     public function testSubSecondsDSTAutumn()
     {
-        $this->assertSame(0, Carbon::create(2017, 10, 29, 4, 0, 0, 'Europe/London')->subHours(5 * 3600)->hour);
+        $this->assertSame(0, Carbon::create(2017, 10, 29, 4, 0, 0, 'Europe/London')->subSeconds(5 * 3600)->hour);
     }
 
     public function testSubSecond()


### PR DESCRIPTION
I know there already is a pull request on this (https://github.com/Ovsyanka/Carbon/commit/eb6581b3fdddd9e5110539f5f49726127ccb4ebe) but I think my solution may be cleaner. Seems to me that `DateTime::modify` is really bad when it comes to DST, so it is better to do these `addXxx` and `subXxxx` operations with timestamps instead. Since timestamps doesn't have timezone and doesn't care about DST.