### PR TITLE
Add methods to set date or time from another instance

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1203,6 +1203,22 @@ class Carbon extends DateTime
     }
 
     /**
+     * Set the hour, day, and time for this instance to that of the passed instance.
+     *
+     * @param \Carbon\Carbon|\DateTimeInterface $date
+     *
+     * @return static
+     */
+    public function setTimeFrom($date)
+    {
+        $date = static::instance($date);
+
+        $this->setTime($date->hour, $date->minute, $date->second);
+
+        return $this;
+    }
+
+    /**
      * Get the days of the week
      *
      * @return array

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1187,6 +1187,22 @@ class Carbon extends DateTime
     }
 
     /**
+     * Set the year, month, and date for this instance to that of the passed instance.
+     *
+     * @param \Carbon\Carbon|\DateTimeInterface $date
+     *
+     * @return static
+     */
+    public function setDateFrom($date)
+    {
+        $date = static::instance($date);
+
+        $this->setDate($date->year, $date->month, $date->day);
+
+        return $this;
+    }
+
+    /**
      * Get the days of the week
      *
      * @return array

--- a/tests/Carbon/SetDateAndTimeFromTest.php
+++ b/tests/Carbon/SetDateAndTimeFromTest.php
@@ -35,4 +35,24 @@ class SetDateAndTimeFromTest extends AbstractTestCase
             $target->second
         );
     }
+
+    public function testSetTimeFrom()
+    {
+        $source = Carbon::now();
+        $target = $source->copy()
+            ->addDays(rand(1, 6))
+            ->addHours(rand(1, 23))
+            ->addMinutes(rand(1, 59))
+            ->addSeconds(rand(1, 59));
+
+        $this->assertCarbon(
+            $target->copy()->setTimeFrom($source),
+            $target->year,
+            $target->month,
+            $target->day,
+            $source->hour,
+            $source->minute,
+            $source->second
+        );
+    }
 }

--- a/tests/Carbon/SetDateAndTimeFromTest.php
+++ b/tests/Carbon/SetDateAndTimeFromTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Carbon;
+
+use Carbon\Carbon;
+use Tests\AbstractTestCase;
+
+class SetDateAndTimeFromTest extends AbstractTestCase
+{
+    public function testSetDateFrom()
+    {
+        $source = Carbon::now();
+        $target = $source->copy()
+            ->addDays(rand(1, 6))
+            ->addHours(rand(1, 23))
+            ->addMinutes(rand(1, 59))
+            ->addSeconds(rand(1, 59));
+
+        $this->assertCarbon(
+            $target->copy()->setDateFrom($source),
+            $source->year,
+            $source->month,
+            $source->day,
+            $target->hour,
+            $target->minute,
+            $target->second
+        );
+    }
+}


### PR DESCRIPTION
This adds the two new methods `matchDate` and `matchTime`, which sets the `year`, `month`, and `day` or `hour`, `minute`, and `second` respectively, based on the passed datetime.

This is based on discussions in #918. I decided to add these more explicitly named methods instead of overloading the existing `setDate` and `setTime` methods, but I'm happy to make any changes to naming etc., if deemed more appropriate.