### PR TITLE
Removed date() and time() functions from Carbon::create()

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -428,7 +428,7 @@ class Carbon extends DateTime
      */
     public static function create($year = null, $month = null, $day = null, $hour = null, $minute = null, $second = null, $tz = null)
     {
-        $now = static::hasTestNow() ? static::getTestNow()->getTimestamp() : time();
+        $now = static::hasTestNow() ? static::getTestNow() : static::now($tz);
 
         $defaults = array_combine(array(
             'year',
@@ -437,7 +437,7 @@ class Carbon extends DateTime
             'hour',
             'minute',
             'second',
-        ), explode('-', date('Y-n-j-G-i-s', $now)));
+        ), explode('-', $now->format('Y-n-j-G-i-s')));
 
         $year = $year === null ? $defaults['year'] : $year;
         $month = $month === null ? $defaults['month'] : $month;

--- a/tests/Carbon/CreateFromTimeTest.php
+++ b/tests/Carbon/CreateFromTimeTest.php
@@ -71,4 +71,23 @@ class CreateFromTimeTest extends AbstractTestCase
         $this->assertCarbon($d, Carbon::now()->year, Carbon::now()->month, Carbon::now()->day, 12, 0, 0);
         $this->assertSame('Europe/London', $d->tzName);
     }
+
+    public function testCreateFromTime()
+    {
+        // disable test for now
+        // because we need Carbon::now() in Carbon::create() to work with given TZ
+        $test = Carbon::getTestNow();
+        Carbon::setTestNow();
+
+        $tz = 'Etc/GMT+12';
+        $now = Carbon::now($tz);
+        $dt = Carbon::createFromTime($now->hour, $now->minute, $now->second, $tz);
+
+        // reenable test
+        Carbon::setTestNow($test);
+
+        // tested without microseconds
+        // because they appear withing calls to Carbon
+        $this->assertEquals($now->format('c'), $dt->format('c'));
+    }
 }


### PR DESCRIPTION
These 2 functions should have no business doing Carbon library which uses supreme DateTime class.

They are also causing bugz when user enters other timezone than the one he has set globally. See issue https://github.com/briannesbitt/Carbon/issues/983.