### PR TITLE
Use a real relativity test instead of a RegExp detection

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1321,11 +1321,6 @@ class Carbon extends DateTime
      */
     public static function hasRelativeKeywords($time)
     {
-        // skip common format with a '-' in it
-        if (preg_match('/\d{4}-\d{1,2}-\d{1,2}/', $time) === 1) {
-            return false;
-        }
-
         // looks for years within dates
         if (preg_match('/\d{4}/', $time) === 1) {
             return false;

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -81,46 +81,6 @@ class Carbon extends DateTime
     );
 
     /**
-     * Terms used to detect if a time passed is a relative date.
-     *
-     * This is here for testing purposes.
-     *
-     * @var array
-     */
-    protected static $relativeKeywords = array(
-        '+',
-        '-',
-        'ago',
-        'first',
-        'last',
-        'next',
-        'this',
-        'today',
-        'tomorrow',
-        'yesterday',
-
-        'sunday',
-        'monday',
-        'tuesday',
-        'wednesday',
-        'thursday',
-        'friday',
-        'saturday',
-
-        'january',
-        'february',
-        'march',
-        'april',
-        'may',
-        'june',
-        'july',
-        'august',
-        'september',
-        'october',
-        'december',
-    );
-
-    /**
      * Number of X in Y.
      */
     const YEARS_PER_CENTURY = 100;
@@ -410,9 +370,9 @@ class Carbon extends DateTime
         // If the class has a test now set and we are trying to create a now()
         // instance then override as required
         $isNow = empty($time) || $time === 'now';
-        if (static::hasTestNow() && ($isNow || static::isRelativeTimeString($time))) {
+        if (static::hasTestNow() && ($isNow || static::hasRelativeKeywords($time))) {
             $testInstance = clone static::getTestNow();
-            if (static::isRelativeTimeString($time)) {
+            if (static::hasRelativeKeywords($time)) {
                 $testInstance->modify($time);
             }
 
@@ -1310,39 +1270,13 @@ class Carbon extends DateTime
     }
 
     /**
-     * @obsolete You're recommended to use isRelativeTimeString instead.
-     *
-     * Determine if there is a relative keyword in the time string, this is to
-     * create dates relative to now for test instances. e.g.: next tuesday
-     *
-     * @param string $time
-     *
-     * @return bool true if there is a keyword, otherwise false
-     */
-    public static function hasRelativeKeywords($time)
-    {
-        // looks for years within dates
-        if (preg_match('/\d{4}/', $time) === 1) {
-            return false;
-        }
-
-        foreach (static::$relativeKeywords as $keyword) {
-            if (stripos($time, $keyword) !== false) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
      * Determine if a time string will produce a relative date.
      *
      * @param string $time
      *
      * @return bool true if time match a relative date, false if absolute or invalid time string
      */
-    public static function isRelativeTimeString($time)
+    public static function hasRelativeKeywords($time)
     {
         if (strtotime($time) === false) {
             return false;

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -410,9 +410,9 @@ class Carbon extends DateTime
         // If the class has a test now set and we are trying to create a now()
         // instance then override as required
         $isNow = empty($time) || $time === 'now';
-        if (static::hasTestNow() && ($isNow || static::hasRelativeKeywords($time))) {
+        if (static::hasTestNow() && ($isNow || static::isRelativeTimeString($time))) {
             $testInstance = clone static::getTestNow();
-            if (static::hasRelativeKeywords($time)) {
+            if (static::isRelativeTimeString($time)) {
                 $testInstance->modify($time);
             }
 
@@ -1310,6 +1310,8 @@ class Carbon extends DateTime
     }
 
     /**
+     * @obsolete You're recommended to use isRelativeTimeString instead.
+     *
      * Determine if there is a relative keyword in the time string, this is to
      * create dates relative to now for test instances. e.g.: next tuesday
      *
@@ -1336,6 +1338,27 @@ class Carbon extends DateTime
         }
 
         return false;
+    }
+
+    /**
+     * Determine if a time string will produce a relative date.
+     *
+     * @param string $time
+     *
+     * @return bool true if time match a relative date, false if absolute or invalid time string
+     */
+    public static function isRelativeTimeString($time)
+    {
+        if (strtotime($time) === false) {
+            return false;
+        }
+
+        $date1 = new DateTime('2000-01-01T00:00:00Z');
+        $date1->modify($time);
+        $date2 = new DateTime('2001-12-25T00:00:00Z');
+        $date2->modify($time);
+
+        return $date1 != $date2;
     }
 
     ///////////////////////////////////////////////////////////////////

--- a/tests/Carbon/LastErrorTest.php
+++ b/tests/Carbon/LastErrorTest.php
@@ -60,13 +60,4 @@ class LastErrorTest extends AbstractTestCase
         $this->assertSame($this->noErrors, $carbon->getLastErrors());
         $this->assertSame($carbon->getLastErrors(), $datetime->getLastErrors());
     }
-
-    public function testCreateLastErrors()
-    {
-        $carbon = new Carbon('2017-02-30');
-        $this->assertSame($this->lastErrors, $carbon->getLastErrors());
-
-        $carbon = new Carbon('2017-02-15');
-        $this->assertSame($this->noErrors, $carbon->getLastErrors());
-    }
 }

--- a/tests/Carbon/TestingAidsTest.php
+++ b/tests/Carbon/TestingAidsTest.php
@@ -114,6 +114,28 @@ class TestingAidsTest extends AbstractTestCase
         }, $testNow);
     }
 
+    public function testHasRelativeKeywords()
+    {
+        $this->assertFalse(Carbon::hasRelativeKeywords('sunday 2015-02-23'));
+        $this->assertFalse(Carbon::hasRelativeKeywords('today +2014 days'));
+        $this->assertFalse(Carbon::hasRelativeKeywords('next sunday -3600 seconds'));
+        $this->assertTrue(Carbon::hasRelativeKeywords('last day of this month'));
+        $this->assertFalse(Carbon::hasRelativeKeywords('last day of december 2015'));
+        $this->assertTrue(Carbon::hasRelativeKeywords('first sunday of next month'));
+        $this->assertFalse(Carbon::hasRelativeKeywords('first sunday of January 2017'));
+    }
+
+    public function testIsRelativeTimeString()
+    {
+        $this->assertFalse(Carbon::isRelativeTimeString('sunday 2015-02-23'));
+        $this->assertTrue(Carbon::isRelativeTimeString('today +2014 days'));
+        $this->assertTrue(Carbon::isRelativeTimeString('next sunday -3600 seconds'));
+        $this->assertTrue(Carbon::isRelativeTimeString('last day of this month'));
+        $this->assertFalse(Carbon::isRelativeTimeString('last day of last month of 2015'));
+        $this->assertTrue(Carbon::isRelativeTimeString('first sunday of next month'));
+        $this->assertFalse(Carbon::isRelativeTimeString('first sunday of January 2017'));
+    }
+
     public function testParseRelativeWithMinusSignsInDate()
     {
         $testNow = Carbon::parse('2013-09-01 05:15:05');

--- a/tests/Carbon/TestingAidsTest.php
+++ b/tests/Carbon/TestingAidsTest.php
@@ -117,23 +117,12 @@ class TestingAidsTest extends AbstractTestCase
     public function testHasRelativeKeywords()
     {
         $this->assertFalse(Carbon::hasRelativeKeywords('sunday 2015-02-23'));
-        $this->assertFalse(Carbon::hasRelativeKeywords('today +2014 days'));
-        $this->assertFalse(Carbon::hasRelativeKeywords('next sunday -3600 seconds'));
+        $this->assertTrue(Carbon::hasRelativeKeywords('today +2014 days'));
+        $this->assertTrue(Carbon::hasRelativeKeywords('next sunday -3600 seconds'));
         $this->assertTrue(Carbon::hasRelativeKeywords('last day of this month'));
-        $this->assertFalse(Carbon::hasRelativeKeywords('last day of december 2015'));
+        $this->assertFalse(Carbon::hasRelativeKeywords('last day of last month of 2015'));
         $this->assertTrue(Carbon::hasRelativeKeywords('first sunday of next month'));
         $this->assertFalse(Carbon::hasRelativeKeywords('first sunday of January 2017'));
-    }
-
-    public function testIsRelativeTimeString()
-    {
-        $this->assertFalse(Carbon::isRelativeTimeString('sunday 2015-02-23'));
-        $this->assertTrue(Carbon::isRelativeTimeString('today +2014 days'));
-        $this->assertTrue(Carbon::isRelativeTimeString('next sunday -3600 seconds'));
-        $this->assertTrue(Carbon::isRelativeTimeString('last day of this month'));
-        $this->assertFalse(Carbon::isRelativeTimeString('last day of last month of 2015'));
-        $this->assertTrue(Carbon::isRelativeTimeString('first sunday of next month'));
-        $this->assertFalse(Carbon::isRelativeTimeString('first sunday of January 2017'));
     }
 
     public function testParseRelativeWithMinusSignsInDate()

--- a/tests/Carbon/TestingAidsTest.php
+++ b/tests/Carbon/TestingAidsTest.php
@@ -123,6 +123,9 @@ class TestingAidsTest extends AbstractTestCase
             $scope->assertSame('2000-01-03 00:00:00', Carbon::parse('2000-1-3')->toDateTimeString());
             $scope->assertSame('2000-10-10 00:00:00', Carbon::parse('2000-10-10')->toDateTimeString());
         }, $testNow);
+
+        $scope->assertSame('2000-01-03 00:00:00', Carbon::parse('2000-1-3')->toDateTimeString());
+        $scope->assertSame('2000-10-10 00:00:00', Carbon::parse('2000-10-10')->toDateTimeString());
     }
 
     public function testTimeZoneWithTestValueSet()


### PR DESCRIPTION
- Use the testNow instance everywhere a relative time is generated
- Add some tests for hasRelativeKeywords and isRelativeTimeString
- Optimize hasRelativeKeywords