### PR TITLE
Respect mock instance in createFromFormat with partial format

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -430,13 +430,25 @@ class Carbon extends DateTime implements JsonSerializable
             $object = $tzName;
         }
 
-        $tz = @timezone_open((string) $object);
+        $tz = @timezone_open($object = (string) $object);
 
-        if ($tz === false) {
-            throw new InvalidArgumentException('Unknown or bad timezone ('.$object.')');
+        if ($tz !== false) {
+            return $tz;
         }
 
-        return $tz;
+        // Work-around for a bug fixed in PHP 5.5.10 https://bugs.php.net/bug.php?id=45528
+        // See: https://stackoverflow.com/q/14068594/2646927
+        // @codeCoverageIgnoreStart
+        if (strpos($object, ':') !== false) {
+            try {
+                return static::createFromFormat('O', $object)->getTimezone();
+            } catch (InvalidArgumentException $e) {
+                //
+            }
+        }
+        // @codeCoverageIgnoreEnd
+
+        throw new InvalidArgumentException('Unknown or bad timezone ('.$object.')');
     }
 
     ///////////////////////////////////////////////////////////////////

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -677,7 +677,7 @@ class Carbon extends DateTime implements JsonSerializable
             $year = 9999;
         }
 
-        $instance = static::createFromFormat('Y-n-j G:i:s', sprintf('%s-%s-%s %s:%02s:%02s', $year, $month, $day, $hour, $minute, $second), $tz);
+        $instance = static::createFromFormat('!Y-n-j G:i:s', sprintf('%s-%s-%s %s:%02s:%02s', $year, $month, $day, $hour, $minute, $second), $tz);
 
         if ($fixYear !== null) {
             $instance->addYears($fixYear);

--- a/tests/Carbon/TestingAidsTest.php
+++ b/tests/Carbon/TestingAidsTest.php
@@ -150,4 +150,47 @@ class TestingAidsTest extends AbstractTestCase
             $scope->assertSame('2013-07-01T09:00:00-07:00', Carbon::parse('now', 'America/Vancouver')->toIso8601String());
         }, $testNow);
     }
+
+    public function testCreateFromPartialFormat()
+    {
+        Carbon::setTestNow($now = Carbon::parse('2013-09-01 05:10:15', 'America/Vancouver'));
+
+        // Simple partial time.
+        $this->assertEquals('2018-05-06T05:10:15-07:00', Carbon::createFromFormat('Y-m-d', '2018-05-06')->toIso8601String());
+        $this->assertEquals('2013-09-01T10:20:30-07:00', Carbon::createFromFormat('H:i:s', '10:20:30')->toIso8601String());
+
+        // Custom timezone.
+        $this->assertEquals('2013-09-01T10:20:15+03:00', Carbon::createFromFormat('H:i e', '10:20 Europe/Kiev')->toIso8601String());
+        $this->assertEquals('2013-09-01T10:20:15+01:00', Carbon::createFromFormat('H:i', '10:20', 'Europe/London')->toIso8601String());
+        $this->assertEquals('2013-09-01T11:30:00+07:00', Carbon::createFromFormat('H:i:s e', '11:30:00+07:00')->toIso8601String());
+        $this->assertEquals('2013-09-01T11:30:00+05:00', Carbon::createFromFormat('H:i:s', '11:30:00', '+05:00')->toIso8601String());
+
+        // Escaped timezone.
+        $this->assertEquals('2013-09-01T05:10:15-07:00', Carbon::createFromFormat('\e', 'e')->toIso8601String());
+
+        // Weird format, naive modify would fail here.
+        $this->assertEquals('2005-08-09T05:10:15-07:00', Carbon::createFromFormat('l jS \of F Y', 'Tuesday 9th of August 2005')->toIso8601String());
+        $this->assertEquals('2013-09-01T05:12:13-07:00', Carbon::createFromFormat('i:s', '12:13')->toIso8601String());
+        $this->assertEquals('2018-09-05T05:10:15-07:00', Carbon::createFromFormat('Y/d', '2018/5')->toIso8601String());
+
+        // Resetting to epoch.
+        $this->assertEquals('2018-05-06T00:00:00-07:00', Carbon::createFromFormat('!Y-m-d', '2018-05-06')->toIso8601String());
+        $this->assertEquals('1970-01-01T10:20:30-08:00', Carbon::createFromFormat('Y-m-d! H:i:s', '2018-05-06 10:20:30')->toIso8601String());
+        $this->assertEquals('2018-05-06T00:00:00-07:00', Carbon::createFromFormat('Y-m-d|', '2018-05-06')->toIso8601String());
+        $this->assertEquals('1970-01-01T10:20:30-08:00', Carbon::createFromFormat('|H:i:s', '10:20:30')->toIso8601String());
+
+        // Resetting to epoch (timezone fun).
+        $this->assertEquals('1970-01-01T00:00:00-08:00', Carbon::createFromFormat('|', '')->toIso8601String());
+        $this->assertEquals('1970-01-01T00:00:00+03:00', Carbon::createFromFormat('e|', 'Europe/Kiev')->toIso8601String());
+        $this->assertEquals('1970-01-01T00:00:00+01:00', Carbon::createFromFormat('|', '', 'Europe/London')->toIso8601String());
+        $this->assertEquals('1970-01-01T00:00:00-08:00', Carbon::createFromFormat('!', '')->toIso8601String());
+        $this->assertEquals('1970-01-01T00:00:00+03:00', Carbon::createFromFormat('!e', 'Europe/Kiev')->toIso8601String());
+        $this->assertEquals('1970-01-01T00:00:00+01:00', Carbon::createFromFormat('!', '', 'Europe/London')->toIso8601String());
+        $this->assertEquals('1970-01-01T00:00:00-08:00', Carbon::createFromFormat('e!', 'Europe/Kiev')->toIso8601String());
+
+        // Escaped epoch resets.
+        $this->assertEquals('2013-09-01T05:10:15-07:00', Carbon::createFromFormat('\|', '|')->toIso8601String());
+        $this->assertEquals('2013-09-01T05:10:15-07:00', Carbon::createFromFormat('\!', '!')->toIso8601String());
+        $this->assertEquals('2013-09-01T05:10:15+03:00', Carbon::createFromFormat('e \!', 'Europe/Kiev !')->toIso8601String());
+    }
 }

