### PR TITLE
Document getLocale

### DIFF
--- a/check.php
+++ b/check.php
@@ -1,6 +1,6 @@
 <?php
 
-define('MAXIMUM_MISSING_METHODS_THRESHOLD', 66);
+define('MAXIMUM_MISSING_METHODS_THRESHOLD', 58);
 
 require 'vendor/autoload.php';
 
@@ -17,7 +17,13 @@ function display($message) {
     echo $message;
 }
 
+$dateTimeMethods = get_class_methods(new \DateTime());
+
 foreach (get_class_methods(new \Carbon\Carbon()) as $method) {
+    if (in_array($method, $dateTimeMethods)) {
+        continue;
+    }
+
     $methodsCount++;
     $documented = strpos($documentation, $method) !== false;
     if (!$documented) {
@@ -25,8 +31,11 @@ foreach (get_class_methods(new \Carbon\Carbon()) as $method) {
     }
     $color = $documented ? 31 : 32;
     $message = $documented ? 'documented' : 'missing';
+    $method = str_pad($method, 25);
 
-    display("- $method \033[0;{$color}m{$message}\033[0m\n");
+    if (!$documented || !isset($argv[1]) || $argv[1] !== 'missing') {
+        display("- $method \033[0;{$color}m{$message}\033[0m\n");
+    }
 }
 
 display($missingMethodsCount ?

--- a/docs/index.html
+++ b/docs/index.html
@@ -114,13 +114,13 @@ echo Carbon::parse('first day of December 2008')->addWeeks(2);    // 2008-12-15 
 <p>To accompany <code>now()</code>, a few other static instantiation helpers exist to create widely known instances.  The only thing to really notice here is that <code>today()</code>, <code>tomorrow()</code> and <code>yesterday()</code>, besides behaving as expected, all accept a timezone parameter and each has their time value set to <code>00:00:00</code>.</p>
 
 <p><pre><code class="php">$now = Carbon::now();
-echo $now;                               // 2018-02-13 10:41:12
+echo $now;                               // 2018-02-14 09:36:52
 $today = Carbon::today();
-echo $today;                             // 2018-02-13 00:00:00
+echo $today;                             // 2018-02-14 00:00:00
 $tomorrow = Carbon::tomorrow('Europe/London');
-echo $tomorrow;                          // 2018-02-14 00:00:00
+echo $tomorrow;                          // 2018-02-15 00:00:00
 $yesterday = Carbon::yesterday();
-echo $yesterday;                         // 2018-02-12 00:00:00
+echo $yesterday;                         // 2018-02-13 00:00:00
 </code></pre></p>
 
 <p>The next group of static helpers are the <code>createXXX()</code> helpers. Most of the static <code>create</code> functions allow you to provide as many or as few arguments as you want and will provide default values for all others.  Generally default values are the current date, time or timezone.  Higher values will wrap appropriately but invalid values will throw an <code>InvalidArgumentException</code> with an informative message.  The message is obtained from an <a href="http://php.net/manual/en/datetime.getlasterrors.php">DateTime::getLastErrors()</a> call.</p>
@@ -191,7 +191,7 @@ echo Carbon::minValue();                               // '0001-01-01 00:00:00'
 
 <h1 id="api-localization">Localization</h1>
 
-<p>Unfortunately the base class DateTime does not have any localization support.  To begin localization support a <code>formatLocalized($format)</code> method was added.  The implementation makes a call to <a href="http://www.php.net/strftime">strftime</a> using the current instance timestamp.  If you first set the current locale with PHP function <a href="http://www.php.net/setlocale">setlocale()</a> then the string returned will be formatted in the correct locale.</p>
+<p>Unfortunately the base class DateTime does not have any localization support. To begin localization support a <code>formatLocalized($format)</code> method was added.  The implementation makes a call to <a href="http://www.php.net/strftime">strftime</a> using the current instance timestamp.  If you first set the current locale with PHP function <a href="http://www.php.net/setlocale">setlocale()</a> then the string returned will be formatted in the correct locale.</p>
 
 <p><pre><code class="php">setlocale(LC_TIME, 'German');
 echo $dt->formatLocalized('%A %d %B %Y');          // Mittwoch 21 Mai 1975
@@ -200,12 +200,14 @@ echo $dt->formatLocalized('%A %d %B %Y');          // Wednesday 21 May 1975
 setlocale(LC_TIME, ''); // reset locale
 </code></pre></p>
 
-<p><code>diffForHumans()</code> has also been localized.  You can set the Carbon locale by using the static <code>Carbon::setLocale()</code> function.</p>
+<p><code>diffForHumans()</code> has also been localized. You can set the Carbon locale by using the static <code>Carbon::setLocale()</code> function and get the current setting with <code>Carbon::getLocale()</code>.</p>
 
 <p><pre><code class="php">Carbon::setLocale('de');
+echo Carbon::getLocale();                          // de
 echo Carbon::now()->addYear()->diffForHumans();    // in 1 Jahr
 
 Carbon::setLocale('en');
+echo Carbon::getLocale();                          // en
 </code></pre></p>
 
 <blockquote><p><strong>on Linux</strong><br>
@@ -235,7 +237,7 @@ echo Carbon::parse('now');                             // 2001-05-21 12:00:00
 var_dump(Carbon::hasTestNow());                        // bool(true)
 Carbon::setTestNow();                                  // clear the mock
 var_dump(Carbon::hasTestNow());                        // bool(false)
-echo Carbon::now();                                    // 2018-02-13 10:41:12
+echo Carbon::now();                                    // 2018-02-14 09:36:52
 </code></pre></p>
 
 <p>A more meaning full example:</p>
@@ -496,7 +498,7 @@ echo $dt1->max($dt2);                              // 2014-01-30 00:00:00
 
 // now is the default param
 $dt1 = Carbon::create(2000, 1, 1, 0, 0, 0);
-echo $dt1->max();                                  // 2018-02-13 10:41:12
+echo $dt1->max();                                  // 2018-02-14 09:36:52
 </code></pre></p>
 
 <p>To handle the most used cases there are some simple helper functions that hopefully are obvious from their names.  For the methods that compare to <code>now()</code> (ex. isToday()) in some manner the <code>now()</code> is created in the same timezone as the instance.</p>

--- a/docs/index.src.html
+++ b/docs/index.src.html
@@ -144,7 +144,7 @@ $noonLondonTz = Carbon::createFromTime(12, 0, 0, 'Europe/London');
 
 <h1 id="api-localization">Localization</h1>
 
-<p>Unfortunately the base class DateTime does not have any localization support.  To begin localization support a <code>formatLocalized($format)</code> method was added.  The implementation makes a call to <a href="http://www.php.net/strftime">strftime</a> using the current instance timestamp.  If you first set the current locale with PHP function <a href="http://www.php.net/setlocale">setlocale()</a> then the string returned will be formatted in the correct locale.</p>
+<p>Unfortunately the base class DateTime does not have any localization support. To begin localization support a <code>formatLocalized($format)</code> method was added.  The implementation makes a call to <a href="http://www.php.net/strftime">strftime</a> using the current instance timestamp.  If you first set the current locale with PHP function <a href="http://www.php.net/setlocale">setlocale()</a> then the string returned will be formatted in the correct locale.</p>
 
 <p><pre><code class="php">{{::lint(setlocale(LC_TIME, 'German');)}}
 {{locale1::exec(echo $dt->formatLocalized('%A %d %B %Y');/*pad(50)*/)}} // {{locale1_eval}}
@@ -153,12 +153,14 @@ $noonLondonTz = Carbon::createFromTime(12, 0, 0, 'Europe/London');
 {{::lint(setlocale(LC_TIME, ''); // reset locale)}}
 </code></pre></p>
 
-<p><code>diffForHumans()</code> has also been localized.  You can set the Carbon locale by using the static <code>Carbon::setLocale()</code> function.</p>
+<p><code>diffForHumans()</code> has also been localized. You can set the Carbon locale by using the static <code>Carbon::setLocale()</code> function and get the current setting with <code>Carbon::getLocale()</code>.</p>
 
 <p><pre><code class="php">{{::lint(Carbon::setLocale('de');)}}
+{{getlocale1::exec(echo Carbon::getLocale();/*pad(50)*/)}} // {{getlocale1_eval}}
 {{locale3::exec(echo Carbon::now()->addYear()->diffForHumans();/*pad(50)*/)}} // {{locale3_eval}}
 
 {{::lint(Carbon::setLocale('en');)}}
+{{getlocale2::exec(echo Carbon::getLocale();/*pad(50)*/)}} // {{getlocale2_eval}}
 </code></pre></p>
 
 <blockquote><p><strong>on Linux</strong><br>


### PR DESCRIPTION
- Document getLocale
- Cleanup spaces
- Remove native DateTime methods from the check command