### PR TITLE
Fix parsing relative formats with mock and microseconds before PHP 7.1

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1530,7 +1530,7 @@ class Carbon extends DateTime implements JsonSerializable
         $date2 = new DateTime('2001-12-25T17:59:13Z');
         $date2->modify($time);
 
-        if ($date1 == $date2) {
+        if ($date1 == $date2 || $date1->format('Y-m-d') === $date2->format('Y-m-d')) {
             return false;
         }
 

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -471,6 +471,8 @@ class Carbon extends DateTime implements JsonSerializable
         // instance then override as required
         $isNow = empty($time) || $time === 'now';
         if (static::hasTestNow() && ($isNow || static::hasRelativeKeywords($time))) {
+            list($relativeKeywords, $clearMicroseconds) = static::hasRelativeKeywords($time) ?: array(false, false);
+
             $testInstance = clone static::getTestNow();
 
             //shift the time according to the given time zone
@@ -480,11 +482,21 @@ class Carbon extends DateTime implements JsonSerializable
                 $tz = $testInstance->getTimezone();
             }
 
-            if (static::hasRelativeKeywords($time)) {
+            if ($relativeKeywords) {
                 $testInstance->modify($time);
             }
 
-            $time = $testInstance->format(static::MOCK_DATETIME_FORMAT);
+            $result = $testInstance->format(static::MOCK_DATETIME_FORMAT);
+
+            // Fix below let's us reset microseconds in PHP versions before 7.1 when time is given in
+            // absolute form but without date, or as keywords like noon or tomorrow.
+            if (preg_match('/\d+:\d+:\d+\.(\d+)/', $time, $match)) {
+                $time = substr($result, 0, -6).$match[1];
+            } elseif ($clearMicroseconds) {
+                $time = substr($result, 0, -6).'000000';
+            } else {
+                $time = $result;
+            }
         }
 
         $timezone = static::safeCreateDateTimeZone($tz);
@@ -1500,9 +1512,12 @@ class Carbon extends DateTime implements JsonSerializable
     /**
      * Determine if a time string will produce a relative date.
      *
+     * Return false when time is absolute or otherwise return array with two elements.
+     * First element is always true, second will be true if microseconds should be cleared.
+     *
      * @param string $time
      *
-     * @return bool true if time match a relative date, false if absolute or invalid time string
+     * @return false|array
      */
     public static function hasRelativeKeywords($time)
     {
@@ -1510,12 +1525,16 @@ class Carbon extends DateTime implements JsonSerializable
             return false;
         }
 
-        $date1 = new DateTime('2000-01-01T00:00:00Z');
+        $date1 = new DateTime('2000-01-01T03:27:45Z');
         $date1->modify($time);
-        $date2 = new DateTime('2001-12-25T00:00:00Z');
+        $date2 = new DateTime('2001-12-25T17:59:13Z');
         $date2->modify($time);
 
-        return $date1 != $date2;
+        if ($date1 == $date2) {
+            return false;
+        }
+
+        return array(true, $date1->format('s') === $date2->format('s'));
     }
 
     ///////////////////////////////////////////////////////////////////

