### PR TITLE
Document overflow methods

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -114,7 +114,7 @@ echo Carbon::parse('first day of December 2008')->addWeeks(2);    // 2008-12-15 
 <p>To accompany <code>now()</code>, a few other static instantiation helpers exist to create widely known instances.  The only thing to really notice here is that <code>today()</code>, <code>tomorrow()</code> and <code>yesterday()</code>, besides behaving as expected, all accept a timezone parameter and each has their time value set to <code>00:00:00</code>.</p>
 
 <p><pre><code class="php">$now = Carbon::now();
-echo $now;                               // 2018-02-13 07:06:49
+echo $now;                               // 2018-02-13 07:37:34
 $today = Carbon::today();
 echo $today;                             // 2018-02-13 00:00:00
 $tomorrow = Carbon::tomorrow('Europe/London');
@@ -183,14 +183,21 @@ echo $dt->copy()->micro;                               // 123456
 echo Carbon::minValue();                               // '1901-12-13 15:45:52'
 </code></pre></p>
 
+<p>Min and max value mainly depends on the system (32 or 64 bits).</p>
+
+<p>With a 32 bits OS system (you can check it in PHP with <code>PHP_INT_SIZE === 4</code>), the minimum value is the 0-unix-timestamp (1970-01-01 00:00:00) and the maximum is the timestamp given by the constant <code>PHP_INT_MAX</code>.</p>
+
+<p>With a 64 bits OS system, the minimum is 01-01-01 00:00:00 and maximum is 9999-12-31 23:59:59.</p>
+
 <h1 id="api-localization">Localization</h1>
 
 <p>Unfortunately the base class DateTime does not have any localization support.  To begin localization support a <code>formatLocalized($format)</code> method was added.  The implementation makes a call to <a href="http://www.php.net/strftime">strftime</a> using the current instance timestamp.  If you first set the current locale with PHP function <a href="http://www.php.net/setlocale">setlocale()</a> then the string returned will be formatted in the correct locale.</p>
 
 <p><pre><code class="php">setlocale(LC_TIME, 'German');
+echo $dt->formatLocalized('%A %d %B %Y');          // Mittwoch 21 Mai 1975
+setlocale(LC_TIME, 'English');
 echo $dt->formatLocalized('%A %d %B %Y');          // Wednesday 21 May 1975
-setlocale(LC_TIME, '');
-echo $dt->formatLocalized('%A %d %B %Y');          // Wednesday 21 May 1975
+setlocale(LC_TIME, ''); // reset locale
 </code></pre></p>
 
 <p><code>diffForHumans()</code> has also been localized.  You can set the Carbon locale by using the static <code>Carbon::setLocale()</code> function.</p>
@@ -228,7 +235,7 @@ echo Carbon::parse('now');                             // 2001-05-21 12:00:00
 var_dump(Carbon::hasTestNow());                        // bool(true)
 Carbon::setTestNow();                                  // clear the mock
 var_dump(Carbon::hasTestNow());                        // bool(false)
-echo Carbon::now();                                    // 2018-02-13 07:06:49
+echo Carbon::now();                                    // 2018-02-13 07:37:34
 </code></pre></p>
 
 <p>A more meaning full example:</p>
@@ -489,7 +496,7 @@ echo $dt1->max($dt2);                              // 2014-01-30 00:00:00
 
 // now is the default param
 $dt1 = Carbon::create(2000, 1, 1, 0, 0, 0);
-echo $dt1->max();                                  // 2018-02-13 07:06:49
+echo $dt1->max();                                  // 2018-02-13 07:37:34
 </code></pre></p>
 
 <p>To handle the most used cases there are some simple helper functions that hopefully are obvious from their names.  For the methods that compare to <code>now()</code> (ex. isToday()) in some manner the <code>now()</code> is created in the same timezone as the instance.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -114,13 +114,13 @@ echo Carbon::parse('first day of December 2008')->addWeeks(2);    // 2008-12-15 
 <p>To accompany <code>now()</code>, a few other static instantiation helpers exist to create widely known instances.  The only thing to really notice here is that <code>today()</code>, <code>tomorrow()</code> and <code>yesterday()</code>, besides behaving as expected, all accept a timezone parameter and each has their time value set to <code>00:00:00</code>.</p>
 
 <p><pre><code class="php">$now = Carbon::now();
