### PR TITLE
Methods `isSame**()` should also accept \DateTime objects.

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -15,6 +15,7 @@ use Carbon\Exceptions\InvalidDateException;
 use Closure;
 use DatePeriod;
 use DateTime;
+use DateTimeInterface;
 use DateTimeZone;
 use InvalidArgumentException;
 use Symfony\Component\Translation\Loader\ArrayLoader;
@@ -1839,14 +1840,20 @@ class Carbon extends DateTime
     /**
      * Compares the formatted values of the two dates.
      *
-     * @param string                        $format The date formats to compare.
-     * @param \Carbon\Carbon|\DateTime|null $dt     The instance to compare with or null to use current day.
+     * @param string                                 $format The date formats to compare.
+     * @param \Carbon\Carbon|\DateTimeInterface|null $dt     The instance to compare with or null to use current day.
+     *
+     * @throws \InvalidArgumentException
      *
      * @return bool
      */
     public function isSameAs($format, $dt = null)
     {
         $dt = $dt ?: static::now($this->tz);
+
+        if (!($dt instanceof DateTime) && !($dt instanceof DateTimeInterface)) {
+            throw new InvalidArgumentException('Expected DateTime (or instanceof) object as argument.');
+        }
 
         return $this->format($format) === $dt->format($format);
     }
@@ -1864,7 +1871,7 @@ class Carbon extends DateTime
     /**
      * Checks if the passed in date is in the same year as the instance year.
      *
-     * @param \Carbon\Carbon|\DateTime|null $dt The instance to compare with or null to use current day.
+     * @param \Carbon\Carbon|\DateTimeInterface|null $dt The instance to compare with or null to use current day.
      *
      * @return bool
      */
@@ -1886,22 +1893,20 @@ class Carbon extends DateTime
     /**
      * Checks if the passed in date is in the same month as the instance month (and year if needed).
      *
-     * @param \Carbon\Carbon|\DateTime|null $dt         The instance to compare with or null to use current day.
-     * @param bool                          $ofSameYear Check if it is the same month in the same year.
+     * @param \Carbon\Carbon|\DateTimeInterface|null $dt         The instance to compare with or null to use current day.
+     * @param bool                                   $ofSameYear Check if it is the same month in the same year.
      *
      * @return bool
      */
     public function isSameMonth($dt = null, $ofSameYear = false)
     {
-        $format = $ofSameYear ? 'Y-m' : 'm';
-
-        return $this->isSameAs($format, $dt);
+        return $this->isSameAs($ofSameYear ? 'Y-m' : 'm', $dt);
     }
 
     /**
      * Checks if the passed in date is the same day as the instance current day.
      *
-     * @param \Carbon\Carbon|\DateTime $dt
+     * @param \Carbon\Carbon|\DateTimeInterface $dt
      *
      * @return bool
      */
@@ -3350,11 +3355,11 @@ class Carbon extends DateTime
     /**
      * Check if its the birthday. Compares the date/month values of the two dates.
      *
-     * @param \Carbon\Carbon|null $dt The instance to compare with or null to use current day.
+     * @param \Carbon\Carbon|\DateTimeInterface|null $dt The instance to compare with or null to use current day.
      *
      * @return bool
      */
-    public function isBirthday(self $dt = null)
+    public function isBirthday($dt = null)
     {
         return $this->isSameAs('md', $dt);
     }

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1839,12 +1839,12 @@ class Carbon extends DateTime
     /**
      * Compares the formatted values of the two dates.
      *
-     * @param string              $format The date formats to compare.
-     * @param \Carbon\Carbon|null $dt     The instance to compare with or null to use current day.
+     * @param string                        $format The date formats to compare.
+     * @param \Carbon\Carbon|\DateTime|null $dt     The instance to compare with or null to use current day.
      *
      * @return bool
      */
