### PR TITLE
Fix Italian translation for from_now

### DIFF
--- a/src/Carbon/Lang/it.php
+++ b/src/Carbon/Lang/it.php
@@ -25,7 +25,7 @@ return array(
     'second' => '1 secondo|:count secondi',
     's' => '1 secondo|:count secondi',
     'ago' => ':time fa',
-    'from_now' => ':time da adesso',
+    'from_now' => 'tra :time',
     'after' => ':time dopo',
     'before' => ':time prima',
 );

--- a/tests/Localization/ItTest.php
+++ b/tests/Localization/ItTest.php
@@ -65,7 +65,7 @@ class ItTest extends AbstractTestCase
             $scope->assertSame('2 anni fa', $d->diffForHumans());
 
             $d = Carbon::now()->addSecond();
-            $scope->assertSame('1 secondo da adesso', $d->diffForHumans());
+            $scope->assertSame('tra 1 secondo', $d->diffForHumans());
 
             $d = Carbon::now()->addSecond();
             $d2 = Carbon::now();


### PR DESCRIPTION
The correct way to say it in Italian is "tra 2 ore", otherwise it could be misunderstood as if the date is in the past.