### PR TITLE
Test diff in hours with timezones

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -548,6 +548,21 @@ class Carbon extends DateTime
     }
 
     /**
+     * Create a Carbon instance from just a date. The time portion is set to midnight.
+     *
+     * @param int|null                  $year
+     * @param int|null                  $month
+     * @param int|null                  $day
+     * @param \DateTimeZone|string|null $tz
+     *
+     * @return static
+     */
+    public static function createMidnightDate($year = null, $month = null, $day = null, $tz = null)
+    {
+        return static::create($year, $month, $day, 0, 0, 0, $tz);
+    }
+
+    /**
      * Create a Carbon instance from just a time. The date portion is set to today.
      *
      * @param int|null                  $hour

--- a/tests/Carbon/DiffTest.php
+++ b/tests/Carbon/DiffTest.php
@@ -407,6 +407,11 @@ class DiffTest extends AbstractTestCase
         $dtVancouver = Carbon::createFromDate(2012, 1, 1, 'America/Vancouver');
 
         $this->assertSame(0, $dtVancouver->diffInHours($dtToronto) % 24);
+
+        $dtToronto = Carbon::createMidnightDate(2012, 1, 1, 'America/Toronto');
+        $dtVancouver = Carbon::createMidnightDate(2012, 1, 1, 'America/Vancouver');
+
+        $this->assertSame(3, $dtVancouver->diffInHours($dtToronto), 'Midnight in Toronto is 3 hours from midnight in Vancouver');
     }
 
     public function testDiffInMinutesPositive()

--- a/tests/Carbon/DiffTest.php
+++ b/tests/Carbon/DiffTest.php
@@ -395,6 +395,20 @@ class DiffTest extends AbstractTestCase
         $this->assertSame(1, $dt->diffInHours($dt->copy()->addHour()->addMinutes(31)));
     }
 
+    public function testDiffInHoursWithTimezones()
+    {
+        Carbon::setTestNow();
+        $dtToronto = Carbon::create(2012, 1, 1, 0, 0, 0, 'America/Toronto');
+        $dtVancouver = Carbon::create(2012, 1, 1, 0, 0, 0, 'America/Vancouver');
+
+        $this->assertSame(3, $dtVancouver->diffInHours($dtToronto), 'Midnight in Toronto is 3 hours from midnight in Vancouver');
+
+        $dtToronto = Carbon::createFromDate(2012, 1, 1, 'America/Toronto');
+        $dtVancouver = Carbon::createFromDate(2012, 1, 1, 'America/Vancouver');
+
+        $this->assertSame(0, $dtVancouver->diffInHours($dtToronto) % 24);
+    }
+
     public function testDiffInMinutesPositive()
     {
         $dt = Carbon::createFromDate(2000, 1, 1);


### PR DESCRIPTION
After #1091, createFromDate with different timezones will no longer have a gap.

Meaning that this code:
```php
Carbon::createFromDate(2012, 1, 1, 'America/Toronto')->diffInHours(
  Carbon::createFromDate(2012, 1, 1, 'America/Vancouver')
)
```
Returned 3 before #1091 and will return 0 or 24 after #1091 depending on the current time.

That is more correct in my opinion but as the consequences of the mix `Input Date` + `Current time` + `Input Timezone` can be unexpected, that's why I propose to add, document and promote a `createMidnightDate` method that would be `Input Date` + `00:00:00` + `Input Timezone`, this way there is no dynamic unknow part in the produced Carbon instance, and the following code would return `3`:
```php
Carbon::createMidnightDate(2012, 1, 1, 'America/Toronto')->diffInHours(
  Carbon::createMidnightDate(2012, 1, 1, 'America/Vancouver')
)
```

And this method should be the one we recommend to use in the doc to create a date (creating it by default to midnight) and createFromDate should be used only by users that really understand they create a date with the current time.