-    public function isSameAs($format, self $dt = null)
+    public function isSameAs($format, $dt = null)
     {
         $dt = $dt ?: static::now($this->tz);
 
@@ -1864,11 +1864,11 @@ class Carbon extends DateTime
     /**
      * Checks if the passed in date is in the same year as the instance year.
      *
-     * @param \Carbon\Carbon|null $dt The instance to compare with or null to use current day.
+     * @param \Carbon\Carbon|\DateTime|null $dt The instance to compare with or null to use current day.
      *
      * @return bool
      */
-    public function isSameYear(self $dt = null)
+    public function isSameYear($dt = null)
     {
         return $this->isSameAs('Y', $dt);
     }
@@ -1886,12 +1886,12 @@ class Carbon extends DateTime
     /**
      * Checks if the passed in date is in the same month as the instance month (and year if needed).
      *
-     * @param \Carbon\Carbon|null $dt         The instance to compare with or null to use current day.
-     * @param bool                $ofSameYear Check if it is the same month in the same year.
+     * @param \Carbon\Carbon|\DateTime|null $dt         The instance to compare with or null to use current day.
+     * @param bool                          $ofSameYear Check if it is the same month in the same year.
      *
      * @return bool
      */
-    public function isSameMonth(self $dt = null, $ofSameYear = false)
+    public function isSameMonth($dt = null, $ofSameYear = false)
     {
         $format = $ofSameYear ? 'Y-m' : 'm';
 
@@ -1901,13 +1901,13 @@ class Carbon extends DateTime
     /**
      * Checks if the passed in date is the same day as the instance current day.
      *
-     * @param \Carbon\Carbon $dt
+     * @param \Carbon\Carbon|\DateTime $dt
      *
      * @return bool
      */
-    public function isSameDay(self $dt)
+    public function isSameDay($dt)
     {
-        return $this->toDateString() === $dt->toDateString();
+        return $this->isSameAs('Y-m-d', $dt);
     }
 
     /**

--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -11,6 +11,7 @@
 
 namespace Tests\Carbon;
 
+use \DateTime;
 use Carbon\Carbon;
 use Tests\AbstractTestCase;
 
@@ -225,9 +226,21 @@ class IsTest extends AbstractTestCase
         $this->assertTrue(Carbon::now()->isSameMonth(Carbon::now()));
     }
 
+    public function testIsSameMonthTrueWithDateTime()
+    {
+        $this->assertTrue(Carbon::now()->isSameMonth(new DateTime()));
+    }
+
     public function testIsSameMonthFalse()
     {
         $this->assertFalse(Carbon::now()->isSameMonth(Carbon::now()->subMonth()));
+    }
+
+    public function testIsSameMonthFalseWithDateTime()
+    {
+        $dt = new DateTime();
+        $dt->modify('-1 month');
+        $this->assertFalse(Carbon::now()->isSameMonth($dt));
     }
 
     public function testIsSameMonthAndYearTrue()
@@ -235,9 +248,21 @@ class IsTest extends AbstractTestCase
         $this->assertTrue(Carbon::now()->isSameMonth(Carbon::now(), true));
     }
 
+    public function testIsSameMonthAndYearTrueWithDateTime()
+    {
+        $this->assertTrue(Carbon::now()->isSameMonth(new DateTime(), true));
+    }
+
     public function testIsSameMonthAndYearFalse()
     {
         $this->assertFalse(Carbon::now()->isSameMonth(Carbon::now()->subYear(), true));
+    }
+
+    public function testIsSameMonthAndYearFalseWithDateTime()
+    {
+        $dt = new DateTime();
+        $dt->modify('-1 year');
+        $this->assertFalse(Carbon::now()->isSameMonth($dt, true));
     }
 
     public function testIsSameDayTrue()
@@ -246,10 +271,22 @@ class IsTest extends AbstractTestCase
         $this->assertTrue($current->isSameDay(Carbon::createFromDate(2012, 1, 2)));
     }
 
+    public function T_testIsSameDayTrueWithDateTime()
+    {
+        $current = Carbon::createFromDate(2012, 1, 2);
+        $this->assertTrue($current->isSameDay(new DateTime('2012-01-02')));
+    }
+
     public function testIsSameDayFalse()
     {
         $current = Carbon::createFromDate(2012, 1, 2);
         $this->assertFalse($current->isSameDay(Carbon::createFromDate(2012, 1, 3)));
+    }
+
+    public function testIsSameDayFalseWithDateTime()
+    {
+        $current = Carbon::createFromDate(2012, 1, 2);
+        $this->assertFalse($current->isSameDay(new DateTime('2012-01-03')));
     }
 
     public function testIsSunday()

--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -289,6 +289,21 @@ class IsTest extends AbstractTestCase
         $this->assertFalse($current->isSameDay(new DateTime('2012-01-03')));
     }
 
+    public function testIsSameAs()
+    {
+        $current = Carbon::createFromDate(2012, 1, 2);
+        $this->assertTrue($current->isSameAs('c', $current));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testIsSameAsWithInvalidArgument()
+    {
+        $current = Carbon::createFromDate(2012, 1, 2);
+        $current->isSameAs('Y-m-d', 'abc');
+    }
+
     public function testIsSunday()
     {
         // True in the past past


### PR DESCRIPTION
Issue #974.