### PR TITLE
Implement macro and JSON serialization in a PHP 5.3 compatible way

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Carbon\\": "src/Carbon/"
+            "": "src/"
         }
     },
     "autoload-dev": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,7 @@ parameters:
 		- '#Call to an undefined static method Carbon\\CarbonInterval::anything()#'
 		- '#Static method DateTime::__set_state()#'
 	excludes_analyse:
+		- '*/tests/Carbon/MacroTest.php'
 		- '*/tests/Carbon/SettersTest.php'
 		- '*/tests/Carbon/GettersTest.php'
 		- '*/tests/CarbonInterval/GettersTest.php'

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -84,7 +84,7 @@ class CarbonInterval extends DateInterval
 
     /**
      * Before PHP 5.4.20/5.5.4 instead of FALSE days will be set to -99999 when the interval instance
-     * was created by DateTime:diff().
+     * was created by DateTime::diff().
      */
     const PHP_DAYS_FALSE = -99999;
 

--- a/src/JsonSerializable.php
+++ b/src/JsonSerializable.php
@@ -1,0 +1,16 @@
+<?php
+
+interface JsonSerializable
+{
+    /**
+     * Specify data which should be serialized to JSON.
+     *
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     *
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     *               which is a value of any type other than a resource.
+     *
+     * @since 5.4.0
+     */
+    public function jsonSerialize();
+}

--- a/tests/Carbon/Fixtures/Mixin.php
+++ b/tests/Carbon/Fixtures/Mixin.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Carbon\Fixtures;
+
+class Mixin
+{
+    public $timezone = null;
+
+    public function setUserTimezone()
+    {
+        $mixin = $this;
+
+        return function ($timezone) use ($mixin) {
+            $mixin->timezone = $timezone;
+        };
+    }
+
+    public function userFormat()
+    {
+        $mixin = $this;
+
+        return function ($format, $self) use ($mixin) {
+            if ($mixin->timezone) {
+                $self->setTimezone($mixin->timezone);
+            }
+
+            return $self->format($format);
+        };
+    }
+}

--- a/tests/Carbon/InstanceTest.php
+++ b/tests/Carbon/InstanceTest.php
@@ -67,4 +67,13 @@ class InstanceTest extends AbstractTestCase
         ));
         $this->assertInstanceOf('Carbon\Carbon', $carbon);
     }
+
+    public function testDeserializationOccursCorrectly()
+    {
+        $carbon = new Carbon('2017-06-27 13:14:15.000000');
+        $serialized = 'return '.var_export($carbon, true).';';
+        $deserialized = eval($serialized);
+
+        $this->assertInstanceOf('Carbon\Carbon', $deserialized);
+    }
 }

--- a/tests/Carbon/JsonSerializationTest.php
+++ b/tests/Carbon/JsonSerializationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Carbon;
+
+use Carbon\Carbon;
+use Tests\AbstractTestCase;
+
+class JsonSerializationTest extends AbstractTestCase
+{
+    /**
+     * @var \Carbon\Carbon
+     */
+    protected $now;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Carbon::setTestNow($this->now = Carbon::create(2017, 6, 27, 13, 14, 15, 'UTC'));
+    }
+
+    public function tearDown()
+    {
+        Carbon::setTestNow();
+        Carbon::serializeUsing(null);
+
+        parent::tearDown();
+    }
+
+    public function testCarbonAllowsCustomSerializer()
+    {
+        if (version_compare(PHP_VERSION, '5.4.0-dev', '<')) {
+            $this->markTestSkipped();
+        }
+
+        Carbon::serializeUsing(function (Carbon $carbon) {
+            return $carbon->getTimestamp();
+        });
+
+        $result = json_decode(json_encode($this->now), true);
+
+        $this->assertSame(1498569255, $result);
+    }
+
+    public function testCarbonCanSerializeToJson()
+    {
+        if (version_compare(PHP_VERSION, '5.4.0-dev', '<')) {
+            $this->markTestSkipped();
+        }
+
+        $this->assertSame(array(
+            'date' => '2017-06-27 13:14:15.000000',
+            'timezone_type' => 3,
+            'timezone' => 'UTC',
+        ), $this->now->jsonSerialize());
+    }
+}