--- a/tests/Carbon/TestingAidsTest.php
+++ b/tests/Carbon/TestingAidsTest.php
@@ -193,4 +193,12 @@ class TestingAidsTest extends AbstractTestCase
         $this->assertEquals('2013-09-01T05:10:15-07:00', Carbon::createFromFormat('\!', '!')->toIso8601String());
         $this->assertEquals('2013-09-01T05:10:15+03:00', Carbon::createFromFormat('e \!', 'Europe/Kiev !')->toIso8601String());
     }
+
+    public function testCreateFromPartialFormatWithMicroseconds()
+    {
+        Carbon::setTestNow($now = Carbon::parse('2013-09-01 05:10:15.123456', 'America/Vancouver'));
+
+        $this->assertEquals('2018-05-06 05:10:15.123456', Carbon::createFromFormat('Y-m-d', '2018-05-06')->format('Y-m-d H:i:s.u'));
+        $this->assertEquals('2013-09-01 10:20:30.654321', Carbon::createFromFormat('H:i:s.u', '10:20:30.654321')->format('Y-m-d H:i:s.u'));
+    }
 }


### PR DESCRIPTION
Let's say current time is:

```php
Carbon::now(); // 2018-05-10 16:22:30 America/Toronto
```

We set the mock instance to:

```php
Carbon::setTestNow('2013-09-01 05:10:15 America/Vancouver');
```

One would expect that when using `Carbon::createFromFormat` with a partial format, the missing part will be filled from the mock:

```php
Carbon::createFromFormat('Y-m-d', '2016-06-10'); // 2016-06-10 05:10:15 America/Vancouver
Carbon::createFromFormat('H:i:s', '10:20:30'); // 2013-09-01 10:20:30 America/Vancouver
```

However as of now it is filled from the actual time instead:

```php
Carbon::createFromFormat('Y-m-d', '2016-06-10'); // 2016-06-10 16:22:30 America/Toronto
Carbon::createFromFormat('H:i:s', '10:20:30'); // 2018-05-10 10:20:30 America/Toronto
```

This PR fixes that issue, by prepending mocked time to the input. It works with many fancy formats, including unix epoch reset flags `!`, `|`. See new tests for more details.

Changes are not backwards compatible, however that's often the case when fixing bugs, which I would assume the old behavior to be. Worst case scenario would be that we break some odd monkey-fixed tests that circumvented the problem by comparing against the real time. We don't need to worry about someone using `setTestNow` in the business code, right?

The PR includes two additional changes to preserve current behaviors:
1. Last errors applied to resulting instance come from parsing original (unmodified) format.
2. Microseconds in the `Carbon::create` method are explicitly set to 0 by using format `!Y-n-j G:i:s` instead of previous `Y-n-j G:i:s`.

Bonus:
1. Fix creating timezone from an offset for PHP below 5.5.10.

Fixes #1280.