-echo $now;                               // 2016-06-24 15:18:34
+echo $now;                               // 2018-02-13 07:06:49
 $today = Carbon::today();
-echo $today;                             // 2016-06-24 00:00:00
+echo $today;                             // 2018-02-13 00:00:00
 $tomorrow = Carbon::tomorrow('Europe/London');
-echo $tomorrow;                          // 2016-06-25 00:00:00
+echo $tomorrow;                          // 2018-02-14 00:00:00
 $yesterday = Carbon::yesterday();
-echo $yesterday;                         // 2016-06-23 00:00:00
+echo $yesterday;                         // 2018-02-12 00:00:00
 </code></pre></p>
 
 <p>The next group of static helpers are the <code>createXXX()</code> helpers. Most of the static <code>create</code> functions allow you to provide as many or as few arguments as you want and will provide default values for all others.  Generally default values are the current date, time or timezone.  Higher values will wrap appropriately but invalid values will throw an <code>InvalidArgumentException</code> with an informative message.  The message is obtained from an <a href="http://php.net/manual/en/datetime.getlasterrors.php">DateTime::getLastErrors()</a> call.</p>
@@ -188,7 +188,7 @@ echo Carbon::minValue();                               // '1901-12-13 15:45:52'
 <p>Unfortunately the base class DateTime does not have any localization support.  To begin localization support a <code>formatLocalized($format)</code> method was added.  The implementation makes a call to <a href="http://www.php.net/strftime">strftime</a> using the current instance timestamp.  If you first set the current locale with PHP function <a href="http://www.php.net/setlocale">setlocale()</a> then the string returned will be formatted in the correct locale.</p>
 
 <p><pre><code class="php">setlocale(LC_TIME, 'German');
-echo $dt->formatLocalized('%A %d %B %Y');          // Mittwoch 21 Mai 1975
+echo $dt->formatLocalized('%A %d %B %Y');          // Wednesday 21 May 1975
 setlocale(LC_TIME, '');
 echo $dt->formatLocalized('%A %d %B %Y');          // Wednesday 21 May 1975
 </code></pre></p>
@@ -228,7 +228,7 @@ echo Carbon::parse('now');                             // 2001-05-21 12:00:00
 var_dump(Carbon::hasTestNow());                        // bool(true)
 Carbon::setTestNow();                                  // clear the mock
 var_dump(Carbon::hasTestNow());                        // bool(false)
-echo Carbon::now();                                    // 2016-06-24 15:18:34
+echo Carbon::now();                                    // 2018-02-13 07:06:49
 </code></pre></p>
 
 <p>A more meaning full example:</p>
@@ -311,7 +311,7 @@ var_dump($dt->weekOfMonth);                                  // int(1)
 var_dump($dt->weekOfYear);                                   // int(36)
 var_dump($dt->daysInMonth);                                  // int(30)
 var_dump($dt->timestamp);                                    // int(1346901971)
-var_dump(Carbon::createFromDate(1975, 5, 21)->age);          // int(41) calculated vs now in the same tz
+var_dump(Carbon::createFromDate(1975, 5, 21)->age);          // int(42) calculated vs now in the same tz
 var_dump($dt->quarter);                                      // int(3)
 
 // Returns an int of seconds difference from UTC (+/- sign included)
@@ -331,7 +331,7 @@ var_dump(Carbon::now('America/Vancouver')->local);           // bool(false)
 
 // Indicates if the instance is in the UTC timezone
 var_dump(Carbon::now()->utc);                                // bool(false)
-var_dump(Carbon::now('Europe/London')->utc);                 // bool(false)
+var_dump(Carbon::now('Europe/London')->utc);                 // bool(true)
 var_dump(Carbon::createFromTimestampUTC(0)->utc);            // bool(true)
 
 // Gets the DateTimeZone instance
@@ -426,7 +426,7 @@ echo $dt;                                          // 1975-12-25 14:15:16
 // $dt->toAtomString() is the same as $dt->format(DateTime::ATOM);
 echo $dt->toAtomString();      // 1975-12-25T14:15:16-05:00
 echo $dt->toCookieString();    // Thursday, 25-Dec-1975 14:15:16 EST
