### PR TITLE
create CarbonInterval::fromString(string) method

### DIFF
--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -251,10 +251,10 @@ class CarbonInterval extends DateInterval
         $minutes = 0;
         $seconds = 0;
 
-        $pattern = '/([\d.]+)\h*([a-z]+)/i';
+        $pattern = '/(\d+(?:\.\d+)?)\h*([^\d\h]*)/i';
         preg_match_all($pattern, $intervalDefinition, $parts, PREG_SET_ORDER);
         while ($match = array_shift($parts)) {
-            list(, $value, $unit) = $match;
+            list($part, $value, $unit) = $match;
             $intValue = intval($value);
             $fraction = floatval($value) - $intValue;
             switch (strtolower($unit)) {
@@ -313,7 +313,9 @@ class CarbonInterval extends DateInterval
                     break;
 
                 default:
-                    throw new InvalidArgumentException(sprintf('Invalid unit %s', $unit));
+                    throw new InvalidArgumentException(
+                        sprintf('Invalid part %s in definition %s', $part, $intervalDefinition)
+                    );
             }
         }
 

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -235,6 +235,7 @@ class CarbonInterval extends DateInterval
      *    and rounded to the next smaller value (caution: 0.5w = 4d)
      *
      * @param string $intervalDefinition
+     *
      * @return static
      */
     public static function fromString($intervalDefinition)

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -253,7 +253,7 @@ class CarbonInterval extends DateInterval
 
         $pattern = '/([\d.]+)\h*([a-z]+)/i';
         preg_match_all($pattern, $intervalDefinition, $parts, PREG_SET_ORDER);
-        foreach ($parts as &$match) {
+        while ($match = array_shift($parts)) {
             list(, $value, $unit) = $match;
             $intValue = intval($value);
             $fraction = floatval($value) - $intValue;

--- a/tests/CarbonInterval/FromStringTest.php
+++ b/tests/CarbonInterval/FromStringTest.php
@@ -28,29 +28,65 @@ class FromStringTest extends AbstractTestCase
 
             // single values
             array('1y', new CarbonInterval(1)),
-            array('1M', new CarbonInterval(0, 1)),
+            array('1mo', new CarbonInterval(0, 1)),
             array('1w', new CarbonInterval(0, 0, 1)),
             array('1d', new CarbonInterval(0, 0, 0, 1)),
             array('1h', new CarbonInterval(0, 0, 0, 0, 1)),
             array('1m', new CarbonInterval(0, 0, 0, 0, 0, 1)),
             array('1s', new CarbonInterval(0, 0, 0, 0, 0, 0, 1)),
 
+            // single values with space
+            array('1 y', new CarbonInterval(1)),
+            array('1 mo', new CarbonInterval(0, 1)),
+            array('1 w', new CarbonInterval(0, 0, 1)),
+
             // fractions with integer result
-            array('0.571428571w', new CarbonInterval(0, 0, 0, 4)),
+            array('0.571428572w', new CarbonInterval(0, 0, 0, 4)),
             array('0.5d', new CarbonInterval(0, 0, 0, 0, 12)),
             array('0.5h', new CarbonInterval(0, 0, 0, 0, 0, 30)),
             array('0.5m', new CarbonInterval(0, 0, 0, 0, 0, 0, 30)),
 
             // fractions with float result
-            array('1.5w', new CarbonInterval(0, 0, 1, 4)),
-            array('2.34d', new CarbonInterval(0, 0, 0, 2, 8)),
-            array('3.12h', new CarbonInterval(0, 0, 0, 0, 3, 7)),
-            array('3.129h', new CarbonInterval(0, 0, 0, 0, 3, 8)),
+            array('1.5w', new CarbonInterval(0, 0, 1, 3, 12)),
+            array('2.34d', new CarbonInterval(0, 0, 0, 2, 8, 9, 36)),
+            array('3.12h', new CarbonInterval(0, 0, 0, 0, 3, 7, 12)),
+            array('3.129h', new CarbonInterval(0, 0, 0, 0, 3, 7, 44)),
             array('4.24m', new CarbonInterval(0, 0, 0, 0, 0, 4, 14)),
 
             // combinations
             array('2w 3d', new CarbonInterval(0, 0, 0, 17)),
-            array('1y 2M 1.5w 3d', new CarbonInterval(1, 2, 2, 0)),
+            array('1y 2mo 1.5w 3d', new CarbonInterval(1, 2, 1, 6, 12)),
+
+            // multi same values
+            array('1y 2y', new CarbonInterval(3)),
+            array('1mo 20mo', new CarbonInterval(0, 21)),
+            array('1w 2w 3w', new CarbonInterval(0, 0, 6)),
+            array('10d 20d 30d', new CarbonInterval(0, 0, 0, 60)),
+            array('5h 15h 25h', new CarbonInterval(0, 0, 0, 0, 45)),
+            array('3m 3m 3m 1m', new CarbonInterval(0, 0, 0, 0, 0, 10)),
+            array('55s 45s 1s 2s 3s 4s', new CarbonInterval(0, 0, 0, 0, 0, 0, 110)),
+
+            // multi same values with space
+            array('1 y 2 y', new CarbonInterval(3)),
+            array('1 mo 20 mo', new CarbonInterval(0, 21)),
+            array('1 w      2  w       3    w', new CarbonInterval(0, 0, 6)),
+
+            // no-space values
+            array('2w3d', new CarbonInterval(0, 0, 0, 17)),
+            array('1y2mo3w4d5h6m7s', new CarbonInterval(1, 2, 3, 4, 5, 6, 7)),
+
+            // written-out units
+            array('1year 2month 3week 4day 5hour 6minute 7second', new CarbonInterval(1, 2, 3, 4, 5, 6, 7)),
+            array('1 year 2 month 3 week', new CarbonInterval(1, 2, 3)),
+            array('2 Years 3 Months 4 Weeks', new CarbonInterval(2, 3, 4)),
+            array('5 Days 6 Hours 7 Minutes 8 Seconds', new CarbonInterval(0, 0, 0, 5, 6, 7, 8)),
+
+            // ignore invalid format; parse only [num][char-format] or [num] [char-format]
+            array('Hello! Please add 1y2w to ...', new CarbonInterval(1, 0, 2)),
+            array('nothing to parse :(', new CarbonInterval(0)),
+
+            // case insenstive
+            array('1Y 3MO 1W 3D 12H 23M 42S', new CarbonInterval(1, 3, 1, 3, 12, 23, 42)),
         );
     }
 