--- a/tests/Carbon/MacroTest.php
+++ b/tests/Carbon/MacroTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Carbon;
+
+use Carbon\Carbon;
+use Tests\AbstractTestCase;
+use Tests\Carbon\Fixtures\Mixin;
+
+class MacroTest extends AbstractTestCase
+{
+    /**
+     * @var \Carbon\Carbon
+     */
+    protected $now;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Carbon::setTestNow($this->now = Carbon::create(2017, 6, 27, 13, 14, 15, 'UTC'));
+    }
+
+    public function tearDown()
+    {
+        Carbon::setTestNow();
+        Carbon::serializeUsing(null);
+
+        parent::tearDown();
+    }
+
+    public function testInstance()
+    {
+        $this->assertInstanceOf('DateTime', $this->now);
+        $this->assertInstanceOf('Carbon\Carbon', $this->now);
+    }
+
+    public function testCarbonIsMacroableWhenNotCalledStatically()
+    {
+        Carbon::macro('diffFromEaster', function ($year, $self) {
+            $instance = Carbon::create($year);
+
+            $a = $instance->year % 19;
+            $b = floor($instance->year / 100);
+            $c = $instance->year % 100;
+            $d = floor($b / 4);
+            $e = $b % 4;
+            $f = floor(($b + 8) / 25);
+            $g = floor(($b - $f + 1) / 3);
+            $h = (19 * $a + $b - $d - $g + 15) % 30;
+            $i = floor($c / 4);
+            $k = $c % 4;
+            $l = (32 + 2 * $e + 2 * $i - $h - $k) % 7;
+            $m = floor(($a + 11 * $h + 22 * $l) / 451);
+            $month = floor(($h + $l - 7 * $m + 114) / 31);
+            $day = (($h + $l - 7 * $m + 114) % 31) + 1;
+
+            $instance->month($month)->day($day);
+
+            return $self->diff($instance);
+        });
+
+        $this->assertSame(1020, $this->now->diffFromEaster(2020)->days);
+    }
+
+    public function testCarbonIsMacroableWhenNotCalledStaticallyUsingThis()
+    {
+        if (version_compare(PHP_VERSION, '5.4.0-dev', '<')) {
+            $this->markTestSkipped();
+        }
+
+        Carbon::macro('diffFromEaster', function ($year) {
+            $instance = Carbon::create($year);
+
+            $a = $instance->year % 19;
+            $b = floor($instance->year / 100);
+            $c = $instance->year % 100;
+            $d = floor($b / 4);
+            $e = $b % 4;
+            $f = floor(($b + 8) / 25);
+            $g = floor(($b - $f + 1) / 3);
+            $h = (19 * $a + $b - $d - $g + 15) % 30;
+            $i = floor($c / 4);
+            $k = $c % 4;
+            $l = (32 + 2 * $e + 2 * $i - $h - $k) % 7;
+            $m = floor(($a + 11 * $h + 22 * $l) / 451);
+            $month = floor(($h + $l - 7 * $m + 114) / 31);
+            $day = (($h + $l - 7 * $m + 114) % 31) + 1;
+
+            $instance->month($month)->day($day);
+
+            return $this->diff($instance);
+        });
+
+        $this->assertSame(1020, $this->now->diffFromEaster(2020)->days);
+    }
+
+    public function testCarbonIsMacroableWhenCalledStatically()
+    {
+        Carbon::macro('easterDate', function ($year) {
+            $instance = Carbon::create($year);
+
+            $a = $instance->year % 19;
+            $b = floor($instance->year / 100);
+            $c = $instance->year % 100;
+            $d = floor($b / 4);
+            $e = $b % 4;
+            $f = floor(($b + 8) / 25);
+            $g = floor(($b - $f + 1) / 3);
+            $h = (19 * $a + $b - $d - $g + 15) % 30;
+            $i = floor($c / 4);
+            $k = $c % 4;
+            $l = (32 + 2 * $e + 2 * $i - $h - $k) % 7;
+            $m = floor(($a + 11 * $h + 22 * $l) / 451);
+            $month = floor(($h + $l - 7 * $m + 114) / 31);
+            $day = (($h + $l - 7 * $m + 114) % 31) + 1;
+
+            $instance->month($month)->day($day);
+
+            return $instance;
+        });
+
+        $this->assertSame('05/04', Carbon::easterDate(2015)->format('d/m'));
+    }
+
+    public function testCarbonIsMacroableWhithNonClosureCallables()
+    {
+        Carbon::macro('lower', 'strtolower');
+
+        $this->assertSame('abc', $this->now->lower('ABC'));
+        $this->assertSame('abc', Carbon::lower('ABC'));
+    }
+
+    public function testCarbonIsMixinable()
+    {
+        include_once __DIR__.'/Fixtures/Mixin.php';
+        $mixin = new Mixin();
+        Carbon::mixin($mixin);
+        Carbon::setUserTimezone('America/Belize');
+        $date = Carbon::parse('2000-01-01 12:00:00', 'UTC');
+
+        $this->assertSame('06:00 America/Belize', $date->userFormat('H:i e'));
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     * @expectedExceptionMessage Method nonExistingStaticMacro does not exist.
+     */
+    public function testCarbonRaisesExceptionWhenStaticMacroIsNotFound()
+    {
+        Carbon::nonExistingStaticMacro();
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     * @expectedExceptionMessage Method nonExistingMacro does not exist.
+     */
+    public function testCarbonRaisesExceptionWhenMacroIsNotFound()
+    {
+        Carbon::now()->nonExistingMacro();
+    }
+}


### PR DESCRIPTION
- Implement macro/hasMacro/mixin
- Implement JSON methods
- Allow json_encode/json_decode Carbon instances with PHP >=5.4
- Allow `$this` usage in macros with PHP >=5.4
