### PR TITLE
Implement hasFormat() method

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -2005,17 +2005,17 @@ class Carbon extends DateTime
     /**
      * Checks if the (date)time string is in a given format.
      *
+     * @param string $date
      * @param string $format
-     * @param string $time
      *
      * @return bool
      */
-    public static function isFormat($format, $time)
+    public static function hasFormat($date, $format)
     {
         try {
             // Try to create a DateTime object. Throws an InvalidArgumentException if the provided time string
             // doesn't match the format in any way.
-            static::createFromFormat($format, $time);
+            static::createFromFormat($format, $date);
 
             // createFromFormat() is known to handle edge cases silently.
             // E.g. "1975-5-1" (Y-n-j) will still be parsed correctly when "Y-m-d" is supplied as the format.
@@ -2025,7 +2025,7 @@ class Carbon extends DateTime
                 static::$regexFormats
             );
 
-            return (bool) preg_match('/^'.$regex.'$/', $time);
+            return (bool) preg_match('/^'.$regex.'$/', $date);
         } catch (InvalidArgumentException $e) {
         }
 

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -150,6 +150,54 @@ class Carbon extends DateTime
     );
 
     /**
+     * Format regex patterns.
+     *
+     * @var array
+     */
+    protected static $regexFormats = array(
+        'd' => '(3[01]|[12][0-9]|0[1-9])',
+        'D' => '([a-zA-Z]{3})',
+        'j' => '([123][0-9]|[1-9])',
+        'l' => '([a-zA-Z]{2,})',
+        'N' => '([1-7])',
+        'S' => '([a-zA-Z]{2})',
+        'w' => '([0-6])',
+        'z' => '(36[0-5]|3[0-5][0-9]|[12][0-9]{2}|[1-9]?[0-9])',
+        'W' => '(5[012]|[1-4][0-9]|[1-9])',
+        'F' => '([a-zA-Z]{2,})',
+        'm' => '(1[012]|0[1-9])',
+        'M' => '([a-zA-Z]{3})',
+        'n' => '(1[012]|[1-9])',
+        't' => '(2[89]|3[01])',
+        'L' => '(0|1)',
+        'o' => '([1-9][0-9]{0,4})',
+        'Y' => '([1-9][0-9]{0,4})',
+        'y' => '([0-9]{2})',
+        'a' => '(am|pm)',
+        'A' => '(AM|PM)',
+        'B' => '([0-9]{3})',
+        'g' => '(1[012]|[1-9])',
+        'G' => '(2[0-3]|1?[0-9])',
+        'h' => '(1[012]|0[1-9])',
+        'H' => '(2[0-3]|[01][0-9])',
+        'i' => '([0-5][0-9])',
+        's' => '([0-5][0-9])',
+        'u' => '([0-9]{1,6})',
+        'v' => '([0-9]{1,3})',
+        'e' => '([a-zA-Z]{1,5})|([a-zA-Z]*\/[a-zA-Z]*)',
+        'I' => '(0|1)',
+        'O' => '([\+\-](1[012]|0[0-9])[0134][05])',
+        'P' => '([\+\-](1[012]|0[0-9]):[0134][05])',
+        'T' => '([a-zA-Z]{1,5})',
+        'Z' => '(-?[1-5]?[0-9]{1,4})',
+        'U' => '([0-9]*)',
+
+        // The formats below are combinations of the above formats.
+        'c' => '(([1-9][0-9]{0,4})\-(1[012]|0[1-9])\-(3[01]|[12][0-9]|0[1-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])[\+\-](1[012]|0[0-9]):([0134][05]))', // Y-m-dTH:i:sP
+        'r' => '(([a-zA-Z]{3}), ([123][0-9]|[1-9]) ([a-zA-Z]{3}) ([1-9][0-9]{0,4}) (2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9]) [\+\-](1[012]|0[0-9])([0134][05]))', // D, j M Y H:i:s O
+    );
+
+    /**
      * A test Carbon instance to be returned when now instances are created.
      *
      * @var \Carbon\Carbon
@@ -1952,6 +2000,36 @@ class Carbon extends DateTime
     public function isSaturday()
     {
         return $this->dayOfWeek === static::SATURDAY;
+    }
+
+    /**
+     * Checks if the (date)time string is in a given format.
+     *
+     * @param string $format
+     * @param string $time
+     *
+     * @return bool
+     */
+    public static function isFormat($format, $time)
+    {
+        try {
+            // Try to create a DateTime object. Throws an InvalidArgumentException if the provided time string
+            // doesn't match the format in any way.
+            static::createFromFormat($format, $time);
+
+            // createFromFormat() is known to handle edge cases silently.
+            // E.g. "1975-5-1" (Y-n-j) will still be parsed correctly when "Y-m-d" is supplied as the format.
+            // To ensure we're really testing against our desired format, perform an additional regex validation.
+            $regex = strtr(
+                preg_quote($format, '/'),
+                static::$regexFormats
+            );
+
+            return (bool) preg_match('/^'.$regex.'$/', $time);
+        } catch (InvalidArgumentException $e) {
+        }
+
+        return false;
     }
 
     ///////////////////////////////////////////////////////////////////