--- a/tests/Carbon/RelativeDateStringTest.php
+++ b/tests/Carbon/RelativeDateStringTest.php
@@ -18,7 +18,7 @@ class RelativeDateStringTest extends AbstractTestCase
 {
     public $scenarios = array(
 
-        // ensure regular timestamps are flagged as relative
+        // ensure regular timestamps are not flagged as relative
         '2018-01-02 03:04:05' => array('date' => '2018-01-02', 'is_relative' => false),
         '1500-01-02 12:00:00' => array('date' => '1500-01-02', 'is_relative' => false),
         '1985-12-10' => array('date' => '1985-12-10', 'is_relative' => false),
@@ -55,7 +55,7 @@ class RelativeDateStringTest extends AbstractTestCase
 
             $this->assertEquals(
                 $expected['is_relative'],
-                $actual,
+                (bool) $actual,
                 "Failed relative keyword matching for scenario: {$string} (expected: {$expected['is_relative']})"
             );
         }

--- a/tests/Carbon/RelativeDateStringTest.php
+++ b/tests/Carbon/RelativeDateStringTest.php
@@ -38,6 +38,8 @@ class RelativeDateStringTest extends AbstractTestCase
         'december 1750' => array('date' => '1750-12-01', 'is_relative' => false),
         'last sunday of January 2005' => array('date' => '2005-01-30', 'is_relative' => false),
         'January 2008' => array('date' => '2008-01-01', 'is_relative' => false),
+        'sunday 2015-02-23' => array('date' => '2015-03-01', 'is_relative' => false),
+        'first sunday of January 2017' => array('date' => '2017-01-01', 'is_relative' => false),
 
         // dates relative to now
         'first day of next month' => array('date' => '2017-02-01', 'is_relative' => true),
@@ -46,6 +48,10 @@ class RelativeDateStringTest extends AbstractTestCase
         'monday december' => array('date' => '2017-12-04', 'is_relative' => true),
         'next saturday' => array('date' => '2017-01-07', 'is_relative' => true),
         'april' => array('date' => '2017-04-01', 'is_relative' => true),
+        'today +2014 days' => array('date' => '2022-07-08', 'is_relative' => true),
+        'next sunday -3600 seconds' => array('date' => '2017-01-07', 'is_relative' => true),
+        'last day of this month' => array('date' => '2017-01-31', 'is_relative' => true),
+        'first sunday of next month' => array('date' => '2017-02-05', 'is_relative' => true),
     );
 
     public function test_keyword_matching()

--- a/tests/Carbon/RelativeDateStringTest.php
+++ b/tests/Carbon/RelativeDateStringTest.php
@@ -52,6 +52,8 @@ class RelativeDateStringTest extends AbstractTestCase
         'next sunday -3600 seconds' => array('date' => '2017-01-07', 'is_relative' => true),
         'last day of this month' => array('date' => '2017-01-31', 'is_relative' => true),
         'first sunday of next month' => array('date' => '2017-02-05', 'is_relative' => true),
+        'noon' => array('date' => '2017-01-01', 'is_relative' => true),
+        'tomorrow' => array('date' => '2017-01-02', 'is_relative' => true),
     );
 
     public function test_keyword_matching()

--- a/tests/Carbon/TestingAidsTest.php
+++ b/tests/Carbon/TestingAidsTest.php
@@ -111,7 +111,39 @@ class TestingAidsTest extends AbstractTestCase
 
             $scope->assertSame('2013-10-01 05:15:05', Carbon::parse('first day of next month')->toDateTimeString());
             $scope->assertSame('2013-09-30 05:15:05', Carbon::parse('last day of this month')->toDateTimeString());
+
+            $scope->assertSame('2013-09-01 06:00:00', Carbon::parse('6:00')->toDateTimeString());
+            $scope->assertSame('2013-09-01 17:31:24', Carbon::parse('17:31:24')->toDateTimeString());
+
+            $scope->assertSame('2013-09-01 12:00:00', Carbon::parse('noon')->toDateTimeString());
         }, $testNow);
