### PR TITLE
Adds ability to pass a timestamp to the constructor

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -265,7 +265,7 @@ class Carbon extends DateTime
      * Please see the testing aids section (specifically static::setTestNow())
      * for more on the possibility of this constructor returning a test instance.
      *
-     * @param string|null               $time
+     * @param string|int|null           $time
      * @param \DateTimeZone|string|null $tz
      */
     public function __construct($time = null, $tz = null)

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -270,6 +270,11 @@ class Carbon extends DateTime
      */
     public function __construct($time = null, $tz = null)
     {
+        // Convert timestamp to date string
+        if (is_int($time)) {
+            $time = date('Y-m-d H:i:s', $time);
+        }
+
         // If the class has a test now set and we are trying to create a now()
         // instance then override as required
         if (static::hasTestNow() && (empty($time) || $time === 'now' || static::hasRelativeKeywords($time))) {


### PR DESCRIPTION
This makes it possible to pass a timestamp to the Carbon class, like:
```
$date = new Carbon(1518358828);
```