### PR TITLE
Implemented CarbonRange to take work and weekend days count from a date range.

### DIFF
--- a/src/Carbon/CarbonRange.php
+++ b/src/Carbon/CarbonRange.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * User: denys
+ * Date: 25.12.17
+ * Time: 14:23
+ */
+
+namespace Carbon;
+
+
+use Carbon\Exceptions\UnknownIntervalException;
+
+class CarbonRange
+{
+    private $begin;
+    private $end;
+
+    public function __construct(Carbon $begin, Carbon $end)
+    {
+        $this->begin = $begin;
+        $this->end = $end;
+    }
+
+    /**
+     * @return Carbon
+     */
+    public function getEnd()
+    {
+        return $this->end;
+    }
+
+    /**
+     * @param Carbon $end
+     */
+    public function setEnd($end)
+    {
+        $this->end = $end;
+    }
+
+    /**
+     * @return Carbon
+     */
+    public function getBegin()
+    {
+        return $this->begin;
+    }
+
+    /**
+     * @param Carbon $begin
+     */
+    public function setBegin($begin)
+    {
+        $this->begin = $begin;
+    }
+
+    /**
+     * Return count of working days at interval.
+     * @param array $weekendDays Weekend days.
+     * @return int Count of working days.
+     * @throws \Exception
+     */
+    public function getWorkingDays($weekendDays = array(Carbon::SATURDAY, Carbon::SUNDAY))
+    {
+        $interval = $this->getIntervalAtDays();
+
+        $begin = clone $this->getBegin();
+
+        $count = 0;
+        for ($i = 0; $i < $interval; $i++) {
+
+            if (!in_array($begin->dayOfWeek, $weekendDays)) {
+                $count++;
+            }
+
+            $begin->addDay();
+        }
+
+        return $count;
+    }
+
+    public function getWeekendDays($weekendDays = [Carbon::SUNDAY, Carbon::SATURDAY])
+    {
+        $weekendDays = is_array($weekendDays) ? $weekendDays : array($weekendDays);
+
+        $intervalAtDays = $this->getIntervalAtDays();
+        return $intervalAtDays - $this->getWorkingDays($weekendDays);
+    }
+
+    /**
+     * Return days count between start and end date.
+     * @return mixed
+     */
+    private function getIntervalAtDays()
+    {
+        //Adding 1 days forward to include end date to calculation otherwise only begin date will be included.
+        //Must be cloned because stored at class start and end date aren't immutable.
+        $end = clone $this->getEnd();
+        return $end->addDay()->diff($this->getBegin())->days;
+    }
+}

--- a/tests/CarbonRange/WorkingDaysAtIntervalTest.php
+++ b/tests/CarbonRange/WorkingDaysAtIntervalTest.php
@@ -6,7 +6,7 @@
  * Time: 13:37
  */
 
-namespace Tests\CarbonInterval;
+namespace Tests\CarbonRange;
 
 
 use Carbon\Carbon;

