### PR TITLE
Simpler unit conversions in CarbonInterval

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -88,6 +88,7 @@ class Carbon extends DateTime implements JsonSerializable
     const MONTHS_PER_YEAR = 12;
     const MONTHS_PER_QUARTER = 3;
     const WEEKS_PER_YEAR = 52;
+    const DAYS_PER_MONTH = 30;
     const DAYS_PER_WEEK = 7;
     const HOURS_PER_DAY = 24;
     const MINUTES_PER_HOUR = 60;

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -88,7 +88,7 @@ class Carbon extends DateTime implements JsonSerializable
     const MONTHS_PER_YEAR = 12;
     const MONTHS_PER_QUARTER = 3;
     const WEEKS_PER_YEAR = 52;
-    const DAYS_PER_MONTH = 30;
+    const WEEKS_PER_MONTH = 4;
     const DAYS_PER_WEEK = 7;
     const HOURS_PER_DAY = 24;
     const MINUTES_PER_HOUR = 60;

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -787,7 +787,7 @@ class CarbonInterval extends DateInterval
                 $result += $this->$target * $cumulativeFactor;
             }
             else {
-               $result = ($result + $this->$source) / $factor;
+                $result = ($result + $this->$source) / $factor;
             }
         }
 

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -89,6 +89,20 @@ class CarbonInterval extends DateInterval
     const PHP_DAYS_FALSE = -99999;
 
     /**
+     * Mapping of values after which properties should cascade.
+     *
+     * @var array
+     */
+    protected static $cascades = [
+        'seconds' => Carbon::SECONDS_PER_MINUTE,
+        'minutes' => Carbon::MINUTES_PER_HOUR,
+        'hours'   => Carbon::HOURS_PER_DAY,
+        'dayz'    => Carbon::DAYS_PER_MONTH,
+        'months'  => Carbon::MONTHS_PER_YEAR,
+        'years'   => null,
+    ];
+
+    /**
      * Determine if the interval was created via DateTime:diff() or not.
      *
      * @param DateInterval $interval
@@ -701,5 +715,30 @@ class CarbonInterval extends DateInterval
     public function compare(DateInterval $interval)
     {
         return static::compareDateIntervals($this, $interval);
+    }
+
+    /**
+     * Convert overflowed values into bigger units.
+     *
+     * @return $this
+     */
+    public function cascade()
+    {
+        $carry = 0;
+
+        foreach (static::$cascades as $property => $max) {
+            $value = $this->$property + $carry;
+
+            if ($max) {
+                $this->$property = $value % $max;
+                $carry = ($value - $this->$property) / $max;
+            }
+            else {
+                $this->$property = $value;
+                $carry = 0;
+            }
+        }
+
+        return $this;
     }
 }

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -785,8 +785,7 @@ class CarbonInterval extends DateInterval
             if ($cumulativeFactor) {
                 $cumulativeFactor *= $factor;
                 $result += $this->$target * $cumulativeFactor;
-            }
-            else {
+            } else {
                 $result = ($result + $this->$source) / $factor;
             }
         }

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -29,6 +29,14 @@ use Symfony\Component\Translation\TranslatorInterface;
  * @property int $seconds Total seconds of the current interval.
  * @property-read int $dayzExcludeWeeks Total days remaining in the final week of the current instance (days % 7).
  * @property-read int $daysExcludeWeeks alias of dayzExcludeWeeks
+ * @property-read float $totalYears Number of years equivalent to the interval.
+ * @property-read float $totalMonths Number of months equivalent to the interval.
+ * @property-read float $totalWeeks Number of weeks equivalent to the interval.
+ * @property-read float $totalDays Number of days equivalent to the interval.
+ * @property-read float $totalDayz Alias for totalDays.
+ * @property-read float $totalHours Number of hours equivalent to the interval.
+ * @property-read float $totalMinutes Number of minutes equivalent to the interval.
+ * @property-read float $totalSeconds Number of seconds equivalent to the interval.
  *
  * @method static CarbonInterval years($years = 1) Create instance specifying a number of years.
  * @method static CarbonInterval year($years = 1) Alias for years()

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -93,14 +93,14 @@ class CarbonInterval extends DateInterval
      *
      * @var array
      */
