### PR TITLE
Removed dead code.

### DIFF
--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -230,7 +230,6 @@ class CarbonInterval extends DateInterval
 
         $instance = new static($di->y, $di->m, 0, $di->d, $di->h, $di->i, $di->s);
         $instance->invert = $di->invert;
-        $instance->days = $di->days;
 
         return $instance;
     }


### PR DESCRIPTION
1. You cannot set days on DateInterval object. > https://3v4l.org/M9lqa
2. Even if it could be set, DateInterval created with DateTime::diff() is not allowed (few lines before). 