### PR TITLE
Create createFromTimeString() method

### DIFF
--- a/build.php
+++ b/build.php
@@ -6,11 +6,15 @@ if (preg_match('/On branch ([^\n]+)\n/', shell_exec('git status'), $match)) {
     $currentBranch = $match[1];
 }
 shell_exec('git fetch --all --tags --prune');
+$remotes = explode("\n", trim(shell_exec('git remote')));
+$tagsCommand =  count($remotes)
+    ? 'git ls-remote --tags '.(in_array('upstream', $remotes) ? 'upstream' : (in_array('origin', $remotes) ? 'origin' : $remotes[0]))
+    : 'git tag';
 $tags = array_map(function ($ref) {
     $ref = explode('refs/tags/', $ref);
 
-    return $ref[1];
-}, array_filter(explode("\n", trim(shell_exec('git ls-remote --tags origin'))), function ($ref) {
+    return isset($ref[1]) ? $ref[1] : $ref[0];
+}, array_filter(explode("\n", trim(shell_exec($tagsCommand))), function ($ref) {
     return substr($ref, -3) !== '^{}';
 }));
 usort($tags, 'version_compare');
@@ -32,6 +36,11 @@ if (strtolower($tag) !== 'all') {
 }
 
 foreach ($tags as $tag) {
+    $archive = "Carbon-$tag.zip";
+    if (isset($argv[2]) && $argv[2] === 'missing' && file_exists($archive)) {
+        continue;
+    }
+
     $branch = "build-$tag";
     shell_exec('git stash');
     shell_exec("git branch -d $branch");
@@ -40,7 +49,7 @@ foreach ($tags as $tag) {
     shell_exec('composer update --no-interaction --no-dev --optimize-autoloader');
     $zip = new ZipArchive();
 
-    $zip->open("Carbon-$tag.zip", ZipArchive::CREATE | ZipArchive::OVERWRITE);
+    $zip->open($archive, ZipArchive::CREATE | ZipArchive::OVERWRITE);
 
     foreach (array('src', 'vendor', 'Carbon') as $directory) {
         if (is_dir($directory)) {

--- a/build.php
+++ b/build.php
@@ -7,7 +7,7 @@ if (preg_match('/On branch ([^\n]+)\n/', shell_exec('git status'), $match)) {
 }
 shell_exec('git fetch --all --tags --prune');
 $remotes = explode("\n", trim(shell_exec('git remote')));
-$tagsCommand =  count($remotes)
+$tagsCommand = count($remotes)
     ? 'git ls-remote --tags '.(in_array('upstream', $remotes) ? 'upstream' : (in_array('origin', $remotes) ? 'origin' : $remotes[0]))
     : 'git tag';
 $tags = array_map(function ($ref) {

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -700,6 +700,21 @@ class Carbon extends DateTime
     }
 
     /**
+     * Create a Carbon instance from a time string. The date portion is set to today.
+     *
+     * @param string                    $time
+     * @param \DateTimeZone|string|null $tz
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return static
+     */
+    public static function createFromTimeString($time, $tz = null)
+    {
+        return static::today($tz)->setTimeFromTimeString($time);
+    }
+
+    /**
      * Create a Carbon instance from a specific format.
      *
      * @param string                    $format Datetime format
@@ -760,7 +775,7 @@ class Carbon extends DateTime
      */
     public static function createFromTimestamp($timestamp, $tz = null)
     {
-        return static::now($tz)->setTimestamp($timestamp);
+        return static::today($tz)->setTimestamp($timestamp);
     }
 
     /**
@@ -1080,13 +1095,11 @@ class Carbon extends DateTime
      */
     public function setTimeFromTimeString($time)
     {
-        $time = explode(':', $time);
+        if (strpos($time, ':') === false) {
+            $time .= ':0';
+        }
 
-        $hour = $time[0];
-        $minute = isset($time[1]) ? $time[1] : 0;
-        $second = isset($time[2]) ? $time[2] : 0;
-
-        return $this->setTime($hour, $minute, $second);
+        return $this->modify($time);
     }
 
     /**

--- a/tests/Carbon/CreateFromTimeStringTest.php
+++ b/tests/Carbon/CreateFromTimeStringTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Carbon;
+
+use Carbon\Carbon;
+use DateTimeZone;
+use Tests\AbstractTestCase;
+
+class CreateFromTimeStringTest extends AbstractTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        Carbon::setTestNow();
+    }
+
+    public function testCreateFromTimeString()
+    {
+        $d = Carbon::createFromTimeString('22:45');
+        $this->assertSame(22, $d->hour);
+        $this->assertSame(45, $d->minute);
+        $this->assertSame(0, $d->second);
+        $this->assertSame(0, $d->micro);
+    }
+
+    public function testCreateFromTimeStringWithSecond()
+    {
+        $d = Carbon::createFromTimeString('22:45:12');
+        $this->assertSame(22, $d->hour);
+        $this->assertSame(45, $d->minute);
+        $this->assertSame(12, $d->second);
+        $this->assertSame(0, $d->micro);
+    }
+
+    public function testCreateFromTimeStringWithMicroSecond()
+    {
+        if (version_compare(PHP_VERSION, '7.1.0-dev', '<')) {
+            $this->markTestSkipped();
+        }
+
+        $d = Carbon::createFromTimeString('22:45:00.625341');
+        $this->assertSame(22, $d->hour);
+        $this->assertSame(45, $d->minute);
+        $this->assertSame(0, $d->second);
+        $this->assertSame(625341, $d->micro);
+    }
+
+    public function testCreateFromTimeStringWithDateTimeZone()
+    {
+        $d = Carbon::createFromTimeString('12:20:30', new DateTimeZone('Europe/London'));
+        $this->assertCarbon($d, Carbon::now()->year, Carbon::now()->month, Carbon::now()->day, 12, 20, 30, 0);
+        $this->assertSame('Europe/London', $d->tzName);
+    }
+
+    public function testCreateFromTimeStringWithTimeZoneString()
+    {
+        $d = Carbon::createFromTimeString('12:20:30', 'Europe/London');
+        $this->assertCarbon($d, Carbon::now()->year, Carbon::now()->month, Carbon::now()->day, 12, 20, 30, 0);
+        $this->assertSame('Europe/London', $d->tzName);
+    }
+}

--- a/tests/Carbon/SettersTest.php
+++ b/tests/Carbon/SettersTest.php
@@ -299,6 +299,9 @@ class SettersTest extends AbstractTestCase
             array(9, 15, 30, '09:15:30'),
             array(9, 15, 0, '09:15'),
             array(9, 0, 0, '09'),
+            array(9, 5, 3, '9:5:3'),
+            array(9, 5, 0, '9:5'),
+            array(9, 0, 0, '9'),
         );
     }
 


### PR DESCRIPTION
- Build script: add "missing" option and better tags detection
- Implement `createFromTimeString()` #919
- Enable microseconds setting in `setTimeFromTimeString()` for PHP >= 7.1
- Remove "now" fallback microseconds from `createFromTimestamp()` on PHP 7.0