### PR TITLE
Add asterisk to isSameAs doc block

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1810,7 +1810,7 @@ class Carbon extends DateTime
         return static::create($this->year, 12, 28, 0, 0, 0, $this->tz)->weekOfYear === 53;
     }
 
-    /*
+    /**
      * Compares the formatted values of the two dates.
      *
      * @param string              $format The date formats to compare.


### PR DESCRIPTION
Extremely minor cosmetic change to the `isSameAs` method doc block to make it a "correct" method doc block.