### PR TITLE
composer: require symfony/translation '~2.6 || ~3.0 || ~4.0'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/translation": "~2.6 || ~3.0"
+        "symfony/translation": "~2.6 || ~3.0 || ~4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2",


### PR DESCRIPTION
Allow symfony/translation 4.0. Tests are passing.
If it gets merged in - could you please release it as a patch? Thank you!