-echo $dt->toIso8601String();   // 1975-12-25T14:15:16-0500
+echo $dt->toIso8601String();   // 1975-12-25T14:15:16-05:00
 echo $dt->toRfc822String();    // Thu, 25 Dec 75 14:15:16 -0500
 echo $dt->toRfc850String();    // Thursday, 25-Dec-75 14:15:16 EST
 echo $dt->toRfc1036String();   // Thu, 25 Dec 75 14:15:16 -0500
@@ -489,7 +489,7 @@ echo $dt1->max($dt2);                              // 2014-01-30 00:00:00
 
 // now is the default param
 $dt1 = Carbon::create(2000, 1, 1, 0, 0, 0);
-echo $dt1->max();                                  // 2016-06-24 15:18:34
+echo $dt1->max();                                  // 2018-02-13 07:06:49
 </code></pre></p>
 
 <p>To handle the most used cases there are some simple helper functions that hopefully are obvious from their names.  For the methods that compare to <code>now()</code> (ex. isToday()) in some manner the <code>now()</code> is created in the same timezone as the instance.</p>
@@ -567,6 +567,61 @@ echo $dt->subSeconds(61);                // 2012-02-03 00:00:00
 
 <p>P.S. Don't worry if you forget and use <code>addDay(5)</code> or <code>subYear(3)</code>, I have your back ;)</p>
 
+<p>By default, Carbon behave as the PHP DateTime do. That means adding or substracting months can overflow, example:</p>
+
+<p><pre><code class="php">$dt = Carbon::create(2017, 1, 31, 0);
+
+echo $dt->copy()->addMonth();            // 2017-03-03 00:00:00
+echo $dt->copy()->subMonths(2);          // 2016-12-01 00:00:00
+</code></pre></p>
+
+<p>You can't prevent the overflow with <code>Carbon::useMonthsOverflow(false)</code></p>
+
+<p><pre><code class="php">Carbon::useMonthsOverflow(false);
+
+$dt = Carbon::create(2017, 1, 31, 0);
+
+echo $dt->copy()->addMonth();            // 2017-02-28 00:00:00
+echo $dt->copy()->subMonths(2);          // 2016-11-30 00:00:00
+
+// Call the method with true to allow overflow again
+Carbon::resetMonthsOverflow();} // same as Carbon::useMonthsOverflow(true);
+</code></pre></p>
+
+The method <code>Carbon::shouldOverflowMonths()</code> allow you to know if the overflow is currently enabled.
+
+You also can use <code>-&gt;addMonthsNoOverflow</code>, <code>-&gt;subMonthsNoOverflow</code>,
+<code>-&gt;addMonthsWithOverflow</code> and <code>-&gt;subMonthsWithOverflow</code>
+(or the singular methods with no <code>s</code> to "month").
+to explicitly add/sub months with or without overflow no matter the current mode.
+
+<p><pre><code class="php">Carbon::useMonthsOverflow(false);
+
+$dt = Carbon::create(2017, 1, 31, 0);
+
+echo $dt->copy()->addMonthWithOverflow();          // 2017-03-03 00:00:00
+echo $dt->copy()->subMonthsWithOverflow(2);        // 2016-12-01 00:00:00
+echo $dt->copy()->addMonthNoOverflow();            // 2017-02-28 00:00:00
+echo $dt->copy()->subMonthsNoOverflow(2);          // 2016-11-30 00:00:00
+
+echo $dt->copy()->addMonth();                      // 2017-02-28 00:00:00
+echo $dt->copy()->subMonths(2);                    // 2016-11-30 00:00:00
+
+Carbon::useMonthsOverflow(true);
+
+$dt = Carbon::create(2017, 1, 31, 0);
+
+echo $dt->copy()->addMonthWithOverflow();          // 2017-03-03 00:00:00
+echo $dt->copy()->subMonthsWithOverflow(2);        // 2016-12-01 00:00:00
+echo $dt->copy()->addMonthNoOverflow();            // 2017-02-28 00:00:00
+echo $dt->copy()->subMonthsNoOverflow(2);          // 2016-11-30 00:00:00
+
+echo $dt->copy()->addMonth();                      // 2017-03-03 00:00:00
+echo $dt->copy()->subMonths(2);                    // 2016-12-01 00:00:00
+
+Carbon::resetMonthsOverflow();}
+</code></pre></p>
+
 <h1 id="api-difference">Difference</h1>
 
 <p>These functions always return the <b>total difference</b> expressed in the specified time requested.  This differs from the base class <code>diff()</code> function where an interval of 61 seconds would be returned as 1 minute and 1 second via a <code>DateInterval</code> instance.  The <code>diffInMinutes()</code> function would simply return 1.  All values are truncated and not rounded.  Each function below has a default first parameter which is the Carbon instance to compare to, or null if you want to use <code>now()</code>.  The 2nd parameter again is optional and indicates if you want the return value to be the absolute value or a relative value that might have a <code>-</code> (negative) sign if the passed in date is less than the current instance.  This will default to true, return the absolute value.  The comparisons are done in UTC.</p>
