### PR TITLE
Update phpdoc comment with content from official documentation

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1977,7 +1977,7 @@ class Carbon extends DateTime implements JsonSerializable
      *
      * @param \Carbon\Carbon|\DateTimeInterface|mixed $date1
      * @param \Carbon\Carbon|\DateTimeInterface|mixed $date2
-     * @param bool                                    $equal Indicates if a > and < comparison should be used or <= or >=
+     * @param bool                                    $equal Indicates if an equal to comparison should be done
      *
      * @return bool
      */


### PR DESCRIPTION
The previous phpdoc comment is inappropriate.

So, I have replace it with the content from the official documentation ([https://carbon.nesbot.com/docs/](https://carbon.nesbot.com/docs/)).

Signed-off-by: codekaar <kharelbarun@gmail.com>