### PR TITLE
Add methods for granular comparison (mentioned in #1248)

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -2329,10 +2329,10 @@ class Carbon extends DateTime implements JsonSerializable
     }
 
     /**
-     * Checks if the passed in date is in the same month as the instance´s month (and year if needed).
+     * Checks if the passed in date is in the same month as the instance´s month.
      *
-     * The second parameter $ofSameYear will be changed to default to true in 2.x to be consistent with
-     * the other comparison methods isSameDay, isSameHour. See Issue #1248
+     * Note that this defaults to only comparing the month while ignoring the year.
+     * To test if it is the same exact month of the same year, pass in true as the second parameter.
      *
      * @param \Carbon\Carbon|\DateTimeInterface|null $date       The instance to compare with or null to use the current date.
      * @param bool                                   $ofSameYear Check if it is the same month in the same year.

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -2331,6 +2331,9 @@ class Carbon extends DateTime implements JsonSerializable
     /**
      * Checks if the passed in date is in the same month as the instance month (and year if needed).
      *
+     * The second parameter $ofSameYear will be changed to default to true in 2.x to be consistent with
+     * the other comparison methods isSameDay, isSameHour. See Issue #1248
+     *
      * @param \Carbon\Carbon|\DateTimeInterface|null $date       The instance to compare with or null to use current day.
      * @param bool                                   $ofSameYear Check if it is the same month in the same year.
      *
@@ -2342,7 +2345,7 @@ class Carbon extends DateTime implements JsonSerializable
     }
 
     /**
-     * Checks if the passed in date is the same day as the instance current day.
+     * Checks if the passed in date is the same exact day as the instance current day.
      *
      * @param \Carbon\Carbon|\DateTimeInterface $date
      *
@@ -2351,6 +2354,18 @@ class Carbon extends DateTime implements JsonSerializable
     public function isSameDay($date)
     {
         return $this->isSameAs('Y-m-d', $date);
+    }
+
+    /**
+     * Checks if the passed in date is the same exact hour as the instance current hour.
+     *
+     * @param \Carbon\Carbon|\DateTimeInterface $date
+     *
+     * @return bool
+     */
+    public function isSameHour($date)
+    {
+        return $this->isSameAs('Y-m-d H', $date);
     }
 
     /**

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -2329,12 +2329,12 @@ class Carbon extends DateTime implements JsonSerializable
     }
 
     /**
-     * Checks if the passed in date is in the same month as the instance month (and year if needed).
+     * Checks if the passed in date is in the same month as the instance´s month (and year if needed).
      *
      * The second parameter $ofSameYear will be changed to default to true in 2.x to be consistent with
      * the other comparison methods isSameDay, isSameHour. See Issue #1248
      *
-     * @param \Carbon\Carbon|\DateTimeInterface|null $date       The instance to compare with or null to use current day.
+     * @param \Carbon\Carbon|\DateTimeInterface|null $date       The instance to compare with or null to use the current date.
      * @param bool                                   $ofSameYear Check if it is the same month in the same year.
      *
      * @return bool
@@ -2345,27 +2345,51 @@ class Carbon extends DateTime implements JsonSerializable
     }
 
     /**
-     * Checks if the passed in date is the same exact day as the instance current day.
+     * Checks if the passed in date is the same exact day as the instance´s day.
      *
-     * @param \Carbon\Carbon|\DateTimeInterface $date
+     * @param \Carbon\Carbon|\DateTimeInterface|null $date The instance to compare with or null to use the current date.
      *
      * @return bool
      */
-    public function isSameDay($date)
+    public function isSameDay($date = null)
     {
         return $this->isSameAs('Y-m-d', $date);
     }
 
     /**
-     * Checks if the passed in date is the same exact hour as the instance current hour.
+     * Checks if the passed in date is the same exact hour as the instance´s hour.
      *
-     * @param \Carbon\Carbon|\DateTimeInterface $date
+     * @param \Carbon\Carbon|\DateTimeInterface|null $date The instance to compare with or null to use the current date.
      *
      * @return bool
      */