@@ -626,7 +681,7 @@ echo $littleHandRotations;     // 24
 
 <h1 id="api-humandiff">Difference for Humans</h1>
 
-<p>It is easier for humans to read <code>1 month ago</code> compared to 30 days ago.  This is a common function seen in most date libraries so I thought I would add it here as well.  It uses approximations for a month being 4 weeks. The lone argument for the function is the other Carbon instance to diff against, and of course it defaults to <code>now()</code> if not specified.</p>
+<p>It is easier for humans to read <code>1 month ago</code> compared to 30 days ago.  This is a common function seen in most date libraries so I thought I would add it here as well. The lone argument for the function is the other Carbon instance to diff against, and of course it defaults to <code>now()</code> if not specified.</p>
 
 <p>This method will add a phrase after the difference value relative to the instance and the passed in instance.  There are 4 possibilities:</p>
 
@@ -709,10 +764,10 @@ $dt = Carbon::create(2012, 1, 31, 12, 0, 0);
 echo $dt->endOfDecade();                           // 2019-12-31 23:59:59
 
 $dt = Carbon::create(2012, 1, 31, 12, 0, 0);
-echo $dt->startOfCentury();                        // 2000-01-01 00:00:00
+echo $dt->startOfCentury();                        // 2001-01-01 00:00:00
 
 $dt = Carbon::create(2012, 1, 31, 12, 0, 0);
-echo $dt->endOfCentury();                          // 2099-12-31 23:59:59
+echo $dt->endOfCentury();                          // 2100-12-31 23:59:59
 
 $dt = Carbon::create(2012, 1, 31, 12, 0, 0);
 echo $dt->startOfWeek();                           // 2012-01-30 00:00:00

--- a/docs/index.html
+++ b/docs/index.html
@@ -114,7 +114,7 @@ echo Carbon::parse('first day of December 2008')->addWeeks(2);    // 2008-12-15 
 <p>To accompany <code>now()</code>, a few other static instantiation helpers exist to create widely known instances.  The only thing to really notice here is that <code>today()</code>, <code>tomorrow()</code> and <code>yesterday()</code>, besides behaving as expected, all accept a timezone parameter and each has their time value set to <code>00:00:00</code>.</p>
 
 <p><pre><code class="php">$now = Carbon::now();
-echo $now;                               // 2018-02-13 07:37:34
+echo $now;                               // 2018-02-13 10:41:12
 $today = Carbon::today();
 echo $today;                             // 2018-02-13 00:00:00
 $tomorrow = Carbon::tomorrow('Europe/London');
@@ -179,15 +179,15 @@ echo $dt->copy()->micro;                               // 123456
 
 <p>Ever need to loop through some dates to find the earliest or latest date?  Didn't know what to set your initial maximum/minimum values to? There are now two helpers for this to make your decision simple:</p>
 
-<p><pre><code class="php">echo Carbon::maxValue();                               // '2038-01-18 22:14:07'
-echo Carbon::minValue();                               // '1901-12-13 15:45:52'
+<p><pre><code class="php">echo Carbon::maxValue();                               // '9999-12-31 23:59:59'
+echo Carbon::minValue();                               // '0001-01-01 00:00:00'
 </code></pre></p>
 
-<p>Min and max value mainly depends on the system (32 or 64 bits).</p>
+<p>Min and max value mainly depends on the system (32 or 64 bit).</p>
 