--- a/tests/CarbonInterval/FromStringTest.php
+++ b/tests/CarbonInterval/FromStringTest.php
@@ -91,10 +91,28 @@ class FromStringTest extends AbstractTestCase
     }
 
     /**
+     * @dataProvider provideInvalidStrings
      * @expectedException \InvalidArgumentException
+     *
+     * @param string $string
+     * @param string $part
      */
-    public function testThrowsExceptionForUnknownValues()
+    public function testThrowsExceptionForUnknownValues($string, $part)
     {
-        CarbonInterval::fromString('1q');
+        try {
+            CarbonInterval::fromString($string);
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertContains($part, $exception->getMessage());
+            throw $exception;
+        }
+    }
+
+    public function provideInvalidStrings()
+    {
+        return array(
+            array('1q', '1q'),
+            array('about 12..14m', '12..'),
+            array('4h 13', '13'),
+        );
     }
 }

--- a/tests/CarbonInterval/FromStringTest.php
+++ b/tests/CarbonInterval/FromStringTest.php
@@ -10,7 +10,7 @@ class FromStringTest extends AbstractTestCase
     /**
      * @dataProvider provideValidStrings
      *
-     * @param string $string
+     * @param string         $string
      * @param CarbonInterval $expected
      */
     public function testReturnsInterval($string, $expected)

