### PR TITLE
Fixed bug $parts parameter is ignored

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -2861,7 +2861,7 @@ class Carbon extends DateTime
                     // get the count days excluding weeks (might be zero)
                     $numOfDaysCount = (int) ($diffIntervalData['value'] - ($count * static::DAYS_PER_WEEK));
 
-                    if ($numOfDaysCount > 0) {
+                    if ($numOfDaysCount > 0 && count($interval) < $parts) {
                         $unit = $short ? 'd' : 'day';
                         $count = $numOfDaysCount;
                         $interval[] = static::translator()->transChoice($unit, $count, array(':count' => $count));

--- a/tests/Carbon/DiffTest.php
+++ b/tests/Carbon/DiffTest.php
@@ -918,6 +918,30 @@ class DiffTest extends AbstractTestCase
         });
     }
 
+    public function testDiffForHumansOverWeekWithDefaultPartsCount()
+    {
+        $scope = $this;
+        $this->wrapWithTestNow(function () use ($scope) {
+            $scope->assertSame('1 week ago', Carbon::now()->subDays(8)->diffForHumans());
+        });
+    }
+
+    public function testDiffForHumansOverWeekWithPartsCount1()
+    {
+        $scope = $this;
+        $this->wrapWithTestNow(function () use ($scope) {
+            $scope->assertSame('1 week ago', Carbon::now()->subDays(8)->diffForHumans(null, false, false, 1));
+        });
+    }
+
+    public function testDiffForHumansOverWeekWithPartsCount2()
+    {
+        $scope = $this;
+        $this->wrapWithTestNow(function () use ($scope) {
+            $scope->assertSame('1 week 1 day ago', Carbon::now()->subDays(8)->diffForHumans(null, false, false, 2));
+        });
+    }
+
     public function testDiffForHumansOtherAndWeek()
     {
         $scope = $this;


### PR DESCRIPTION
diffForHumans() $parts parameter is ignored when injecting the remaining days after subtracting weeks.  Added test to confirm.