-<p>With a 32 bits OS system (you can check it in PHP with <code>PHP_INT_SIZE === 4</code>), the minimum value is the 0-unix-timestamp (1970-01-01 00:00:00) and the maximum is the timestamp given by the constant <code>PHP_INT_MAX</code>.</p>
+<p>With a 32-bit OS system or 32-bit version of PHP (you can check it in PHP with <code>PHP_INT_SIZE === 4</code>), the minimum value is the 0-unix-timestamp (1970-01-01 00:00:00) and the maximum is the timestamp given by the constant <code>PHP_INT_MAX</code>.</p>
 
-<p>With a 64 bits OS system, the minimum is 01-01-01 00:00:00 and maximum is 9999-12-31 23:59:59.</p>
+<p>With a 64-bit OS system and 64-bit version of PHP, the minimum is 01-01-01 00:00:00 and maximum is 9999-12-31 23:59:59.</p>
 
 <h1 id="api-localization">Localization</h1>
 
@@ -235,7 +235,7 @@ echo Carbon::parse('now');                             // 2001-05-21 12:00:00
 var_dump(Carbon::hasTestNow());                        // bool(true)
 Carbon::setTestNow();                                  // clear the mock
 var_dump(Carbon::hasTestNow());                        // bool(false)
-echo Carbon::now();                                    // 2018-02-13 07:37:34
+echo Carbon::now();                                    // 2018-02-13 10:41:12
 </code></pre></p>
 
 <p>A more meaning full example:</p>
@@ -496,7 +496,7 @@ echo $dt1->max($dt2);                              // 2014-01-30 00:00:00
 
 // now is the default param
 $dt1 = Carbon::create(2000, 1, 1, 0, 0, 0);
-echo $dt1->max();                                  // 2018-02-13 07:37:34
+echo $dt1->max();                                  // 2018-02-13 10:41:12
 </code></pre></p>
 
 <p>To handle the most used cases there are some simple helper functions that hopefully are obvious from their names.  For the methods that compare to <code>now()</code> (ex. isToday()) in some manner the <code>now()</code> is created in the same timezone as the instance.</p>
@@ -574,7 +574,7 @@ echo $dt->subSeconds(61);                // 2012-02-03 00:00:00
 
 <p>P.S. Don't worry if you forget and use <code>addDay(5)</code> or <code>subYear(3)</code>, I have your back ;)</p>
 
-<p>By default, Carbon behave as the PHP DateTime do. That means adding or substracting months can overflow, example:</p>
+<p>By default, Carbon relies on the underlying parent class PHP DateTime behavior. As a result adding or subtracting months can overflow, example:</p>
 
 <p><pre><code class="php">$dt = Carbon::create(2017, 1, 31, 0);
 
@@ -582,7 +582,7 @@ echo $dt->copy()->addMonth();            // 2017-03-03 00:00:00
 echo $dt->copy()->subMonths(2);          // 2016-12-01 00:00:00
 </code></pre></p>
 
-<p>You can't prevent the overflow with <code>Carbon::useMonthsOverflow(false)</code></p>
+<p>You can prevent the overflow with <code>Carbon::useMonthsOverflow(false)</code></p>
 
 <p><pre><code class="php">Carbon::useMonthsOverflow(false);
 
@@ -595,7 +595,7 @@ echo $dt->copy()->subMonths(2);          // 2016-11-30 00:00:00
 Carbon::resetMonthsOverflow();} // same as Carbon::useMonthsOverflow(true);
 </code></pre></p>
 
-The method <code>Carbon::shouldOverflowMonths()</code> allow you to know if the overflow is currently enabled.
+The method <code>Carbon::shouldOverflowMonths()</code> allows you to know if the overflow is currently enabled.
 
 You also can use <code>-&gt;addMonthsNoOverflow</code>, <code>-&gt;subMonthsNoOverflow</code>,
 <code>-&gt;addMonthsWithOverflow</code> and <code>-&gt;subMonthsWithOverflow</code>

--- a/docs/index.src.html
+++ b/docs/index.src.html
@@ -136,14 +136,21 @@ $noonLondonTz = Carbon::createFromTime(12, 0, 0, 'Europe/London');
 {{minValue::exec(echo Carbon::minValue();/*pad(54)*/)}} // '{{minValue_eval}}'
 </code></pre></p>
 