+    }
+
+    public function testParseRelativeWithTestValueSetAndMicroseconds()
+    {
+        Carbon::setTestNow($now = Carbon::parse('2013-09-01 05:15:05.123456'));
+
+        $this->assertSame('2013-09-01 05:10:05.123456', Carbon::parse('5 minutes ago')->format('Y-m-d H:i:s.u'));
+        $this->assertSame('2013-08-25 05:15:05.123456', Carbon::parse('1 week ago')->format('Y-m-d H:i:s.u'));
+
+        $this->assertSame('2013-09-02 00:00:00.000000', Carbon::parse('tomorrow')->format('Y-m-d H:i:s.u'));
+        $this->assertSame('2013-09-01 00:00:00.000000', Carbon::parse('today')->format('Y-m-d H:i:s.u'));
+        $this->assertSame('2013-08-31 00:00:00.000000', Carbon::parse('yesterday')->format('Y-m-d H:i:s.u'));
+
+        $this->assertSame('2013-09-02 05:15:05.123456', Carbon::parse('+1 day')->format('Y-m-d H:i:s.u'));
+        $this->assertSame('2013-08-31 05:15:05.123456', Carbon::parse('-1 day')->format('Y-m-d H:i:s.u'));
+
+        $this->assertSame('2013-09-02 00:00:00.000000', Carbon::parse('next monday')->format('Y-m-d H:i:s.u'));
+        $this->assertSame('2013-08-27 00:00:00.000000', Carbon::parse('last tuesday')->format('Y-m-d H:i:s.u'));
+        $this->assertSame('2013-09-04 00:00:00.000000', Carbon::parse('this wednesday')->format('Y-m-d H:i:s.u'));
+
+        $this->assertSame('2013-10-01 05:15:05.123456', Carbon::parse('first day of next month')->format('Y-m-d H:i:s.u'));
+        $this->assertSame('2013-09-30 05:15:05.123456', Carbon::parse('last day of this month')->format('Y-m-d H:i:s.u'));
+
+        $this->assertSame('2013-09-01 06:00:00.000000', Carbon::parse('6:00')->format('Y-m-d H:i:s.u'));
+        $this->assertSame('2013-09-01 17:31:24.654321', Carbon::parse('17:31:24.654321')->format('Y-m-d H:i:s.u'));
+
+        $this->assertSame('2013-09-01 12:00:00.000000', Carbon::parse('noon')->format('Y-m-d H:i:s.u'));
     }
 
     public function testHasRelativeKeywords()

--- a/tests/Carbon/TestingAidsTest.php
+++ b/tests/Carbon/TestingAidsTest.php
@@ -146,17 +146,6 @@ class TestingAidsTest extends AbstractTestCase
         $this->assertSame('2013-09-01 12:00:00.000000', Carbon::parse('noon')->format('Y-m-d H:i:s.u'));
     }
 
-    public function testHasRelativeKeywords()
-    {
-        $this->assertFalse(Carbon::hasRelativeKeywords('sunday 2015-02-23'));
-        $this->assertTrue(Carbon::hasRelativeKeywords('today +2014 days'));
-        $this->assertTrue(Carbon::hasRelativeKeywords('next sunday -3600 seconds'));
-        $this->assertTrue(Carbon::hasRelativeKeywords('last day of this month'));
-        $this->assertFalse(Carbon::hasRelativeKeywords('last day of last month of 2015'));
-        $this->assertTrue(Carbon::hasRelativeKeywords('first sunday of next month'));
-        $this->assertFalse(Carbon::hasRelativeKeywords('first sunday of January 2017'));
-    }
-
     public function testParseRelativeWithMinusSignsInDate()
     {
         $testNow = Carbon::parse('2013-09-01 05:15:05');


### PR DESCRIPTION
Fixed a little inconsistency when parsing relative formats with a mock instance prior to PHP 7.1:

```php
Carbon::now(); // 2018-05-16 18:11:12.123456
Carbon::parse('12:25'); // 2018-05-16 12:25:00.000000

Carbon::setTestNow('2018-05-16 18:11:12.123456');
Carbon::parse('12:25'); // PHP >= 7.1: 2018-05-16 12:25:00.000000
                        // PHP  < 7.1: 2018-05-16 12:25:00.123456
Carbon::parse('17:31:24.654321'); // PHP >= 7.1: 2018-05-16 17:31:24.654321
                                  // PHP  < 7.1: 2018-05-16 17:31:24.123456
```

All absolute and relative formats will now work correctly with microseconds.