-    public function isSameHour($date)
+    public function isSameHour($date = null)
     {
         return $this->isSameAs('Y-m-d H', $date);
+    }
+
+    /**
+     * Checks if the passed in date is the same exact minute as the instance´s minute.
+     *
+     * @param \Carbon\Carbon|\DateTimeInterface|null $date The instance to compare with or null to use the current date.
+     *
+     * @return bool
+     */
+    public function isSameMinute($date = null)
+    {
+        return $this->isSameAs('Y-m-d H:i', $date);
+    }
+
+    /**
+     * Checks if the passed in date is the same exact second as the instance´s second.
+     *
+     * @param \Carbon\Carbon|\DateTimeInterface|null $date The instance to compare with or null to use the current date.
+     *
+     * @return bool
+     */
+    public function isSameSecond($date = null)
+    {
+        return $this->isSameAs('Y-m-d H:i:s', $date);
     }
 
     /**

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -2345,6 +2345,16 @@ class Carbon extends DateTime implements JsonSerializable
     }
 
     /**
+     * Determines if the instance is in the current day.
+     *
+     * @return bool
+     */
+    public function isCurrentDay()
+    {
+        return $this->isSameDay();
+    }
+
+    /**
      * Checks if the passed in date is the same exact day as the instance´s day.
      *
      * @param \Carbon\Carbon|\DateTimeInterface|null $date The instance to compare with or null to use the current date.
@@ -2354,6 +2364,16 @@ class Carbon extends DateTime implements JsonSerializable
     public function isSameDay($date = null)
     {
         return $this->isSameAs('Y-m-d', $date);
+    }
+
+    /**
+     * Determines if the instance is in the current hour.
+     *
+     * @return bool
+     */
+    public function isCurrentHour()
+    {
+        return $this->isSameHour();
     }
 
     /**
@@ -2369,6 +2389,16 @@ class Carbon extends DateTime implements JsonSerializable
     }
 
     /**
+     * Determines if the instance is in the current minute.
+     *
+     * @return bool
+     */
+    public function isCurrentMinute()
+    {
+        return $this->isSameMinute();
+    }
+
+    /**
      * Checks if the passed in date is the same exact minute as the instance´s minute.
      *
      * @param \Carbon\Carbon|\DateTimeInterface|null $date The instance to compare with or null to use the current date.
@@ -2378,6 +2408,16 @@ class Carbon extends DateTime implements JsonSerializable
     public function isSameMinute($date = null)
     {
         return $this->isSameAs('Y-m-d H:i', $date);
+    }
+
+    /**
+     * Determines if the instance is in the current second.
+     *
+     * @return bool
+     */
+    public function isCurrentSecond()
+    {
+        return $this->isSameSecond();
     }
 
     /**

--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -359,6 +359,16 @@ class IsTest extends AbstractTestCase
         $this->assertFalse($current->isSameDay(new DateTime('2012-01-03')));
     }
 
+    public function testIsCurrentDayTrue()
+    {
+        $this->assertTrue(Carbon::now()->isCurrentDay());
+    }
+
+    public function testIsCurrentDayFalse()
+    {
+        $this->assertFalse(Carbon::now()->subDay()->isCurrentDay());
+    }
+
     public function testIsSameHourTrue()
     {
         $current = Carbon::create(2018, 5, 6, 12);
@@ -381,6 +391,16 @@ class IsTest extends AbstractTestCase
     {
         $current = Carbon::create(2018, 5, 6, 12);
         $this->assertFalse($current->isSameHour(new DateTime('2018-05-06T13:00:00')));
+    }
+
+    public function testIsCurrentHourTrue()
+    {
+        $this->assertTrue(Carbon::now()->isCurrentHour());
+    }
+
+    public function testIsCurrentHourFalse()
+    {
+        $this->assertFalse(Carbon::now()->subHour()->isCurrentHour());
     }
 
     public function testIsSameMinuteTrue()
@@ -407,6 +427,16 @@ class IsTest extends AbstractTestCase
         $this->assertFalse($current->isSameMinute(new DateTime('2018-05-06T13:31:00')));
     }
 
+    public function testIsCurrentMinuteTrue()
+    {
+        $this->assertTrue(Carbon::now()->isCurrentMinute());
+    }
+
+    public function testIsCurrentMinuteFalse()
+    {
+        $this->assertFalse(Carbon::now()->subMinute()->isCurrentMinute());
+    }
+
     public function testIsSameSecondTrue()
     {
         $current = Carbon::create(2018, 5, 6, 12, 30, 13);
@@ -429,6 +459,16 @@ class IsTest extends AbstractTestCase
     {
         $current = Carbon::create(2018, 5, 6, 12, 30, 13);
         $this->assertFalse($current->isSameSecond(new DateTime('2018-05-06T13:30:54')));
+    }
+
+    public function testIsCurrentSecondTrue()
+    {
+        $this->assertTrue(Carbon::now()->isCurrentSecond());
+    }
+
+    public function testIsCurrentSecondFalse()
+    {
+        $this->assertFalse(Carbon::now()->subSecond()->isCurrentSecond());
     }
 
     public function testIsDayOfWeek()

--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -353,6 +353,36 @@ class IsTest extends AbstractTestCase
         $this->assertFalse($current->isSameDay(Carbon::createFromDate(2012, 1, 3)));
     }
 
+    public function testIsSameDayFalseWithDateTime()
+    {
+        $current = Carbon::createFromDate(2012, 1, 2);
+        $this->assertFalse($current->isSameDay(new DateTime('2012-01-03')));
+    }
+
+    public function testIsSameHourTrue()
+    {
+        $current = Carbon::create(2018, 5, 6, 12);
+        $this->assertTrue($current->isSameHour(Carbon::create(2018, 5, 6, 12)));
+    }
+
+    public function testIsSameHourTrueWithDateTime()
+    {
+        $current = Carbon::create(2018, 5, 6, 12);
+        $this->assertTrue($current->isSameHour(new DateTime('2018-05-06T12:00:00')));
+    }
+
+    public function testIsSameHourFalse()
+    {
+        $current = Carbon::create(2018, 5, 6, 12);
+        $this->assertFalse($current->isSameHour(Carbon::create(2018, 5, 6, 13)));
+    }
+
+    public function testIsSameHourFalseWithDateTime()
+    {
+        $current = Carbon::create(2018, 5, 6, 12);
+        $this->assertFalse($current->isSameHour(new DateTime('2018-05-06T13:00:00')));
+    }
+
     public function testIsDayOfWeek()
     {
         // True in the past past
@@ -371,12 +401,6 @@ class IsTest extends AbstractTestCase
         // False in the future
         $this->assertFalse(Carbon::now()->addWeek()->previous(Carbon::MONDAY)->isDayOfWeek(0));
         $this->assertFalse(Carbon::now()->addMonth()->previous(Carbon::MONDAY)->isDayOfWeek(0));
-    }
-
-    public function testIsSameDayFalseWithDateTime()
-    {
-        $current = Carbon::createFromDate(2012, 1, 2);
-        $this->assertFalse($current->isSameDay(new DateTime('2012-01-03')));
     }
 
     public function testIsSameAs()

--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -383,6 +383,54 @@ class IsTest extends AbstractTestCase
         $this->assertFalse($current->isSameHour(new DateTime('2018-05-06T13:00:00')));
     }
 
+    public function testIsSameMinuteTrue()
+    {
+        $current = Carbon::create(2018, 5, 6, 12, 30);
+        $this->assertTrue($current->isSameMinute(Carbon::create(2018, 5, 6, 12, 30)));
+    }
+
+    public function testIsSameMinuteTrueWithDateTime()
+    {
+        $current = Carbon::create(2018, 5, 6, 12, 30);
+        $this->assertTrue($current->isSameMinute(new DateTime('2018-05-06T12:30:00')));
+    }
+
+    public function testIsSameMinuteFalse()
+    {
+        $current = Carbon::create(2018, 5, 6, 12, 30);
+        $this->assertFalse($current->isSameMinute(Carbon::create(2018, 5, 6, 13, 31)));
+    }
+
+    public function testIsSameMinuteFalseWithDateTime()
+    {
+        $current = Carbon::create(2018, 5, 6, 12, 30);
+        $this->assertFalse($current->isSameMinute(new DateTime('2018-05-06T13:31:00')));
+    }
+
+    public function testIsSameSecondTrue()
+    {
+        $current = Carbon::create(2018, 5, 6, 12, 30, 13);
+        $this->assertTrue($current->isSameSecond(Carbon::create(2018, 5, 6, 12, 30, 13)));
+    }
+
+    public function testIsSameSecondTrueWithDateTime()
+    {
+        $current = Carbon::create(2018, 5, 6, 12, 30, 13);
+        $this->assertTrue($current->isSameSecond(new DateTime('2018-05-06T12:30:13')));
+    }
+
+    public function testIsSameSecondFalse()
+    {
+        $current = Carbon::create(2018, 5, 6, 12, 30, 13);
+        $this->assertFalse($current->isSameSecond(Carbon::create(2018, 5, 6, 12, 30, 55)));
+    }
+
+    public function testIsSameSecondFalseWithDateTime()
+    {
+        $current = Carbon::create(2018, 5, 6, 12, 30, 13);
+        $this->assertFalse($current->isSameSecond(new DateTime('2018-05-06T13:30:54')));
+    }
+
     public function testIsDayOfWeek()
     {
         // True in the past past


### PR DESCRIPTION
This adds 6 methods for more fine-granular comparison of hours, minutes and seconds.

- isSameHour / isCurrentHour
- isSameMinute / isCurrentMinute
- isSameSecond / isCurrentSecond

Tests are in place and ran successfully, i also unified the PHPDocs for related methods and added a comment mentioning planned changes to align the behaviour of `isSameMonth()` with the other methods.