-    protected static $cascades = [
+    protected static $cascades = array(
         'seconds' => Carbon::SECONDS_PER_MINUTE,
         'minutes' => Carbon::MINUTES_PER_HOUR,
-        'hours'   => Carbon::HOURS_PER_DAY,
-        'dayz'    => Carbon::DAYS_PER_MONTH,
-        'months'  => Carbon::MONTHS_PER_YEAR,
-        'years'   => null,
-    ];
+        'hours' => Carbon::HOURS_PER_DAY,
+        'dayz' => Carbon::DAYS_PER_MONTH,
+        'months' => Carbon::MONTHS_PER_YEAR,
+        'years' => null,
+    );
 
     /**
      * Determine if the interval was created via DateTime:diff() or not.
@@ -736,8 +736,7 @@ class CarbonInterval extends DateInterval
             if ($max) {
                 $this->$property = $value % $max;
                 $carry = ($value - $this->$property) / $max;
-            }
-            else {
+            } else {
                 $this->$property = $value;
                 $carry = 0;
             }
@@ -749,16 +748,17 @@ class CarbonInterval extends DateInterval
     /**
      * Get total amount of given unit.
      *
-     * @param  string  $unit
-     * @return float
+     * @param string $unit
      *
      * @throws \InvalidArgumentException
+     *
+     * @return float
      */
     public function total($unit)
     {
         $unit = strtolower($unit);
 
-        if (! in_array($unit, ['seconds', 'minutes', 'hours', 'dayz', 'days', 'weeks', 'months', 'years'])) {
+        if (!in_array($unit, array('seconds', 'minutes', 'hours', 'dayz', 'days', 'weeks', 'months', 'years'))) {
             throw new InvalidArgumentException("Unknown unit '$unit'.");
         }
 
@@ -767,7 +767,7 @@ class CarbonInterval extends DateInterval
         foreach (static::$cascades as $property => $perBigger) {
             $carry = $this->$property + $carry;
 
-            if ($property == $unit || ($property == 'dayz' && in_array($unit, ['days', 'weeks']))) {
+            if ($property == $unit || ($property == 'dayz' && in_array($unit, array('days', 'weeks')))) {
                 $result = $carry;
 
                 break;
@@ -779,7 +779,7 @@ class CarbonInterval extends DateInterval
         foreach (array_reverse(static::$cascades, true) as $property => $perBigger) {
             $carry *= $perBigger;
 
-            if ($property == $unit || ($property == 'dayz' && in_array($unit, ['days', 'weeks']))) {
+            if ($property == $unit || ($property == 'dayz' && in_array($unit, array('days', 'weeks')))) {
                 $result += $carry;
 
                 break;

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -93,15 +93,18 @@ class CarbonInterval extends DateInterval
      *
      * Should only be modified by changing the factors or referenced constants.
      *
-     * @var array
+     * @return array
      */
-    protected static $cascades = array(
-        'seconds' => array('minutes', Carbon::SECONDS_PER_MINUTE),
-        'minutes' => array('hours', Carbon::MINUTES_PER_HOUR),
-        'hours' => array('dayz', Carbon::HOURS_PER_DAY),
-        'dayz' => array('months', Carbon::DAYS_PER_WEEK * Carbon::WEEKS_PER_MONTH),
-        'months' => array('years', Carbon::MONTHS_PER_YEAR),
-    );
+    protected static function getCascadeFactors()
+    {
+        return array(
+            'seconds' => array('minutes', Carbon::SECONDS_PER_MINUTE),
+            'minutes' => array('hours', Carbon::MINUTES_PER_HOUR),
+            'hours' => array('dayz', Carbon::HOURS_PER_DAY),
+            'dayz' => array('months', Carbon::DAYS_PER_WEEK * Carbon::WEEKS_PER_MONTH),
+            'months' => array('years', Carbon::MONTHS_PER_YEAR),
+        );
+    }
 
     /**
      * Determine if the interval was created via DateTime:diff() or not.
@@ -729,7 +732,7 @@ class CarbonInterval extends DateInterval
      */
     public function cascade()
     {
-        foreach (static::$cascades as $source => $cascade) {
+        foreach (static::getCascadeFactors() as $source => $cascade) {
             list($target, $factor) = $cascade;
 
             $value = $this->$source;
@@ -761,7 +764,7 @@ class CarbonInterval extends DateInterval
         $upToUnit = 0;
         $aboveUnit = 0;
 
-        foreach (static::$cascades as $source => $cascade) {
+        foreach (static::getCascadeFactors() as $source => $cascade) {
             list($target, $factor) = $cascade;
 
             if ($source == $unit || ($source == 'dayz' && in_array($unit, array('days', 'weeks')))) {
@@ -773,7 +776,7 @@ class CarbonInterval extends DateInterval
             $upToUnit = ($this->$source + $upToUnit) / $factor;
         }
 
-        foreach (array_reverse(static::$cascades, true) as $source => $cascade) {
+        foreach (array_reverse(static::getCascadeFactors(), true) as $source => $cascade) {
             list($target, $factor) = $cascade;
 
             if ($target == $unit || ($target == 'dayz' && in_array($unit, array('days', 'weeks')))) {

--- a/tests/CarbonInterval/CascadeTest.php
+++ b/tests/CarbonInterval/CascadeTest.php
@@ -22,9 +22,9 @@ class CascadeTest extends AbstractTestCase
         return array(
             array('3600s',                        'PT1H'),
             array('10000s',                       'PT2H46M40S'),
-            array('1276d',                        'P3Y6M16D'),
-            array('47d 14h',                      'P1M17DT14H'),
-            array('2y 123mo 5w 6d 47h 160m 217s', 'P12Y4M13DT1H43M37S'),
+            array('1276d',                        'P3Y9M16D'),
+            array('47d 14h',                      'P1M19DT14H'),
+            array('2y 123mo 5w 6d 47h 160m 217s', 'P12Y4M15DT1H43M37S'),
         );
     }
 }

--- a/tests/CarbonInterval/CascadeTest.php
+++ b/tests/CarbonInterval/CascadeTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\CarbonInterval;
+
+use Carbon\CarbonInterval;
+use Tests\AbstractTestCase;
+
+class CascadeTest extends AbstractTestCase
+{
+    /**
+     * @dataProvider provideIntervalSpecs
+     */
+    public function testCascadesOverflowedValues($spec, $expected)
+    {
+        $this->assertSame(
+            $expected, CarbonInterval::fromString($spec)->cascade()->spec()
+        );
+    }
+
+    public function provideIntervalSpecs() {
+        return array(
+            array('3600s',                        'PT1H'),
+            array('10000s',                       'PT2H46M40S'),
+            array('1276d',                        'P3Y6M16D'),
+            array('47d 14h',                      'P1M17DT14H'),
+            array('2y 123mo 5w 6d 47h 160m 217s', 'P12Y4M13DT1H43M37S'),
+        );
+    }
+}

--- a/tests/CarbonInterval/CascadeTest.php
+++ b/tests/CarbonInterval/CascadeTest.php
@@ -17,7 +17,8 @@ class CascadeTest extends AbstractTestCase
         );
     }
 
-    public function provideIntervalSpecs() {
+    public function provideIntervalSpecs()
+    {
         return array(
             array('3600s',                        'PT1H'),
             array('10000s',                       'PT2H46M40S'),

--- a/tests/CarbonInterval/TotalTest.php
+++ b/tests/CarbonInterval/TotalTest.php
@@ -17,7 +17,8 @@ class TotalTest extends AbstractTestCase
         );
     }
 
-    public function provideIntervalSpecs() {
+    public function provideIntervalSpecs()
+    {
         return array(
             array('10s',                'seconds', 10),
             array('100s',               'seconds', 100),
@@ -31,7 +32,7 @@ class TotalTest extends AbstractTestCase
             array('4y 2mo',             'days',    (4 * 12 + 2) * 30),
             array('165d',               'weeks',   165 / 7),
             array('5mo',                'weeks',   5 * 30 / 7),
-            array('6897d',              'months',  6897/30),
+            array('6897d',              'months',  6897 / 30),
             array('35mo',               'years',   35 / 12),
         );
     }
@@ -48,12 +49,12 @@ class TotalTest extends AbstractTestCase
     {
         $interval = CarbonInterval::create(0, 0, 0, 0, 150, 0, 0);
 
-        $this->assertSame(150 * 60 * 60,      $interval->totalSeconds);
-        $this->assertSame(150 * 60,           $interval->totalMinutes);
-        $this->assertSame(150,                $interval->totalHours);
-        $this->assertSame(150 / 24,           $interval->totalDays);
-        $this->assertSame(150 / 24 / 7,       $interval->totalWeeks);
-        $this->assertSame(150 / 24 / 30,      $interval->totalMonths);
+        $this->assertSame(150 * 60 * 60, $interval->totalSeconds);
+        $this->assertSame(150 * 60, $interval->totalMinutes);
+        $this->assertSame(150, $interval->totalHours);
+        $this->assertSame(150 / 24, $interval->totalDays);
+        $this->assertSame(150 / 24 / 7, $interval->totalWeeks);
+        $this->assertSame(150 / 24 / 30, $interval->totalMonths);
         $this->assertSame(150 / 24 / 30 / 12, $interval->totalYears);
     }
 }

--- a/tests/CarbonInterval/TotalTest.php
+++ b/tests/CarbonInterval/TotalTest.php
@@ -23,16 +23,16 @@ class TotalTest extends AbstractTestCase
             array('10s',                'seconds', 10),
             array('100s',               'seconds', 100),
             array('2d 4h 17m 35s',      'seconds', ((2 * 24 + 4) * 60 + 17) * 60 + 35),
-            array('1y',                 'Seconds', 12 * 30 * 24 * 60 * 60),
-            array('1000y',              'SECONDS', 1000 * 12 * 30 * 24 * 60 * 60),
+            array('1y',                 'Seconds', 12 * 4 * 7 * 24 * 60 * 60),
+            array('1000y',              'SECONDS', 1000 * 12 * 4 * 7 * 24 * 60 * 60),
             array('235s',               'minutes', 235 / 60),
             array('3h 14m 235s',        'minutes', 3 * 60 + 14 + 235 / 60),
             array('27h 150m 4960s',     'hours',   27 + (150 + 4960 / 60) / 60),
-            array('5mo 54d 185h 7680m', 'days',    5 * 30 + 54 + (185 + 7680 / 60) / 24),
-            array('4y 2mo',             'days',    (4 * 12 + 2) * 30),
+            array('5mo 54d 185h 7680m', 'days',    5 * 4 * 7 + 54 + (185 + 7680 / 60) / 24),
+            array('4y 2mo',             'days',    (4 * 12 + 2) * 4 * 7),
             array('165d',               'weeks',   165 / 7),
-            array('5mo',                'weeks',   5 * 30 / 7),
-            array('6897d',              'months',  6897 / 30),
+            array('5mo',                'weeks',   5 * 4),
+            array('6897d',              'months',  6897 / 7 / 4),
             array('35mo',               'years',   35 / 12),
         );
     }
@@ -54,7 +54,7 @@ class TotalTest extends AbstractTestCase
         $this->assertSame(150, $interval->totalHours);
         $this->assertSame(150 / 24, $interval->totalDays);
         $this->assertSame(150 / 24 / 7, $interval->totalWeeks);
-        $this->assertSame(150 / 24 / 30, $interval->totalMonths);
-        $this->assertSame(150 / 24 / 30 / 12, $interval->totalYears);
+        $this->assertSame(150 / 24 / 7 / 4, $interval->totalMonths);
+        $this->assertSame(150 / 24 / 7 / 4 / 12, $interval->totalYears);
     }
 }

--- a/tests/CarbonInterval/TotalTest.php
+++ b/tests/CarbonInterval/TotalTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\CarbonInterval;
+
+use Carbon\CarbonInterval;
+use Tests\AbstractTestCase;
+
+class TotalTest extends AbstractTestCase
+{
+    /**
+     * @dataProvider provideIntervalSpecs
+     */
+    public function testReturnsTotalValue($spec, $unit, $expected)
+    {
+        $this->assertSame(
+            $expected, CarbonInterval::fromString($spec)->total($unit)
+        );
+    }
+
+    public function provideIntervalSpecs() {
+        return array(
+            array('10s',                'seconds', 10),
+            array('100s',               'seconds', 100),
+            array('2d 4h 17m 35s',      'seconds', ((2 * 24 + 4) * 60 + 17) * 60 + 35),
+            array('1y',                 'Seconds', 12 * 30 * 24 * 60 * 60),
+            array('1000y',              'SECONDS', 1000 * 12 * 30 * 24 * 60 * 60),
+            array('235s',               'minutes', 235 / 60),
+            array('3h 14m 235s',        'minutes', 3 * 60 + 14 + 235 / 60),
+            array('27h 150m 4960s',     'hours',   27 + (150 + 4960 / 60) / 60),
+            array('5mo 54d 185h 7680m', 'days',    5 * 30 + 54 + (185 + 7680 / 60) / 24),
+            array('4y 2mo',             'days',    (4 * 12 + 2) * 30),
+            array('165d',               'weeks',   165 / 7),
+            array('5mo',                'weeks',   5 * 30 / 7),
+            array('6897d',              'months',  6897/30),
+            array('35mo',               'years',   35 / 12),
+        );
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testThrowsExceptionForInvalidUnits()
+    {
+        CarbonInterval::create()->total('foo');
+    }
+
+    public function testGetTotalsViaGetters()
+    {
+        $interval = CarbonInterval::create(0, 0, 0, 0, 150, 0, 0);
+
+        $this->assertSame(150 * 60 * 60,      $interval->totalSeconds);
+        $this->assertSame(150 * 60,           $interval->totalMinutes);
+        $this->assertSame(150,                $interval->totalHours);
+        $this->assertSame(150 / 24,           $interval->totalDays);
+        $this->assertSame(150 / 24 / 7,       $interval->totalWeeks);
+        $this->assertSame(150 / 24 / 30,      $interval->totalMonths);
+        $this->assertSame(150 / 24 / 30 / 12, $interval->totalYears);
+    }
+}


### PR DESCRIPTION
This PR adds two new `CarbonInterval` methods: `cascade()` and `total($unit)`, accompanied by `total<unit>` getters:

```php
echo CarbonInterval::months(76)->forHumans(); // 29 months
echo CarbonInterval::months(76)->cascade()->forHumans(); // 2 years 5 months
```

```php
$interval = CarbonInterval::fromString('3h 30m');
echo $interval->hours * 3600 + $interval->minutes * 60; // 12600

// even more useful when string can contain any units
echo CarbonInterval::fromString('3h 30m')->totalSeconds; // 12600
```

Methods functionality is slightly different, but both are based on the same `static::$cascades` mapping, thus I added both in the same pull request.

Let me know what you think!

I'm also open for suggestions about names, current may be a bit ambiguous. 