--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -386,18 +386,18 @@ class IsTest extends AbstractTestCase
         $this->assertFalse(Carbon::now()->addMonth()->previous(Carbon::SUNDAY)->isSaturday());
     }
 
-    public function testIsFormat()
+    public function testHasFormat()
     {
-        $this->assertTrue(Carbon::isFormat('Y-m-d', '1975-05-01'));
-        $this->assertTrue(Carbon::isFormat('D jS', 'Sun 21st'));
+        $this->assertTrue(Carbon::hasFormat('1975-05-01', 'Y-m-d'));
+        $this->assertTrue(Carbon::hasFormat('Sun 21st', 'D jS'));
 
         // Format failure
-        $this->assertFalse(Carbon::isFormat('d m Y', '1975-05-01'));
-        $this->assertFalse(Carbon::isFormat('D jS', 'Foo 21st'));
-        $this->assertFalse(Carbon::isFormat('D jS', 'Sun 51st'));
-        $this->assertFalse(Carbon::isFormat('D jS', 'Sun 21xx'));
+        $this->assertFalse(Carbon::hasFormat('1975-05-01', 'd m Y'));
+        $this->assertFalse(Carbon::hasFormat('Foo 21st', 'D jS'));
+        $this->assertFalse(Carbon::hasFormat('Sun 51st', 'D jS'));
+        $this->assertFalse(Carbon::hasFormat('Sun 21xx', 'D jS'));
 
         // Regex failure
-        $this->assertFalse(Carbon::isFormat('Y-m-d', '1975-5-1'));
+        $this->assertFalse(Carbon::hasFormat('1975-5-1', 'Y-m-d'));
     }
 }

--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -385,4 +385,19 @@ class IsTest extends AbstractTestCase
         $this->assertFalse(Carbon::now()->addWeek()->previous(Carbon::SUNDAY)->isSaturday());
         $this->assertFalse(Carbon::now()->addMonth()->previous(Carbon::SUNDAY)->isSaturday());
     }
+
+    public function testIsFormat()
+    {
+        $this->assertTrue(Carbon::isFormat('Y-m-d', '1975-05-01'));
+        $this->assertTrue(Carbon::isFormat('D jS', 'Sun 21st'));
+
+        // Format failure
+        $this->assertFalse(Carbon::isFormat('d m Y', '1975-05-01'));
+        $this->assertFalse(Carbon::isFormat('D jS', 'Foo 21st'));
+        $this->assertFalse(Carbon::isFormat('D jS', 'Sun 51st'));
+        $this->assertFalse(Carbon::isFormat('D jS', 'Sun 21xx'));
+
+        // Regex failure
+        $this->assertFalse(Carbon::isFormat('Y-m-d', '1975-5-1'));
+    }
 }


### PR DESCRIPTION
This PR adds a method to check if a string is in a given datetime format. Would be glad to see this merged.

Note: the regex patterns could perhaps be shortened but I preferred a readable pattern...