### PR TITLE
* Make .php_cs.dist compatible with PHP 5.3

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -3,20 +3,20 @@
 use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
 
-$rules = [
+$rules = array(
     '@PSR2' => true,
-    'array_syntax' => [
+    'array_syntax' => array(
         'syntax' => 'long',
-    ],
-    'binary_operator_spaces' => [
+    ),
+    'binary_operator_spaces' => array(
         'align_double_arrow' => false,
         'align_equals' => false,
-    ],
+    ),
     'blank_line_before_return' => true,
     'cast_spaces' => true,
-    'concat_space' => [
+    'concat_space' => array(
         'spacing' => 'none',
-    ],
+    ),
     'ereg_to_preg' => true,
     'method_separation' => true,
     'no_blank_lines_after_phpdoc' => true,
@@ -30,9 +30,9 @@ $rules = [
     'phpdoc_indent' => true,
     'phpdoc_inline_tag' => true,
     'phpdoc_no_access' => true,
-    'phpdoc_no_alias_tag' => [
+    'phpdoc_no_alias_tag' => array(
         'type' => 'var',
-    ],
+    ),
     'phpdoc_no_package' => true,
     'phpdoc_order' => true,
     'phpdoc_scalar' => true,
@@ -52,7 +52,7 @@ $rules = [
     'line_ending' => true,
     'blank_line_after_namespace' => true,
     'no_unused_imports' => true,
-];
+);
 
 return Config::create()->setRules($rules)
              ->setFinder(Finder::create()->in(__DIR__))

--- a/tests/Carbon/CreateFromTimeTest.php
+++ b/tests/Carbon/CreateFromTimeTest.php
@@ -83,7 +83,7 @@ class CreateFromTimeTest extends AbstractTestCase
         $now = Carbon::now($tz);
         $dt = Carbon::createFromTime($now->hour, $now->minute, $now->second, $tz);
 
-        // reenable test
+        // re-enable test
         Carbon::setTestNow($test);
 
         // tested without microseconds

--- a/tests/Carbon/CreateSafeTest.php
+++ b/tests/Carbon/CreateSafeTest.php
@@ -177,7 +177,7 @@ class CreateSafeTest extends AbstractTestCase
         try {
             // 1h jumped to 2h because of the DST, so 1h30 is not a safe date in PHP 5.4+
             $date = Carbon::createSafe(2014, 3, 30, 1, 30, 0, 'Europe/London');
-        } catch (\Carbon\Exceptions\InvalidDateException $exception) {
+        } catch (InvalidDateException $exception) {
             $message = $exception->getMessage();
         }
 

--- a/tests/Carbon/DayOfWeekModifiersTest.php
+++ b/tests/Carbon/DayOfWeekModifiersTest.php
@@ -227,7 +227,7 @@ class DayOfWeekModifiersTest extends AbstractTestCase
         $this->assertCarbon($d, 1975, 10, 3, 0, 0, 0);
     }
 
-    public function testFirstOfQuarterFromADayThatWillNotExistIntheFirstMonth()
+    public function testFirstOfQuarterFromADayThatWillNotExistInTheFirstMonth()
     {
         $d = Carbon::createFromDate(2014, 5, 31)->firstOfQuarter();
         $this->assertCarbon($d, 2014, 4, 1, 0, 0, 0);
@@ -251,7 +251,7 @@ class DayOfWeekModifiersTest extends AbstractTestCase
         $this->assertCarbon($d, 1975, 9, 26, 0, 0, 0);
     }
 
-    public function testLastOfQuarterFromADayThatWillNotExistIntheLastMonth()
+    public function testLastOfQuarterFromADayThatWillNotExistInTheLastMonth()
     {
         $d = Carbon::createFromDate(2014, 5, 31)->lastOfQuarter();
         $this->assertCarbon($d, 2014, 6, 30, 0, 0, 0);
@@ -267,7 +267,7 @@ class DayOfWeekModifiersTest extends AbstractTestCase
         $this->assertFalse(Carbon::createFromDate(1975, 1, 5)->nthOfQuarter(55, Carbon::MONDAY));
     }
 
-    public function testNthOfQuarterFromADayThatWillNotExistIntheFirstMonth()
+    public function testNthOfQuarterFromADayThatWillNotExistInTheFirstMonth()
     {
         $d = Carbon::createFromDate(2014, 5, 31)->nthOfQuarter(2, Carbon::MONDAY);
         $this->assertCarbon($d, 2014, 4, 14, 0, 0, 0);

--- a/tests/Carbon/DiffTest.php
+++ b/tests/Carbon/DiffTest.php
@@ -420,7 +420,7 @@ class DiffTest extends AbstractTestCase
         $this->assertSame(62, $dt->diffInMinutes($dt->copy()->addHour()->addMinutes(2)));
     }
 
-    public function testDiffInMinutesPositiveAlot()
+    public function testDiffInMinutesPositiveALot()
     {
         $dt = Carbon::createFromDate(2000, 1, 1);
         $this->assertSame(1502, $dt->diffInMinutes($dt->copy()->addHours(25)->addMinutes(2)));
@@ -458,7 +458,7 @@ class DiffTest extends AbstractTestCase
         $this->assertSame(62, $dt->diffInSeconds($dt->copy()->addMinute()->addSeconds(2)));
     }
 
-    public function testDiffInSecondsPositiveAlot()
+    public function testDiffInSecondsPositiveALot()
     {
         $dt = Carbon::createFromDate(2000, 1, 1);
         $this->assertSame(7202, $dt->diffInSeconds($dt->copy()->addHours(2)->addSeconds(2)));

--- a/tests/Carbon/ModifyNearDSTChangeTest.php
+++ b/tests/Carbon/ModifyNearDSTChangeTest.php
@@ -19,6 +19,9 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
     /**
      * Tests transition through DST change hour in non default timezone
      *
+     * @param string $dateString
+     * @param int    $addHours
+     * @param string $expected
      * @dataProvider getTransitionTests
      */
     public function testTransitionInNonDefaultTimezone($dateString, $addHours, $expected)
@@ -32,6 +35,9 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
     /**
      * Tests transition through DST change hour in default timezone
      *
+     * @param string $dateString
+     * @param int    $addHours
+     * @param string $expected
      * @dataProvider getTransitionTests
      */
     public function testTransitionInDefaultTimezone($dateString, $addHours, $expected)

--- a/tests/Carbon/PhpBug72338Test.php
+++ b/tests/Carbon/PhpBug72338Test.php
@@ -35,14 +35,14 @@ class PhpBug72338Test extends AbstractTestCase
         parent::setUp();
 
         // In versions <= 5.5.5 setTimezone doesn't accept timezone in 'HH:MM' format.
-        // I dont know about versions between 5.5.5 and 5.5.18, but 5.5.18 accept it.
+        // I don't know about versions between 5.5.5 and 5.5.18, but 5.5.18 accept it.
         if (version_compare(PHP_VERSION, '5.5.18-dev', '<')) {
             $this->markTestSkipped();
         }
     }
 
     /**
-     * Ensures that modify dont use changed timestamp
+     * Ensures that modify don't use changed timestamp
      */
     public function testModify()
     {
@@ -74,7 +74,7 @@ class PhpBug72338Test extends AbstractTestCase
     }
 
     /**
-     * Ensures that second call to setTimezone() dont changing timestamp
+     * Ensures that second call to setTimezone() don't changing timestamp
      */
     public function testSecondSetTimezone()
     {


### PR DESCRIPTION
* Fix unit-tests (`testAddHourPassingArg`, `testMicroGetterWithDefaultNow`) while running on Windows
* Correct spelling for some unit-test methods and comments