### PR TITLE
Allow to create from multiple formats

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -808,7 +808,7 @@ class Carbon extends DateTime implements JsonSerializable
     /**
      * Create a Carbon instance from a specific format or a format list.
      *
-     * @param string|array              $formats Datetime format or formats array to try
+     * @param string|array              $format Datetime format or formats array to try
      * @param string                    $time
      * @param \DateTimeZone|string|null $tz
      *
@@ -816,13 +816,13 @@ class Carbon extends DateTime implements JsonSerializable
      *
      * @return static
      */
-    public static function createFromFormat($formats, $time, $tz = null)
+    public static function createFromFormat($format, $time, $tz = null)
     {
-        foreach ((array) $formats as $format) {
+        foreach ((array) $format as $formatString) {
             if ($tz !== null) {
-                $date = parent::createFromFormat($format, $time, static::safeCreateDateTimeZone($tz));
+                $date = parent::createFromFormat($formatString, $time, static::safeCreateDateTimeZone($tz));
             } else {
-                $date = parent::createFromFormat($format, $time);
+                $date = parent::createFromFormat($formatString, $time);
             }
 
             $lastErrors = parent::getLastErrors();

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -818,6 +818,10 @@ class Carbon extends DateTime implements JsonSerializable
      */
     public static function createFromFormat($format, $time, $tz = null)
     {
+        $lastErrors = array(
+            'errors' => 'Empty formats list provided.',
+        );
+
         foreach ((array) $format as $formatString) {
             if ($tz !== null) {
                 $date = parent::createFromFormat($formatString, $time, static::safeCreateDateTimeZone($tz));

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -806,9 +806,9 @@ class Carbon extends DateTime implements JsonSerializable
     }
 
     /**
-     * Create a Carbon instance from a specific format.
+     * Create a Carbon instance from a specific format or a format list.
      *
-     * @param string                    $format Datetime format
+     * @param string|array              $formats Datetime format or formats array to try
      * @param string                    $time
      * @param \DateTimeZone|string|null $tz
      *
@@ -816,24 +816,42 @@ class Carbon extends DateTime implements JsonSerializable
      *
      * @return static
      */
-    public static function createFromFormat($format, $time, $tz = null)
+    public static function createFromFormat($formats, $time, $tz = null)
     {
-        if ($tz !== null) {
-            $date = parent::createFromFormat($format, $time, static::safeCreateDateTimeZone($tz));
-        } else {
-            $date = parent::createFromFormat($format, $time);
-        }
+        foreach ((array) $formats as $format) {
+            if ($tz !== null) {
+                $date = parent::createFromFormat($format, $time, static::safeCreateDateTimeZone($tz));
+            } else {
+                $date = parent::createFromFormat($format, $time);
+            }
 
-        $lastErrors = parent::getLastErrors();
+            $lastErrors = parent::getLastErrors();
 
-        if ($date instanceof DateTime || $date instanceof DateTimeInterface) {
-            $instance = static::instance($date);
-            $instance::setLastErrors($lastErrors);
+            if ($date instanceof DateTime || $date instanceof DateTimeInterface) {
+                $instance = static::instance($date);
+                $instance::setLastErrors($lastErrors);
 
-            return $instance;
+                return $instance;
+            }
         }
 
         throw new InvalidArgumentException(implode(PHP_EOL, $lastErrors['errors']));
+    }
+
+    /**
+     * Create a Carbon instance from a specific format or a format list.
+     *
+     * @param string|array              $formats Datetime format or formats array to try
+     * @param string                    $time
+     * @param \DateTimeZone|string|null $tz
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return static
+     */
+    public static function createFromFormats($formats, $time, $tz = null)
+    {
+        return static::createFromFormat($formats, $time, $tz);
     }
 
     /**

--- a/tests/Carbon/InstanceTest.php
+++ b/tests/Carbon/InstanceTest.php
@@ -58,6 +58,20 @@ class InstanceTest extends AbstractTestCase
         $this->assertSame($micro, $carbon->micro);
     }
 
+    public function testInstanceFromMultipleFormats()
+    {
+        $formats = array(
+            'Y-m-d H:i:s.u',
+            'Y-m-d H:i:s',
+        );
+        $carbon = Carbon::createFromFormats($formats, '2014-02-01 03:45:27.254687');
+        $carbon = Carbon::instance($carbon);
+        $this->assertSame('2014-02-01 03:45:27.254687', $carbon->format('Y-m-d H:i:s.u'));
+        $carbon = Carbon::createFromFormats($formats, '2014-02-01 03:45:27');
+        $carbon = Carbon::instance($carbon);
+        $this->assertSame('2014-02-01 03:45:27.000000', $carbon->format('Y-m-d H:i:s.u'));
+    }
+
     public function testInstanceStateSetBySetStateMethod()
     {
         $carbon = Carbon::__set_state(array(


### PR DESCRIPTION
This allow to create a Carbon instance from multiple possible formats. For example, if you have both date with and without microseconds, you can first try to get microsecond, then if the format does not match fallback to format without microseconds (see `testInstanceFromMultipleFormats`).

This can also allow some user multiple input such as: `array('Y-m-d', 'm/d/Y', 'n/j/Y', 'm/d/y')`

An alias `createFromFormats` allow to call with both singular and plural form.