+<p>Min and max value mainly depends on the system (32 or 64 bits).</p>
+
+<p>With a 32 bits OS system (you can check it in PHP with <code>PHP_INT_SIZE === 4</code>), the minimum value is the 0-unix-timestamp (1970-01-01 00:00:00) and the maximum is the timestamp given by the constant <code>PHP_INT_MAX</code>.</p>
+
+<p>With a 64 bits OS system, the minimum is 01-01-01 00:00:00 and maximum is 9999-12-31 23:59:59.</p>
+
 <h1 id="api-localization">Localization</h1>
 
 <p>Unfortunately the base class DateTime does not have any localization support.  To begin localization support a <code>formatLocalized($format)</code> method was added.  The implementation makes a call to <a href="http://www.php.net/strftime">strftime</a> using the current instance timestamp.  If you first set the current locale with PHP function <a href="http://www.php.net/setlocale">setlocale()</a> then the string returned will be formatted in the correct locale.</p>
 
 <p><pre><code class="php">{{::lint(setlocale(LC_TIME, 'German');)}}
 {{locale1::exec(echo $dt->formatLocalized('%A %d %B %Y');/*pad(50)*/)}} // {{locale1_eval}}
-{{::lint(setlocale(LC_TIME, '');)}}
+{{::lint(setlocale(LC_TIME, 'English');)}}
 {{locale2::exec(echo $dt->formatLocalized('%A %d %B %Y');/*pad(50)*/)}} // {{locale2_eval}}
