### PR TITLE
previous with timezone fix

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -3127,7 +3127,7 @@ class Carbon extends DateTime
             $dayOfWeek = $this->dayOfWeek;
         }
 
-        return $this->startOfDay()->modify('last '.static::$days[$dayOfWeek]);
+        return $this->modify('last '.static::$days[$dayOfWeek])->startOfDay();
     }
 
     /**

--- a/tests/Carbon/DayOfWeekModifiersTest.php
+++ b/tests/Carbon/DayOfWeekModifiersTest.php
@@ -129,6 +129,12 @@ class DayOfWeekModifiersTest extends AbstractTestCase
         $this->assertCarbon($d, 1975, 5, 19, 0, 0, 0);
     }
 
+    public function testPreviousFridayWithTimezone()
+    {
+        $d = Carbon::create(2017, 9, 23, 19, 00, 00, 'Europe/Berlin')->previous(Carbon::FRIDAY);
+        $this->assertCarbon($d, 2017, 9, 22, 0, 0, 0);
+    }
+
     public function testPreviousSaturday()
     {
         $d = Carbon::createFromDate(1975, 5, 21)->previous(6);


### PR DESCRIPTION
When you create a new date with specific timezone and then use `previous()` function it returns the wrong date. 

Switching the `startOfDay()` call solves the problem.

For example `$d = Carbon::create(2017, 9, 23, 19, 00, 00, 'Europe/Berlin')->previous(Carbon::FRIDAY);` should return 2017-09-22 but it returns 2017-09-15. This PR fixes that.