### PR TITLE
Add Syfmony 4.0 constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/translation": "~2.6 || ~3.0"
+        "symfony/translation": "~2.6 || ~3.0 || ~4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2",


### PR DESCRIPTION
Symfony 4 is about to land :tada: :champagne:, and the breaking changes to the Translate component aren't relevant to Carbon … and your wonderful little library is used pretty heavily out there. :heart: 

So here we go :smile: 

Closes: #1049