### PR TITLE
Composer scripts refactored mainly to work on the Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=auto
+* text=auto eol=lf
 
 .codecov.yml export-ignore
 .editorconfig export-ignore

--- a/composer.json
+++ b/composer.json
@@ -47,8 +47,11 @@
         "sort-packages": true
     },
     "scripts": {
-        "test": "./vendor/bin/phpunit; ./vendor/bin/php-cs-fixer fix -v --diff --dry-run;",
-        "phpunit": "./vendor/bin/phpunit;",
-        "phpcs": "./vendor/bin/php-cs-fixer fix -v --diff --dry-run;"
+        "test": [
+            "@phpunit",
+            "@phpcs"
+        ],
+        "phpunit": "phpunit",
+        "phpcs": "php-cs-fixer fix -v --diff --dry-run"
     }
 }


### PR DESCRIPTION
There was an error on the win:

```
> composer test
> ./vendor/bin/phpunit; ./vendor/bin/php-cs-fixer fix -v --diff --dry-run;
The system cannot find the path specified.
Script ./vendor/bin/phpunit; ./vendor/bin/php-cs-fixer fix -v --diff --dry-run; handling the test event returned with error code 1
```

In the composer documentstion [written](https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands) that
> Note: Before executing scripts, Composer's bin-dir is temporarily pushed on top of the PATH environment variable so that binaries of dependencies are easily accessible. In this example no matter if the phpunit binary is actually in vendor/bin/phpunit or bin/phpunit it will be found and executed.