### PR TITLE
Microseconds improvements

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -236,6 +236,13 @@ class Carbon extends DateTime
     protected static $utf8 = false;
 
     /**
+     * Add microseconds to now on PHP < 7.1 and 7.1.3. true by default.
+     *
+     * @var bool
+     */
+    protected static $microsecondsFallback = true;
+
+    /**
      * Indicates if months should be calculated with overflow.
      *
      * @var bool
@@ -248,6 +255,28 @@ class Carbon extends DateTime
      * @var bool
      */
     protected static $yearsOverflow = true;
+
+    /**
+     * Add microseconds to now on PHP < 7.1 and 7.1.3 if set to true,
+     * let microseconds to 0 on those PHP versions if false.
+     *
+     * @param bool $microsecondsFallback
+     */
+    public static function useMicrosecondsFallback($microsecondsFallback = true)
+    {
+        static::$microsecondsFallback = $microsecondsFallback;
+    }
+
+    /**
+     * Return true if microseconds fallback on PHP < 7.1 and 7.1.3 is
+     * enabled. false if disabled.
+     *
+     * @return bool
+     */
+    public static function isMicrosecondsFallbackEnabled()
+    {
+        return static::$microsecondsFallback;
+    }
 
     /**
      * Indicates if months should be calculated with overflow.
@@ -387,17 +416,19 @@ class Carbon extends DateTime
             $time = $testInstance->format(static::MOCK_DATETIME_FORMAT);
         }
 
-        // Get microseconds from microtime() if "now" asked and PHP < 7.1
         $timezone = static::safeCreateDateTimeZone($tz);
         // @codeCoverageIgnoreStart
-        if ($isNow && !isset($testInstance) && (
+        if ($isNow && !isset($testInstance) && static::isMicrosecondsFallbackEnabled() && (
                 version_compare(PHP_VERSION, '7.1.0-dev', '<')
                 ||
                 version_compare(PHP_VERSION, '7.1.3-dev', '>=') && version_compare(PHP_VERSION, '7.1.4-dev', '<')
             )
         ) {
+            // Get microseconds from microtime() if "now" asked and PHP < 7.1 and PHP 7.1.3 if fallback enabled.
+            list($microTime, $timeStamp) = explode(' ', microtime());
             $dateTime = new DateTime('now', $timezone);
-            $time = $dateTime->format(static::DEFAULT_TO_STRING_FORMAT).substr(microtime(), 1, 7);
+            $dateTime->setTimestamp($timeStamp); // Use the timestamp returned by microtime as now can happen in the next second
+            $time = $dateTime->format(static::DEFAULT_TO_STRING_FORMAT).substr($microTime, 1, 7);
         }
         // @codeCoverageIgnoreEnd
 

--- a/tests/Carbon/GettersTest.php
+++ b/tests/Carbon/GettersTest.php
@@ -77,14 +77,41 @@ class GettersTest extends AbstractTestCase
     {
         $now = Carbon::getTestNow();
         Carbon::setTestNow(null);
+
+        $this->assertTrue(Carbon::isMicrosecondsFallbackEnabled());
+
         $start = microtime(true);
-        usleep(1000);
+        usleep(10000);
         $d = Carbon::now();
-        usleep(1000);
+        usleep(10000);
         $end = microtime(true);
         $microTime = $d->getTimestamp() + $d->micro / 1000000;
+
         $this->assertGreaterThan($start, $microTime);
         $this->assertLessThan($end, $microTime);
+
+        Carbon::useMicrosecondsFallback(false);
+
+        $this->assertFalse(Carbon::isMicrosecondsFallbackEnabled());
+        $start = microtime(true);
+        usleep(10000);
+        $d = Carbon::now();
+        usleep(10000);
+        $end = microtime(true);
+        $microTime = $d->getTimestamp() + $d->micro / 1000000;
+
+        if (version_compare(PHP_VERSION, '7.1.0-dev', '<')
+            ||
+            version_compare(PHP_VERSION, '7.1.3-dev', '>=') && version_compare(PHP_VERSION, '7.1.4-dev', '<')
+        ) {
+            $this->assertSame(0, $d->micro);
+        } else {
+            $this->assertGreaterThan($start, $microTime);
+            $this->assertLessThan($end, $microTime);
+        }
+
+        Carbon::useMicrosecondsFallback();
+        $this->assertTrue(Carbon::isMicrosecondsFallbackEnabled());
 
         Carbon::setTestNow($now);
     }


### PR DESCRIPTION
- Add useMicrosecondsFallback()
- Add isMicrosecondsFallbackEnabled()
- Calculate microtime and timestamp in the exact same moment