### PR TITLE
Fix unit tests

### DIFF
--- a/tests/Carbon/AddTest.php
+++ b/tests/Carbon/AddTest.php
@@ -183,7 +183,7 @@ class AddTest extends AbstractTestCase
 
     public function testAddHourPassingArg()
     {
-        $this->assertSame(2, Carbon::createFromTime(0)->addHour(2)->hour);
+        $this->assertSame(12, Carbon::createFromTime(10)->addHour(2)->hour);
     }
 
     public function testAddMinutePassingArg()

--- a/tests/Carbon/NowAndOtherStaticHelpersTest.php
+++ b/tests/Carbon/NowAndOtherStaticHelpersTest.php
@@ -20,14 +20,20 @@ class NowAndOtherStaticHelpersTest extends AbstractTestCase
 {
     public function testNow()
     {
+        $before = time();
         $dt = Carbon::now();
-        $this->assertSame(time(), $dt->timestamp);
+        $after = time();
+        $this->assertGreaterThanOrEqual($before, $dt->timestamp);
+        $this->assertLessThanOrEqual($after, $dt->timestamp);
     }
 
     public function testNowWithTimezone()
     {
+        $before = time();
         $dt = Carbon::now('Europe/London');
-        $this->assertSame(time(), $dt->timestamp);
+        $after = time();
+        $this->assertGreaterThanOrEqual($before, $dt->timestamp);
+        $this->assertLessThanOrEqual($after, $dt->timestamp);
         $this->assertSame('Europe/London', $dt->tzName);
     }
 


### PR DESCRIPTION
- Pick an hour that can't take in DST in Toronto
- Avoid failure if time changed before the two statements