### PR TITLE
Fix #1073 Handle microseconds for locales with coma decimal separator

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -297,7 +297,15 @@ class Carbon extends DateTime
             $time = $testInstance->format(static::MOCK_DATETIME_FORMAT);
         }
 
+        // Work-around for PHP bug https://bugs.php.net/bug.php?id=67127
+        if (strpos((string) .1, '.') === false) {
+            $locale = setlocale(LC_NUMERIC, '0');
+            setlocale(LC_NUMERIC, 'C');
+        }
         parent::__construct($time, static::safeCreateDateTimeZone($tz));
+        if (isset($locale)) {
+            setlocale(LC_NUMERIC, $locale);
+        }
         static::setLastErrors(parent::getLastErrors());
     }
 
@@ -639,7 +647,7 @@ class Carbon extends DateTime
     public static function createFromTimestampMs($timestamp, $tz = null)
     {
         return static::createFromFormat('U.u', sprintf('%F', $timestamp / 1000))
-            ->setTimezone(static::safeCreateDateTimeZone($tz));
+            ->setTimezone($tz);
     }
 
     /**
@@ -2581,18 +2589,6 @@ class Carbon extends DateTime
     }
 
     /**
-     * Remove a second from the instance
-     *
-     * @param int $value
-     *
-     * @return static
-     */
-    public function subSecond($value = 1)
-    {
-        return $this->subSeconds($value);
-    }
-
-    /**
      * Remove seconds from the instance
      *
      * @param int $value
@@ -2602,6 +2598,18 @@ class Carbon extends DateTime
     public function subSeconds($value)
     {
         return $this->addSeconds(-1 * $value);
+    }
+
+    /**
+     * Remove a second from the instance
+     *
+     * @param int $value
+     *
+     * @return static
+     */
+    public function subSecond($value = 1)
+    {
+        return $this->subSeconds($value);
     }
 
     ///////////////////////////////////////////////////////////////////

--- a/tests/Carbon/CreateFromTimestampTest.php
+++ b/tests/Carbon/CreateFromTimestampTest.php
@@ -30,6 +30,36 @@ class CreateFromTimestampTest extends AbstractTestCase
         $this->assertCarbon($d, 1975, 5, 21, 22, 32, 5, 321000);
     }
 
+    public function testComaDecimalSeparatorLocale()
+    {
+        $date = new Carbon('2017-07-29T13:57:27.123456Z');
+        $this->assertSame('2017-07-29 13:57:27.123456 Z', $date->format('Y-m-d H:i:s.u e'));
+
+        $date = Carbon::createFromFormat('Y-m-d\TH:i:s.uT', '2017-07-29T13:57:27.123456Z');
+        $this->assertSame('2017-07-29 13:57:27.123456 Z', $date->format('Y-m-d H:i:s.u e'));
+        $timestamp = Carbon::create(1975, 5, 21, 22, 32, 5)->timestamp * 1000 + 321;
+        $d = Carbon::createFromTimestampMs($timestamp);
+        $this->assertCarbon($d, 1975, 5, 21, 22, 32, 5, 321000);
+
+        $locale = setlocale(LC_ALL, '0');
+        setlocale(LC_ALL, 'fr_FR.UTF-8');
+
+        $timestamp = Carbon::create(1975, 5, 21, 22, 32, 5)->timestamp * 1000 + 321;
+        $d = Carbon::createFromTimestampMs($timestamp);
+        $this->assertCarbon($d, 1975, 5, 21, 22, 32, 5, 321000);
+
+        $date = new Carbon('2017-07-29T13:57:27.123456Z');
+        $this->assertSame('2017-07-29 13:57:27.123456 Z', $date->format('Y-m-d H:i:s.u e'));
+
+        $date = Carbon::createFromFormat('Y-m-d\TH:i:s.uT', '2017-07-29T13:57:27.123456Z');
+        $this->assertSame('2017-07-29 13:57:27.123456 Z', $date->format('Y-m-d H:i:s.u e'));
+        $timestamp = Carbon::create(1975, 5, 21, 22, 32, 5)->timestamp * 1000 + 321;
+        $d = Carbon::createFromTimestampMs($timestamp);
+        $this->assertCarbon($d, 1975, 5, 21, 22, 32, 5, 321000);
+
+        setlocale(LC_ALL, $locale);
+    }
+
     public function testCreateFromTimestampUsesDefaultTimezone()
     {
         $d = Carbon::createFromTimestamp(0);


### PR DESCRIPTION
Work-around for bug https://bugs.php.net/bug.php?id=67127