### PR TITLE
Add Diff translations for Dutch

### DIFF
--- a/src/Carbon/Lang/nl.php
+++ b/src/Carbon/Lang/nl.php
@@ -28,4 +28,9 @@ return array(
     'from_now' => 'over :time',
     'after' => ':time later',
     'before' => ':time eerder',
+    'diff_now' => 'nu',
+    'diff_yesterday' => 'gisteren',
+    'diff_tomorrow' => 'morgen',
+    'diff_after_tomorrow' => 'overmorgen',
+    //'diff_before_tomorrow' => 'before yesterday', AFAIK this is not a thing in Dutch.
 );

--- a/src/Carbon/Lang/nl.php
+++ b/src/Carbon/Lang/nl.php
@@ -32,5 +32,5 @@ return array(
     'diff_yesterday' => 'gisteren',
     'diff_tomorrow' => 'morgen',
     'diff_after_tomorrow' => 'overmorgen',
-    //'diff_before_tomorrow' => 'before yesterday', AFAIK this is not a thing in Dutch.
+    'diff_before_yesterday' => 'eergisteren',
 );


### PR DESCRIPTION
```
There is still one string that I could  not translate,  since that does
not exist in Dutch.

If anyone else knows the word for "before yesterday" in English, please
leave a comment on the PR.

"Voorgisteren" would be the closest I can imagine, but its not correct.

Closing briannesbitt/Carbon#1272

Signed-off-by: MegaXLR <admin@megaxlr.net>
```