### PR TITLE
Do a complete check (date, DST, etc.) in createSafe

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -570,6 +570,8 @@ class Carbon extends DateTime
      * @param int|null                  $second
      * @param \DateTimeZone|string|null $tz
      *
+     * @throws \InvalidArgumentException
+     *
      * @return static
      */
     public static function create($year = null, $month = null, $day = null, $hour = null, $minute = null, $second = null, $tz = null)
@@ -640,7 +642,7 @@ class Carbon extends DateTime
      * @param int|null                  $second
      * @param \DateTimeZone|string|null $tz
      *
-     * @throws \Carbon\Exceptions\InvalidDateException
+     * @throws \Carbon\Exceptions\InvalidDateException|\InvalidArgumentException
      *
      * @return static
      */
@@ -680,6 +682,8 @@ class Carbon extends DateTime
      * @param int|null                  $day
      * @param \DateTimeZone|string|null $tz
      *
+     * @throws \InvalidArgumentException
+     *
      * @return static
      */
     public static function createFromDate($year = null, $month = null, $day = null, $tz = null)
@@ -709,6 +713,8 @@ class Carbon extends DateTime
      * @param int|null                  $minute
      * @param int|null                  $second
      * @param \DateTimeZone|string|null $tz
+     *
+     * @throws \InvalidArgumentException
      *
      * @return static
      */

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -661,13 +661,15 @@ class Carbon extends DateTime
             }
         }
 
-        $instance = static::create($year, $month, 1, $hour, $minute, $second, $tz);
+        $instance = static::create($year, $month, $day, $hour, $minute, $second, $tz);
 
-        if ($day !== null && $day > $instance->daysInMonth) {
-            throw new InvalidDateException('day', $day);
+        foreach (array_reverse($fields) as $field => $range) {
+            if ($$field !== null && (!is_int($$field) || $$field !== $instance->$field)) {
+                throw new InvalidDateException($field, $$field);
+            }
         }
 
-        return $instance->day($day);
+        return $instance;
     }
 
     /**

--- a/tests/Carbon/CreateSafeTest.php
+++ b/tests/Carbon/CreateSafeTest.php
@@ -172,6 +172,24 @@ class CreateSafeTest extends AbstractTestCase
 
     /**
      * @expectedException \Carbon\Exceptions\InvalidDateException
+     * @expectedExceptionMessage hour : 1 is not a valid value.
+     */
+    public function testCreateSafePassesForFebruaryInInvalidDSTTime()
+    {
+        // 1h jumped to 2h because of the DST, so 1h30 is not a safe date
+        Carbon::createSafe(2014, 3, 30, 1, 30, 0, 'Europe/London');
+    }
+
+    public function testCreateSafePassesForFebruaryInValidDSTTime()
+    {
+        // 28 days in February for a non-leap year
+        Carbon::createSafe(2014, 3, 30, 0, 30, 0, 'Europe/London');
+        Carbon::createSafe(2014, 3, 30, 2, 30, 0, 'Europe/London');
+        Carbon::createSafe(2014, 3, 30, 1, 30, 0, 'UTC');
+    }
+
+    /**
+     * @expectedException \Carbon\Exceptions\InvalidDateException
      * @expectedExceptionMessage second : 15.1 is not a valid value.
      */
     public function testCreateSafeThrowsExceptionForWithNonIntegerValue()

--- a/tests/Carbon/CreateSafeTest.php
+++ b/tests/Carbon/CreateSafeTest.php
@@ -170,19 +170,23 @@ class CreateSafeTest extends AbstractTestCase
         Carbon::createSafe(2015, 2, 29, 17, 16, 15);
     }
 
-    /**
-     * @expectedException \Carbon\Exceptions\InvalidDateException
-     * @expectedExceptionMessage hour : 1 is not a valid value.
-     */
-    public function testCreateSafePassesForFebruaryInInvalidDSTTime()
+    public function testCreateSafePassesForInvalidDSTTime()
     {
-        // 1h jumped to 2h because of the DST, so 1h30 is not a safe date
-        Carbon::createSafe(2014, 3, 30, 1, 30, 0, 'Europe/London');
+        $message = '';
+        try {
+            // 1h jumped to 2h because of the DST, so 1h30 is not a safe date in PHP 5.4+
+            $date = Carbon::createSafe(2014, 3, 30, 1, 30, 0, 'Europe/London');
+        } catch (\Carbon\Exceptions\InvalidDateException $exception) {
+            $message = $exception->getMessage();
+        }
+
+        version_compare(PHP_VERSION, '5.4.0-dev', '<')
+            ? $this->assertCarbon($date, 2014, 3, 30, 1, 30, 0)
+            : $this->assertContains('hour : 1 is not a valid value.', $message);
     }
 
-    public function testCreateSafePassesForFebruaryInValidDSTTime()
+    public function testCreateSafePassesForValidDSTTime()
     {
-        // 28 days in February for a non-leap year
         Carbon::createSafe(2014, 3, 30, 0, 30, 0, 'Europe/London');
         Carbon::createSafe(2014, 3, 30, 2, 30, 0, 'Europe/London');
         Carbon::createSafe(2014, 3, 30, 1, 30, 0, 'UTC');

--- a/tests/Carbon/CreateSafeTest.php
+++ b/tests/Carbon/CreateSafeTest.php
@@ -173,6 +173,7 @@ class CreateSafeTest extends AbstractTestCase
     public function testCreateSafePassesForInvalidDSTTime()
     {
         $message = '';
+        $date = null;
         try {
             // 1h jumped to 2h because of the DST, so 1h30 is not a safe date in PHP 5.4+
             $date = Carbon::createSafe(2014, 3, 30, 1, 30, 0, 'Europe/London');

--- a/tests/Carbon/PhpBug72338Test.php
+++ b/tests/Carbon/PhpBug72338Test.php
@@ -36,7 +36,7 @@ class PhpBug72338Test extends AbstractTestCase
 
         // In versions <= 5.5.5 setTimezone doesn't accept timezone in 'HH:MM' format.
         // I dont know about versions between 5.5.5 and 5.5.18, but 5.5.18 accept it.
-        if (version_compare(PHP_VERSION, '5.5.18', '<')) {
+        if (version_compare(PHP_VERSION, '5.5.18-dev', '<')) {
             $this->markTestSkipped();
         }
     }

--- a/tests/Carbon/SerializationTest.php
+++ b/tests/Carbon/SerializationTest.php
@@ -25,7 +25,7 @@ class SerializationTest extends AbstractTestCase
     {
         parent::setUp();
 
-        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+        if (version_compare(PHP_VERSION, '5.4.0-dev', '<')) {
             $this->serialized = 'O:13:"Carbon\Carbon":3:{s:4:"date";s:19:"2016-02-01 13:20:25";s:13:"timezone_type";i:3;s:8:"timezone";s:15:"America/Toronto";}';
         } else {
             $this->serialized = 'O:13:"Carbon\Carbon":3:{s:4:"date";s:26:"2016-02-01 13:20:25.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:15:"America/Toronto";}';


### PR DESCRIPTION
- Handle bad DST dates
- Avoid to modify twice the date
- Do a complete check of input values against created values