### PR TITLE
Fix for formatLocalized

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1199,7 +1199,7 @@ class Carbon extends DateTime
             $format = preg_replace('#(?<!%)((?:%%)*)%e#', '\1%#d', $format);
         }
 
-        $formatted = strftime($format, strtotime($this));
+        $formatted = strftime($format, strtotime($this->format(static::DEFAULT_TO_STRING_FORMAT)));
 
         return static::$utf8 ? utf8_encode($formatted) : $formatted;
     }


### PR DESCRIPTION
When you change the default format for the __toString method using setToStringFormat, the formatLocalized will use this format as input for the strtotime function. When you are using a format which is not supported by strtotime (example: d,m,Y), strtotime will return false, resulting in a Carbon object on 1970-01-01.