### PR TITLE
fix readme markdown format

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ printf("Now: %s", Carbon::now());
 ```
 
 <a name="install-nocomposer"/>
+
 ### Without Composer
 
 Why are you not using [composer](http://getcomposer.org/)? Download [Carbon.php](https://github.com/briannesbitt/Carbon/blob/master/src/Carbon/Carbon.php) from the repo and save the file into your project path somewhere.


### PR DESCRIPTION
missing empty lead to "without composer" not being rendered as header