### PR TITLE
Fix issue with mocking time on PHP >=7.1

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -119,6 +119,13 @@ class Carbon extends DateTime
     const DEFAULT_TO_STRING_FORMAT = 'Y-m-d H:i:s';
 
     /**
+     * Format for converting mocked time, includes microseconds.
+     *
+     * @var string
+     */
+    const MOCK_DATETIME_FORMAT = 'Y-m-d H:i:s.u';
+
+    /**
      * Format to use for __toString method when type juggling occurs.
      *
      * @var string
@@ -285,7 +292,7 @@ class Carbon extends DateTime
                 $tz = $testInstance->getTimezone();
             }
 
-            $time = $testInstance->toDateTimeString();
+            $time = $testInstance->format(static::MOCK_DATETIME_FORMAT);
         }
 
         parent::__construct($time, static::safeCreateDateTimeZone($tz));

--- a/tests/Carbon/ConstructTest.php
+++ b/tests/Carbon/ConstructTest.php
@@ -109,4 +109,15 @@ class ConstructTest extends AbstractTestCase
         $this->assertSame($timezone, $c->tzName);
         $this->assertSame(9 + $dayLightSavingTimeOffset, $c->offsetHours);
     }
+
+    public function testMockingWithMicroseconds()
+    {
+        $c = new Carbon(Carbon::now()->toDateTimeString().'.123456');
+        Carbon::setTestNow($c);
+
+        $mockedC = Carbon::now();
+        $this->assertTrue($c->eq($mockedC));
+
+        Carbon::setTestNow();
+    }
 }


### PR DESCRIPTION
Since PHP 7.1 DateTime supports microseconds:
> 7.1 | From now on microseconds are filled with actual value. Not with '00000'.
http://php.net/manual/en/datetime.construct.php#refsect1-datetime.construct-changelog

The constructor when using a mocked time was converting date with the format string:  `Y-m-d H:i:s`. 
This meant that it was losing the microseconds part. 
When using a mocked time with comparison operators you could end up in some weird errors because the microseconds part was 0 on all mocked times.

```php
$c = new Carbon('2017-12-20 15:38:22.1234');
Carbon::setTestNow($c);

$mockedC = Carbon::now();
printf("%s\n", $c->format("Y-m-d H:i:s.u"));       // 2017-12-20 15:38:22.123400
printf("%s\n", $mockedC->format("Y-m-d H:i:s.u")); // 2017-12-20 15:38:22.000000
var_export($c == $mockedC);                        // false
```

This change adds microsecond to the mocked time.

Fixes #1033 