--- a/tests/CarbonTimeline/WorkingDaysAtIntervalTest.php
+++ b/tests/CarbonTimeline/WorkingDaysAtIntervalTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * User: Denys Bushulyak <denys_bushulyak@icloud.com>
+ * Date: 25.12.17
+ * Time: 13:37
+ */
+
+namespace Tests\CarbonInterval;
+
+
+use Carbon\Carbon;
+use Carbon\CarbonRange;
+
+/**
+ * Class WorkingDaysAtIntervalTest
+ * @package Tests\CarbonInterval
+ */
+class WorkingDaysAtIntervalTest extends \PHPUnit_Framework_TestCase
+{
+    public function getWorkingDaysTestRange()
+    {
+        return [
+            [
+                //Taking from 1 to 31 december of 2017. It has 5 Saturdays and 5 Sundays and 21 working days.
+                Carbon::create(2017, 12, 1),
+                Carbon::create(2017, 12, 31),
+                21 //Expected working days
+            ],
+            [
+                //Taking form 4 to 13 december of 2017. It has 1 Saturday and 1 Sunday and 8 working days.
+                Carbon::create(2017, 12, 4),
+                Carbon::create(2017, 12, 13),
+                8 //Expected working days
+            ]
+        ];
+    }
+
+    public function getWeekendDaysTestRange()
+    {
+        return [
+            [
+                //Taking from 1 to 31 december of 2017. It has 5 Saturdays and 5 Sundays and 21 working days.
+                Carbon::create(2017, 12, 1),
+                Carbon::create(2017, 12, 31),
+                10 //Expected working days
+            ],
+            [
+                //Taking form 4 to 13 december of 2017. It has 1 Saturday and 1 Sunday and 8 working days.
+                Carbon::create(2017, 12, 4),
+                Carbon::create(2017, 12, 13),
+                2 //Expected working days
+            ],
+            [
+                Carbon::create(2017, 12, 18),
+                Carbon::create(2017, 12, 31),
+                4
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider getWorkingDaysTestRange
+     * @param Carbon $beginOfRange
+     * @param Carbon $endOfRange
+     * @param $expected
+     * @throws \Exception
+     */
+    public function testWorkingDays(Carbon $beginOfRange, Carbon $endOfRange, $expected)
+    {
+        /** @var CarbonRange $range */
+        $range = new CarbonRange($beginOfRange, $endOfRange);
+        $this->assertEquals($expected, $range->getWorkingDays());
+    }
+
+    /**
+     * @dataProvider getWeekendDaysTestRange
+     * @param Carbon $beginOfRange
+     * @param Carbon $endOfRange
+     * @param $expected
+     */
+    public function testWeekendDays(Carbon $beginOfRange, Carbon $endOfRange, $expected)
+    {
+        /** @var CarbonRange $range */
+        $range = new CarbonRange($beginOfRange, $endOfRange);
+        $this->assertEquals($expected, $range->getWeekendDays());
+    }
+
+    public function getDataForTestWeekendDaysOnlySunday()
+    {
+        return [
+            [
+                Carbon::create(2017, 12, 6),
+                Carbon::create(2017, 12, 10),
+                1
+            ],
+            [
+                Carbon::create(2017, 12, 11),
+                Carbon::create(2017, 12, 15),
+                0
+            ],
+            [
+                Carbon::create(2017, 12, 3),
+                Carbon::create(2017, 12, 30),
+                4
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getDataForTestWeekendDaysOnlySunday
+     * @param $begin
+     * @param $end
+     * @param $expected
+     */
+    public function testWeekendDaysOnlySunday($begin, $end, $expected)
+    {
+        $range = new CarbonRange($begin, $end);
+        $this->assertEquals($expected, $range->getWeekendDays([Carbon::SUNDAY]));
+        $this->assertEquals($expected, $range->getWeekendDays(Carbon::SUNDAY));
+    }
+
+    public function getDataForTestWeekendDaysOnlySaturday()
+    {
+        return [
+            [
+                Carbon::create(2017, 12, 6),
+                Carbon::create(2017, 12, 10),
+                1
+            ],
+            [
+                Carbon::create(2017, 12, 11),
+                Carbon::create(2017, 12, 15),
+                0
+            ],
+            [
+                Carbon::create(2017, 12, 3),
+                Carbon::create(2017, 12, 30),
+                4
+            ],
+            [
+                Carbon::create(2017, 12, 18),
+                Carbon::create(2017, 12, 31),
+                2
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getDataForTestWeekendDaysOnlySaturday
+     * @param $begin
+     * @param $end
+     * @param $expected
+     */
+    public function testWeekendDaysOnlySaturday($begin, $end, $expected)
+    {
+        $this->assertEquals($expected, (new CarbonRange($begin, $end))->getWeekendDays(Carbon::SATURDAY));
+    }
+}


### PR DESCRIPTION
Example:
```php
$begin = Carbon::create(2017,12,1);
$end = Carbon::create(2017,12,31);
$range = new CarbonRange($begin, $end);
$range->getWeekendDays();
$range->getWorkingDays();
````