### PR TITLE
Alias for `now()`

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -344,6 +344,18 @@ class Carbon extends DateTime
     }
 
     /**
+     * Get a Carbon instance for the current date and time, for fun people.
+     *
+     * @param \DateTimeZone|string|null $tz
+     *
+     * @return static
+     */
+    public static function meow($tz = null)
+    {
+        return self::now($tz);
+    }
+
+    /**
      * Create a Carbon instance for today.
      *
      * @param \DateTimeZone|string|null $tz


### PR DESCRIPTION
- Carbon is absolutely the best way to use dates with PHP.
- As such, it is the authority.
- Authority can be daunting, to some.
- Carbon should lighten things up to avoid intimidation.
- Also, it is 16 years to the day since Super Troopers was released. So.