+{{::lint(setlocale(LC_TIME, ''); // reset locale)}}
 </code></pre></p>
 
 <p><code>diffForHumans()</code> has also been localized.  You can set the Carbon locale by using the static <code>Carbon::setLocale()</code> function.</p>

--- a/docs/index.src.html
+++ b/docs/index.src.html
@@ -532,6 +532,61 @@ $dt->isSameDay(Carbon::now());
 
 <p>P.S. Don't worry if you forget and use <code>addDay(5)</code> or <code>subYear(3)</code>, I have your back ;)</p>
 
+<p>By default, Carbon behave as the PHP DateTime do. That means adding or substracting months can overflow, example:</p>
+
+<p><pre><code class="php">{{::lint($dt = Carbon::create(2017, 1, 31, 0);)}}
+
+{{addoverflow1::exec(echo $dt->copy()->addMonth();/*pad(40)*/)}} // {{addoverflow1_eval}}
+{{addoverflow2::exec(echo $dt->copy()->subMonths(2);/*pad(40)*/)}} // {{addoverflow2_eval}}
+</code></pre></p>
+
+<p>You can't prevent the overflow with <code>Carbon::useMonthsOverflow(false)</code></p>
+
+<p><pre><code class="php">{{::lint(Carbon::useMonthsOverflow(false);
+
+$dt = Carbon::create(2017, 1, 31, 0);)}}
+
+{{addoverflow3::exec(echo $dt->copy()->addMonth();/*pad(40)*/)}} // {{addoverflow3_eval}}
+{{addoverflow4::exec(echo $dt->copy()->subMonths(2);/*pad(40)*/)}} // {{addoverflow4_eval}}
+
+// Call the method with true to allow overflow again
+{{reset1::exec(Carbon::resetMonthsOverflow();)}}} // same as Carbon::useMonthsOverflow(true);
+</code></pre></p>
+
+The method <code>Carbon::shouldOverflowMonths()</code> allow you to know if the overflow is currently enabled.
+
+You also can use <code>-&gt;addMonthsNoOverflow</code>, <code>-&gt;subMonthsNoOverflow</code>,
+<code>-&gt;addMonthsWithOverflow</code> and <code>-&gt;subMonthsWithOverflow</code>
+(or the singular methods with no <code>s</code> to "month").
+to explicitly add/sub months with or without overflow no matter the current mode.
+
+<p><pre><code class="php">{{::lint(Carbon::useMonthsOverflow(false);
+
+$dt = Carbon::create(2017, 1, 31, 0);)}}
+
+{{addoverflow5::exec(echo $dt->copy()->addMonthWithOverflow();/*pad(50)*/)}} // {{addoverflow5_eval}}
+{{addoverflow6::exec(echo $dt->copy()->subMonthsWithOverflow(2);/*pad(50)*/)}} // {{addoverflow6_eval}}
+{{addoverflow7::exec(echo $dt->copy()->addMonthNoOverflow();/*pad(50)*/)}} // {{addoverflow7_eval}}
+{{addoverflow8::exec(echo $dt->copy()->subMonthsNoOverflow(2);/*pad(50)*/)}} // {{addoverflow8_eval}}
+
+{{addoverflowremind1::exec(echo $dt->copy()->addMonth();/*pad(50)*/)}} // {{addoverflowremind1_eval}}
+{{addoverflowremind2::exec(echo $dt->copy()->subMonths(2);/*pad(50)*/)}} // {{addoverflowremind2_eval}}
+
+{{::lint(Carbon::useMonthsOverflow(true);
+
+$dt = Carbon::create(2017, 1, 31, 0);)}}
+
+{{addoverflow9::exec(echo $dt->copy()->addMonthWithOverflow();/*pad(50)*/)}} // {{addoverflow9_eval}}
+{{addoverflow10::exec(echo $dt->copy()->subMonthsWithOverflow(2);/*pad(50)*/)}} // {{addoverflow10_eval}}
+{{addoverflow11::exec(echo $dt->copy()->addMonthNoOverflow();/*pad(50)*/)}} // {{addoverflow11_eval}}
+{{addoverflow12::exec(echo $dt->copy()->subMonthsNoOverflow(2);/*pad(50)*/)}} // {{addoverflow12_eval}}
+
+{{addoverflowremind3::exec(echo $dt->copy()->addMonth();/*pad(50)*/)}} // {{addoverflowremind3_eval}}
+{{addoverflowremind4::exec(echo $dt->copy()->subMonths(2);/*pad(50)*/)}} // {{addoverflowremind4_eval}}
+
+{{reset2::exec(Carbon::resetMonthsOverflow();)}}}
+</code></pre></p>
+
 <h1 id="api-difference">Difference</h1>
 
 <p>These functions always return the <b>total difference</b> expressed in the specified time requested.  This differs from the base class <code>diff()</code> function where an interval of 61 seconds would be returned as 1 minute and 1 second via a <code>DateInterval</code> instance.  The <code>diffInMinutes()</code> function would simply return 1.  All values are truncated and not rounded.  Each function below has a default first parameter which is the Carbon instance to compare to, or null if you want to use <code>now()</code>.  The 2nd parameter again is optional and indicates if you want the return value to be the absolute value or a relative value that might have a <code>-</code> (negative) sign if the passed in date is less than the current instance.  This will default to true, return the absolute value.  The comparisons are done in UTC.</p>

--- a/docs/index.src.html
+++ b/docs/index.src.html
@@ -136,11 +136,11 @@ $noonLondonTz = Carbon::createFromTime(12, 0, 0, 'Europe/London');
 {{minValue::exec(echo Carbon::minValue();/*pad(54)*/)}} // '{{minValue_eval}}'
 </code></pre></p>
 
-<p>Min and max value mainly depends on the system (32 or 64 bits).</p>
+<p>Min and max value mainly depends on the system (32 or 64 bit).</p>
 
-<p>With a 32 bits OS system (you can check it in PHP with <code>PHP_INT_SIZE === 4</code>), the minimum value is the 0-unix-timestamp (1970-01-01 00:00:00) and the maximum is the timestamp given by the constant <code>PHP_INT_MAX</code>.</p>
+<p>With a 32-bit OS system or 32-bit version of PHP (you can check it in PHP with <code>PHP_INT_SIZE === 4</code>), the minimum value is the 0-unix-timestamp (1970-01-01 00:00:00) and the maximum is the timestamp given by the constant <code>PHP_INT_MAX</code>.</p>
 
-<p>With a 64 bits OS system, the minimum is 01-01-01 00:00:00 and maximum is 9999-12-31 23:59:59.</p>
+<p>With a 64-bit OS system and 64-bit version of PHP, the minimum is 01-01-01 00:00:00 and maximum is 9999-12-31 23:59:59.</p>
 
 <h1 id="api-localization">Localization</h1>
 
@@ -539,7 +539,7 @@ $dt->isSameDay(Carbon::now());
 
 <p>P.S. Don't worry if you forget and use <code>addDay(5)</code> or <code>subYear(3)</code>, I have your back ;)</p>
 
-<p>By default, Carbon behave as the PHP DateTime do. That means adding or substracting months can overflow, example:</p>
+<p>By default, Carbon relies on the underlying parent class PHP DateTime behavior. As a result adding or subtracting months can overflow, example:</p>
 
 <p><pre><code class="php">{{::lint($dt = Carbon::create(2017, 1, 31, 0);)}}
 
@@ -547,7 +547,7 @@ $dt->isSameDay(Carbon::now());
 {{addoverflow2::exec(echo $dt->copy()->subMonths(2);/*pad(40)*/)}} // {{addoverflow2_eval}}
 </code></pre></p>
 
-<p>You can't prevent the overflow with <code>Carbon::useMonthsOverflow(false)</code></p>
+<p>You can prevent the overflow with <code>Carbon::useMonthsOverflow(false)</code></p>
 
 <p><pre><code class="php">{{::lint(Carbon::useMonthsOverflow(false);
 
@@ -560,7 +560,7 @@ $dt = Carbon::create(2017, 1, 31, 0);)}}
 {{reset1::exec(Carbon::resetMonthsOverflow();)}}} // same as Carbon::useMonthsOverflow(true);
 </code></pre></p>
 
