### PR TITLE
Multiply CarbonInterval given number of times

### DIFF
--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -622,6 +622,25 @@ class CarbonInterval extends DateInterval
     }
 
     /**
+     * Multiply current instance given number of times
+     *
+     * @param float $factor
+     *
+     * @return static
+     */
+    public function times($factor)
+    {
+        $this->years = round($this->years * $factor);
+        $this->months = round($this->months * $factor);
+        $this->dayz = round($this->dayz * $factor);
+        $this->hours = round($this->hours * $factor);
+        $this->minutes = round($this->minutes * $factor);
+        $this->seconds = round($this->seconds * $factor);
+
+        return $this;
+    }
+
+    /**
      * Get the interval_spec string of a date interval
      *
      * @param DateInterval $interval

--- a/tests/CarbonInterval/TimesTest.php
+++ b/tests/CarbonInterval/TimesTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonInterval;
+
+use Carbon\CarbonInterval;
+use Tests\AbstractTestCase;
+
+class TimesTest extends AbstractTestCase
+{
+    public function testTimesMoreThanOne()
+    {
+        $ci = CarbonInterval::create(4, 3, 2, 5, 5, 10, 11)->times(2.75);
+        $this->assertCarbonInterval($ci, 11, 8, 52, 14, 28, 30);
+    }
+
+    public function testTimesOne()
+    {
+        $ci = CarbonInterval::create(4, 3, 2, 5, 5, 10, 11)->times(1);
+        $this->assertCarbonInterval($ci, 4, 3, 19, 5, 10, 11);
+    }
+
+    public function testTimesLessThanOne()
+    {
+        $ci = CarbonInterval::create(4, 3, 2, 5, 5, 10, 11)->times(0.333);
+        $this->assertCarbonInterval($ci, 1, 1, 6, 2, 3, 4);
+    }
+
+    public function testTimesZero()
+    {
+        $ci = CarbonInterval::create(4, 3, 2, 5, 5, 10, 11)->times(0);
+        $this->assertCarbonInterval($ci, 0, 0, 0, 0, 0, 0);
+    }
+
+    public function testTimesLessThanZero()
+    {
+        $ci = CarbonInterval::create(4, 3, 2, 5, 5, 10, 11)->times(-1);
+        $this->assertCarbonInterval($ci, -4, -3, -19, -5, -10, -11);
+    }
+}


### PR DESCRIPTION
With this pull request merged this will be possible (will be useful in `CarbonPeriod`):

```php
$ci = CarbonInterval::create(4, 3, 2, 5, 5, 10, 11); // 4 years 3 months 2 weeks 5 days 5 hours 10 minutes 11 seconds
$ci->times(2.75); // 11 years 8 months 7 weeks 3 days 14 hours 28 minutes 30 seconds
$ci->times(0.333); // 1 year 1 month 6 days 2 hours 3 minutes 4 seconds
$ci->times(-1); // Oops!
```

Interval with negative values seemed to work just fine when added to `DateTime` and stuff. So maybe `forHumans` needs a refresher? Now it generates empty string for such interval.