--- a/tests/CarbonInterval/FromStringTest.php
+++ b/tests/CarbonInterval/FromStringTest.php
@@ -9,6 +9,7 @@ class FromStringTest extends AbstractTestCase
 {
     /**
      * @dataProvider provideValidStrings
+     *
      * @param $string
      * @param $expected
      */
@@ -23,33 +24,33 @@ class FromStringTest extends AbstractTestCase
     {
         return array(
             // zero interval
-            array( '', new CarbonInterval(0) ),
+            array('', new CarbonInterval(0)),
 
             // single values
-            array( '1y', new CarbonInterval(1) ),
-            array( '1M', new CarbonInterval(0, 1) ),
-            array( '1w', new CarbonInterval(0, 0, 1) ),
-            array( '1d', new CarbonInterval(0, 0, 0, 1) ),
-            array( '1h', new CarbonInterval(0, 0, 0, 0, 1) ),
-            array( '1m', new CarbonInterval(0, 0, 0, 0, 0, 1) ),
-            array( '1s', new CarbonInterval(0, 0, 0, 0, 0, 0, 1) ),
+            array('1y', new CarbonInterval(1)),
+            array('1M', new CarbonInterval(0, 1)),
+            array('1w', new CarbonInterval(0, 0, 1)),
+            array('1d', new CarbonInterval(0, 0, 0, 1)),
+            array('1h', new CarbonInterval(0, 0, 0, 0, 1)),
+            array('1m', new CarbonInterval(0, 0, 0, 0, 0, 1)),
+            array('1s', new CarbonInterval(0, 0, 0, 0, 0, 0, 1)),
 
             // fractions with integer result
-            array( '0.571428571w', new CarbonInterval(0, 0, 0, 4) ),
-            array( '0.5d', new CarbonInterval(0, 0, 0, 0, 12) ),
-            array( '0.5h', new CarbonInterval(0, 0, 0, 0, 0, 30) ),
-            array( '0.5m', new CarbonInterval(0, 0, 0, 0, 0, 0, 30) ),
+            array('0.571428571w', new CarbonInterval(0, 0, 0, 4)),
+            array('0.5d', new CarbonInterval(0, 0, 0, 0, 12)),
+            array('0.5h', new CarbonInterval(0, 0, 0, 0, 0, 30)),
+            array('0.5m', new CarbonInterval(0, 0, 0, 0, 0, 0, 30)),
 
             // fractions with float result
-            array( '1.5w', new CarbonInterval(0, 0, 1, 4) ),
-            array( '2.34d', new CarbonInterval(0, 0, 0, 2, 8) ),
-            array( '3.12h', new CarbonInterval(0, 0, 0, 0, 3, 7) ),
-            array( '3.129h', new CarbonInterval(0, 0, 0, 0, 3, 8) ),
-            array( '4.24m', new CarbonInterval(0, 0, 0, 0, 0, 4, 14) ),
+            array('1.5w', new CarbonInterval(0, 0, 1, 4)),
+            array('2.34d', new CarbonInterval(0, 0, 0, 2, 8)),
+            array('3.12h', new CarbonInterval(0, 0, 0, 0, 3, 7)),
+            array('3.129h', new CarbonInterval(0, 0, 0, 0, 3, 8)),
+            array('4.24m', new CarbonInterval(0, 0, 0, 0, 0, 4, 14)),
 
             // combinations
-            array( '2w 3d', new CarbonInterval(0, 0, 0, 17) ),
-            array( '1y 2M 1.5w 3d', new CarbonInterval(1, 2, 2, 0) ),
+            array('2w 3d', new CarbonInterval(0, 0, 0, 17)),
+            array('1y 2M 1.5w 3d', new CarbonInterval(1, 2, 2, 0)),
         );
     }
 

--- a/tests/CarbonInterval/FromStringTest.php
+++ b/tests/CarbonInterval/FromStringTest.php
@@ -10,8 +10,8 @@ class FromStringTest extends AbstractTestCase
     /**
      * @dataProvider provideValidStrings
      *
-     * @param $string
-     * @param $expected
+     * @param string $string
+     * @param CarbonInterval $expected
      */
     public function testReturnsInterval($string, $expected)
     {

--- a/tests/CarbonInterval/FromStringTest.php
+++ b/tests/CarbonInterval/FromStringTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\CarbonInterval;
+
+use Carbon\CarbonInterval;
+use Tests\AbstractTestCase;
+
+class FromStringTest extends AbstractTestCase
+{
+    /**
+     * @dataProvider provideValidStrings
+     * @param $string
+     * @param $expected
+     */
+    public function testReturnsInterval($string, $expected)
+    {
+        $result = CarbonInterval::fromString($string);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function provideValidStrings()
+    {
+        return array(
+            // zero interval
+            array( '', new CarbonInterval(0) ),
+
+            // single values
+            array( '1y', new CarbonInterval(1) ),
+            array( '1M', new CarbonInterval(0, 1) ),
+            array( '1w', new CarbonInterval(0, 0, 1) ),
+            array( '1d', new CarbonInterval(0, 0, 0, 1) ),
+            array( '1h', new CarbonInterval(0, 0, 0, 0, 1) ),
+            array( '1m', new CarbonInterval(0, 0, 0, 0, 0, 1) ),
+            array( '1s', new CarbonInterval(0, 0, 0, 0, 0, 0, 1) ),
+
+            // fractions with integer result
+            array( '0.571428571w', new CarbonInterval(0, 0, 0, 4) ),
+            array( '0.5d', new CarbonInterval(0, 0, 0, 0, 12) ),
+            array( '0.5h', new CarbonInterval(0, 0, 0, 0, 0, 30) ),
+            array( '0.5m', new CarbonInterval(0, 0, 0, 0, 0, 0, 30) ),
+
+            // fractions with float result
+            array( '1.5w', new CarbonInterval(0, 0, 1, 4) ),
+            array( '2.34d', new CarbonInterval(0, 0, 0, 2, 8) ),
+            array( '3.12h', new CarbonInterval(0, 0, 0, 0, 3, 7) ),
+            array( '3.129h', new CarbonInterval(0, 0, 0, 0, 3, 8) ),
+            array( '4.24m', new CarbonInterval(0, 0, 0, 0, 0, 4, 14) ),
+
+            // combinations
+            array( '2w 3d', new CarbonInterval(0, 0, 0, 17) ),
+            array( '1y 2M 1.5w 3d', new CarbonInterval(1, 2, 2, 0) ),
+        );
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testThrowsExceptionForUnknownValues()
+    {
+        CarbonInterval::fromString('1q');
+    }
+}


### PR DESCRIPTION
Creates a CarbonInterval from string in JIRA format (solves #997)

Format:

Suffix | Unit    | Example | DateInterval expression
------ | ------- | ------- | -----------------------
y    | years   |   1y    | P1Y
M    | months  |   3M    | P3M
w    | weeks   |   2w    | P2W
d    | days    |  28d    | P28D
h    | hours   |   4h    | PT4H
m    | minutes |  12m    | PT12M
s    | seconds |  59s    | PT59S

e. g. `1w 3d 4h 32m 23s` is converted to 10 days 4 hours 32 minutes and 23 seconds.

Special cases:
 - An empty string will return a zero interval
 - Fractions are allowed for weeks, days, hours and minutes and will be converted
   and rounded to the next smaller value (caution: 0.5w = 4d)