-The method <code>Carbon::shouldOverflowMonths()</code> allow you to know if the overflow is currently enabled.
+The method <code>Carbon::shouldOverflowMonths()</code> allows you to know if the overflow is currently enabled.
 
 You also can use <code>-&gt;addMonthsNoOverflow</code>, <code>-&gt;subMonthsNoOverflow</code>,
 <code>-&gt;addMonthsWithOverflow</code> and <code>-&gt;subMonthsWithOverflow</code>

--- a/generate.php
+++ b/generate.php
@@ -23,8 +23,7 @@ function genHtml($page, $out, $jumbotron = '') {
 function compile($src, $dest, & $namesCache) {
     $code = file_get_contents($src);
 
-    $pre_src = 'use Carbon\Carbon; use Carbon\CarbonInterval; '.
-        'date_default_timezone_set(\'America/Toronto\'); setlocale(LC_ALL, \'en\'); ';
+    $pre_src = 'use Carbon\Carbon; use Carbon\CarbonInterval; ';
 
     // {{intro::exec(echo Carbon::now()->subMinutes(2)->diffForHumans();)}}
     preg_match_all('@{{(\w*)::(\w+)\((.+)\)}}@sU', $code, $matches, PREG_SET_ORDER);

--- a/generate.php
+++ b/generate.php
@@ -1,12 +1,14 @@
 <?php
 
 date_default_timezone_set('America/Toronto');
+setlocale(LC_ALL, 'en');
 
 require 'vendor/autoload.php';
+
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
 
-$namesCache = [];
+$namesCache = array();
 
 $template = file_get_contents('template.src.html');
 
@@ -21,7 +23,8 @@ function genHtml($page, $out, $jumbotron = '') {
 function compile($src, $dest, & $namesCache) {
     $code = file_get_contents($src);
 
-    $pre_src = 'use Carbon\Carbon; use Carbon\CarbonInterval; ';
+    $pre_src = 'use Carbon\Carbon; use Carbon\CarbonInterval; '.
+        'date_default_timezone_set(\'America/Toronto\'); setlocale(LC_ALL, \'en\'); ';
 
     // {{intro::exec(echo Carbon::now()->subMinutes(2)->diffForHumans();)}}
     preg_match_all('@{{(\w*)::(\w+)\((.+)\)}}@sU', $code, $matches, PREG_SET_ORDER);


### PR DESCRIPTION
Documentation for:
- static useMonthsOverflow
- static resetMonthsOverflow
- static shouldOverflowMonths
- addMonthsWithOverflow
- addMonthWithOverflow
- addMonthsNoOverflow
- addMonthNoOverflow
- subMonthsWithOverflow
- subMonthWithOverflow
- subMonthsNoOverflow
- subMonthNoOverflow