### PR TITLE
Run TravisCI tests for gh-pages branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,11 @@ script:
 after_success:
   - if [[ $coverage = 'true' ]]; then bash <(curl -s https://codecov.io/bash); fi
 
+branches:
+  only:
+    - gh-pages
+    - /.*/
+
 matrix:
   include:
     - php: 5.3


### PR DESCRIPTION
Allow to run tests on the gh-pages branch, this will be used to count documented methods and fail the gh-pages branch build if a new method miss its documentation.