### PR TITLE
Update carbon period

### DIFF
--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -207,7 +207,7 @@ class CarbonPeriod implements Iterator, Countable
     /**
      * The cached validation result for current date.
      *
-     * @var bool|null
+     * @var bool|static::END_ITERATION
      */
     protected $validationResult;
 

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -1246,7 +1246,7 @@ class CarbonPeriod implements Iterator, Countable
         $state = array(
             $this->key,
             $this->current ? $this->current->copy() : null,
-            $this->validationResult
+            $this->validationResult,
         );
 
         $result = iterator_to_array($this);

--- a/tests/CarbonInterval/ToPeriodTest.php
+++ b/tests/CarbonInterval/ToPeriodTest.php
@@ -24,11 +24,6 @@ class ToPeriodTest extends AbstractTestCase
     {
         return array(
             array(
-                CarbonInterval::month(1),
-                array(),
-                'P1M',
-            ),
-            array(
                 CarbonInterval::days(3),
                 array('2017-10-15', 4),
                 'R4/2017-10-15T00:00:00-04:00/P3D',

--- a/tests/CarbonPeriod/AliasTest.php
+++ b/tests/CarbonPeriod/AliasTest.php
@@ -31,9 +31,6 @@ class AliasTest extends AbstractTestCase
         $period->sinceNow(false);
         $this->assertEquals(Carbon::now(), $period->getStartDate());
         $this->assertEquals(CarbonPeriod::EXCLUDE_START_DATE, $period->getOptions());
-
-        $period->start();
-        $this->assertNull($period->getStartDate());
     }
 
     public function testSetEndDate()
@@ -112,8 +109,8 @@ class AliasTest extends AbstractTestCase
         $this->assertEquals(Carbon::parse($start), $period->getStartDate());
         $this->assertEquals(Carbon::parse($end), $period->getEndDate());
 
-        $period->dates();
-        $this->assertNull($period->getStartDate());
+        $period->dates(Carbon::now());
+        $this->assertEquals(Carbon::now(), $period->getStartDate());
         $this->assertNull($period->getEndDate());
     }
 

--- a/tests/CarbonPeriod/CreateTest.php
+++ b/tests/CarbonPeriod/CreateTest.php
@@ -446,13 +446,11 @@ class CreateTest extends AbstractTestCase
     {
         $period = new CarbonPeriod;
 
-        $this->assertNull($period->getStartDate());
-        $this->assertSame('P1D', $period->getDateInterval()->spec());
+        $this->assertEquals(new Carbon, $period->getStartDate());
+        $this->assertEquals('P1D', $period->getDateInterval()->spec());
         $this->assertNull($period->getEndDate());
         $this->assertNull($period->getRecurrences());
-        $this->assertSame(0, $period->getOptions());
-
-        $this->assertEmpty($this->standardizeDates($period));
+        $this->assertEquals(0, $period->getOptions());
     }
 
     public function testCreateFromDateStringsWithTimezones()

--- a/tests/CarbonPeriod/FilterTest.php
+++ b/tests/CarbonPeriod/FilterTest.php
@@ -306,9 +306,6 @@ class FilterTest extends AbstractTestCase
         $this->assertEmpty($period->getFilters());
     }
 
-    /**
-     * Relies on caching validation and iteration results.
-     */
     public function testAcceptEveryOther()
     {
         $period = new CarbonPeriod(
@@ -324,13 +321,6 @@ class FilterTest extends AbstractTestCase
         $this->assertEquals(
             // Note: Without caching validation results the dates would be unpredictable
             // as we cannot know how many calls to validator occur per iteration.
-            $this->standardizeDates(array('2018-04-16', '2018-04-18', '2018-04-20')),
-            $this->standardizeDates($period)
-        );
-
-        $this->assertEquals(
-            // Note: Without caching iteration results the dates would be complementary
-            // to the above as this time first item would be rejected.
             $this->standardizeDates(array('2018-04-16', '2018-04-18', '2018-04-20')),
             $this->standardizeDates($period)
         );

--- a/tests/CarbonPeriod/FilterTest.php
+++ b/tests/CarbonPeriod/FilterTest.php
@@ -268,7 +268,6 @@ class FilterTest extends AbstractTestCase
     {
         $period = CarbonPeriod::create(new DateTime('2018-04-16'), new DateTime('2018-07-15'))->setRecurrences(3);
 
-        $period->setStartDate(null);
         $period->setEndDate(null);
         $period->setRecurrences(null);
 

--- a/tests/CarbonPeriod/FilterTest.php
+++ b/tests/CarbonPeriod/FilterTest.php
@@ -22,17 +22,6 @@ use Tests\CarbonPeriod\Fixtures\FooFilters;
 
 class FilterTest extends AbstractTestCase
 {
-    public function dummyPeriod()
-    {
-        $period = new CarbonPeriod(
-            new DateTime('2018-04-16'), new DateTime('2018-07-15')
-        );
-
-        $period->setFilters(array());
-
-        return $period;
-    }
-
     public function dummyFilter()
     {
         return function () {
@@ -42,7 +31,7 @@ class FilterTest extends AbstractTestCase
 
     public function testGetAndSetFilters()
     {
-        $period = $this->dummyPeriod();
+        $period = new CarbonPeriod;
 
         $this->assertSame(array(), $period->getFilters());
         $this->assertSame($period, $period->setFilters($filters = array(
@@ -91,7 +80,7 @@ class FilterTest extends AbstractTestCase
 
     public function testAddAndPrependFilters()
     {
-        $period = $this->dummyPeriod();
+        $period = new CarbonPeriod;
 
         $period->addFilter($filter1 = $this->dummyFilter())
             ->addFilter($filter2 = $this->dummyFilter())
@@ -106,7 +95,7 @@ class FilterTest extends AbstractTestCase
 
     public function testRemoveFilterByInstance()
     {
-        $period = $this->dummyPeriod();
+        $period = new CarbonPeriod;
 
         $period->addFilter($filter1 = $this->dummyFilter())
             ->addFilter($filter2 = $this->dummyFilter())
@@ -122,7 +111,7 @@ class FilterTest extends AbstractTestCase
 
     public function testRemoveFilterByName()
     {
-        $period = $this->dummyPeriod();
+        $period = new CarbonPeriod;
 
         $period->addFilter($filter1 = $this->dummyFilter())
             ->addFilter($filter2 = $this->dummyFilter(), 'foo')
@@ -240,22 +229,6 @@ class FilterTest extends AbstractTestCase
         );
     }
 
-    public function testResetNumberOfRecurrences()
-    {
-        $period = new CarbonPeriod(
-            new DateTime('2018-04-16'), new DateTime('2018-07-15')
-        );
-
-        $period->setRecurrences(1)
-            ->resetFilters()
-            ->setRecurrences(3);
-
-        $this->assertEquals(
-            $this->standardizeDates(array('2018-04-16', '2018-04-17', '2018-04-18')),
-            $this->standardizeDates($period)
-        );
-    }
-
     public function testCallbackArguments()
     {
         $period = new CarbonPeriod(
@@ -312,6 +285,8 @@ class FilterTest extends AbstractTestCase
             new DateTime('2018-04-16'), new DateTime('2018-04-20')
         );
 
+        // Note: Without caching validation results the dates would be unpredictable
+        // as we cannot know how many calls to the filter will occur per iteration.
         $period->addFilter(function ($date) {
             static $accept;
 
@@ -319,8 +294,6 @@ class FilterTest extends AbstractTestCase
         });
 
         $this->assertEquals(
-            // Note: Without caching validation results the dates would be unpredictable
-            // as we cannot know how many calls to validator occur per iteration.
             $this->standardizeDates(array('2018-04-16', '2018-04-18', '2018-04-20')),
             $this->standardizeDates($period)
         );
@@ -345,7 +318,7 @@ class FilterTest extends AbstractTestCase
         );
     }
 
-    public function testAddFilterFromCarbonIsMethod()
+    public function testAddFilterFromCarbonMethod()
     {
         $period = CarbonPeriod::create('2018-01-01', '2018-06-01');
 

--- a/tests/CarbonPeriod/FilterTest.php
+++ b/tests/CarbonPeriod/FilterTest.php
@@ -47,16 +47,13 @@ class FilterTest extends AbstractTestCase
         );
 
         $period->setRecurrences($recurrences = 3);
-
         $period->setFilters($period->getFilters());
 
-        $this->assertEquals($start, $period->getStartDate());
         $this->assertEquals($end, $period->getEndDate());
         $this->assertEquals($recurrences, $period->getRecurrences());
 
         $period->setFilters(array());
 
-        $this->assertNull($period->getStartDate());
         $this->assertNull($period->getEndDate());
         $this->assertNull($period->getRecurrences());
     }
@@ -73,7 +70,6 @@ class FilterTest extends AbstractTestCase
         $this->assertSame($period, $period->resetFilters());
 
         $this->assertSame(array(
-            array(CarbonPeriod::START_DATE_FILTER, null),
             array(CarbonPeriod::END_DATE_FILTER, null),
         ), $period->getFilters());
     }

--- a/tests/CarbonPeriod/IteratorTest.php
+++ b/tests/CarbonPeriod/IteratorTest.php
@@ -424,4 +424,24 @@ class IteratorTest extends AbstractTestCase
 
         $this->assertEquals($current, $period->current());
     }
+
+    public function testInvertDateIntervalDuringIteration()
+    {
+        $period = new CarbonPeriod('2018-04-11', 5);
+
+        $results = array();
+
+        foreach ($period as $key => $date) {
+            $results[] = $date;
+
+            if ($key === 2) {
+                $period->invertDateInterval();
+            }
+        }
+
+        $this->assertEquals(
+            $this->standardizeDates(array('2018-04-11', '2018-04-12', '2018-04-13', '2018-04-12', '2018-04-11')),
+            $this->standardizeDates($results)
+        );
+    }
 }

--- a/tests/CarbonPeriod/IteratorTest.php
+++ b/tests/CarbonPeriod/IteratorTest.php
@@ -332,25 +332,6 @@ class IteratorTest extends AbstractTestCase
         $this->assertEquals(2, $counter);
     }
 
-    public function testReuseCachedValidationResultAfterRewind()
-    {
-        $period = CarbonPeriodFactory::withCounter($counter);
-
-        $period->addFilter(CarbonPeriod::END_ITERATION);
-
-        foreach ($period as $date) {
-            //
-        }
-
-        $this->assertEquals(1, $counter);
-
-        foreach ($period as $date) {
-            //
-        }
-
-        $this->assertEquals(1, $counter);
-    }
-
     public function testClearCachedValidationResultWhenPropertiesAreChanged()
     {
         $period = CarbonPeriod::create('2012-10-01');
@@ -360,19 +341,6 @@ class IteratorTest extends AbstractTestCase
         $period->addFilter(CarbonPeriod::END_ITERATION);
 
         $this->assertNull($period->current());
-    }
-
-    public function testReuseValidIterationResultsInSubsequentIteration()
-    {
-        $period = CarbonPeriodFactory::withCounter($counter);
-
-        $expected = $this->standardizeDates(array('2012-10-01', '2012-10-02', '2012-10-03'));
-
-        $this->assertEquals($expected, $this->standardizeDates(iterator_to_array($period)));
-        $this->assertEquals(3, $counter);
-
-        $this->assertEquals($expected, $this->standardizeDates(iterator_to_array($period)));
-        $this->assertEquals(3, $counter);
     }
 
     public function testClearInvalidIterationResultsBeforeSubsequentIteration()
@@ -424,17 +392,6 @@ class IteratorTest extends AbstractTestCase
         );
     }
 
-    public function testReusePartialResultsAfterRewindMidIteration()
-    {
-        $period = CarbonPeriodFactory::withCounter($counter);
-
-        $period->next();
-        $this->assertEquals(2, $counter);
-
-        iterator_to_array($period);
-        $this->assertEquals(3, $counter);
-    }
-
     public function testHandleDstBackwardChangeWhenReusingPartialResults()
     {
         $period = CarbonPeriod::create(
@@ -454,17 +411,6 @@ class IteratorTest extends AbstractTestCase
 
         $period->next();
         $this->assertEquals($expected, $this->standardizeDates(iterator_to_array($period)));
-    }
-
-    public function testCacheEmptyIterationResults()
-    {
-        $period = CarbonPeriodFactory::withCounter($counter)->setEndDate('2012-09-01');
-
-        iterator_to_array($period);
-        $this->assertEquals(1, $counter);
-
-        iterator_to_array($period);
-        $this->assertEquals(1, $counter);
     }
 
     public function testExtendCompletedIteration()
@@ -515,39 +461,5 @@ class IteratorTest extends AbstractTestCase
 
         $period->removeFilter(CarbonPeriod::END_ITERATION);
         $this->assertEquals($start, $period->current());
-    }
-
-    public function testClearCachedIterationResults()
-    {
-        $period = CarbonPeriodFactory::withStackFilter();
-
-        $this->assertEquals(
-            $this->standardizeDates(array('2001-01-01', '2001-01-03')),
-            $this->standardizeDates($period)
-        );
-
-        $period->reset();
-
-        $this->assertEquals(
-            $this->standardizeDates(array('2001-01-03', '2001-01-04')),
-            $this->standardizeDates($period)
-        );
-    }
-
-    public function testDisableCachingOfIterationResults()
-    {
-        $period = CarbonPeriodFactory::withStackFilter();
-
-        $this->assertEquals(
-            $this->standardizeDates(array('2001-01-01', '2001-01-03')),
-            $this->standardizeDates($period)
-        );
-
-        $period->setOptions(CarbonPeriod::DISABLE_RESULTS_CACHE);
-
-        $this->assertEquals(
-            $this->standardizeDates(array('2001-01-03', '2001-01-04')),
-            $this->standardizeDates($period)
-        );
     }
 }

--- a/tests/CarbonPeriod/IteratorTest.php
+++ b/tests/CarbonPeriod/IteratorTest.php
@@ -332,7 +332,7 @@ class IteratorTest extends AbstractTestCase
         $this->assertEquals(2, $counter);
     }
 
-    public function testClearCachedValidationResultWhenPropertiesAreChanged()
+    public function testInvalidateCurrentAfterChangingParameters()
     {
         $period = CarbonPeriod::create('2012-10-01');
 
@@ -341,33 +341,6 @@ class IteratorTest extends AbstractTestCase
         $period->addFilter(CarbonPeriod::END_ITERATION);
 
         $this->assertNull($period->current());
-    }
-
-    public function testClearInvalidIterationResultsBeforeSubsequentIteration()
-    {
-        $period = CarbonPeriodFactory::withCounter($counter);
-
-        $results = array();
-
-        foreach ($period as $key => $current) {
-            $results[$key] = $current;
-
-            if ($key === 1) {
-                $period->setStartDate('2012-09-15');
-            }
-        }
-
-        $this->assertEquals(
-            $this->standardizeDates(array('2012-10-01', '2012-10-02', '2012-10-03')),
-            $this->standardizeDates($results)
-        );
-        $this->assertEquals(3, $counter);
-
-        $this->assertEquals(
-            $this->standardizeDates(array('2012-09-15', '2012-09-16', '2012-09-17')),
-            $this->standardizeDates(iterator_to_array($period))
-        );
-        $this->assertEquals(6, $counter);
     }
 
     public function testTraversePeriodDynamically()
@@ -390,27 +363,6 @@ class IteratorTest extends AbstractTestCase
             $this->standardizeDates(array('2012-07-04', '2012-07-10', '2012-07-16')),
             $this->standardizeDates($results)
         );
-    }
-
-    public function testHandleDstBackwardChangeWhenReusingPartialResults()
-    {
-        $period = CarbonPeriod::create(
-            '2018-10-28 1:30 Europe/Oslo', 'PT30M', '2018-10-28 3:30 Europe/Oslo'
-        );
-
-        $expected = array(
-            '2018-10-28 01:30:00 +02:00',
-            // Note: it would be logical if the two following offsets were +02:00 as it is still DST.
-            '2018-10-28 02:00:00 +01:00',
-            '2018-10-28 02:30:00 +01:00',
-            '2018-10-28 02:00:00 +01:00',
-            '2018-10-28 02:30:00 +01:00',
-            '2018-10-28 03:00:00 +01:00',
-            '2018-10-28 03:30:00 +01:00',
-        );
-
-        $period->next();
-        $this->assertEquals($expected, $this->standardizeDates(iterator_to_array($period)));
     }
 
     public function testExtendCompletedIteration()

--- a/tests/CarbonPeriod/IteratorTest.php
+++ b/tests/CarbonPeriod/IteratorTest.php
@@ -300,21 +300,6 @@ class IteratorTest extends AbstractTestCase
         );
     }
 
-    public function testRewindAfterRemovingStartDate()
-    {
-        $period = CarbonPeriodFactory::withEvenDaysFilter();
-
-        $period->current();
-
-        $period->setStartDate(null);
-
-        $period->rewind();
-
-        $this->assertNull($period->key());
-        $this->assertNull($period->current());
-        $this->assertFalse($period->valid());
-    }
-
     public function testValidateOncePerIteration()
     {
         $period = CarbonPeriodFactory::withCounter($counter);

--- a/tests/CarbonPeriod/SettersTest.php
+++ b/tests/CarbonPeriod/SettersTest.php
@@ -268,20 +268,6 @@ class SettersTest extends AbstractTestCase
         $this->assertEmpty($period->getOptions());
     }
 
-    public function testDisableResultsCache()
-    {
-        $period = new CarbonPeriod;
-
-        $period->disableResultsCache();
-        $this->assertSame(CarbonPeriod::DISABLE_RESULTS_CACHE, $period->getOptions());
-
-        $period->disableResultsCache(true);
-        $this->assertSame(CarbonPeriod::DISABLE_RESULTS_CACHE, $period->getOptions());
-
-        $period->disableResultsCache(false);
-        $this->assertEmpty($period->getOptions());
-    }
-
     public function testSetRelativeDates()
     {
         $period = new CarbonPeriod;

--- a/tests/CarbonPeriod/SettersTest.php
+++ b/tests/CarbonPeriod/SettersTest.php
@@ -45,7 +45,7 @@ class SettersTest extends AbstractTestCase
         $this->assertSame('P3D', $period->getDateInterval()->spec());
     }
 
-    public function testSetDateIntervalByFromStringFormat()
+    public function testSetDateIntervalFromStringFormat()
     {
         $period = new CarbonPeriod;
 

--- a/tests/CarbonPeriod/ToArrayTest.php
+++ b/tests/CarbonPeriod/ToArrayTest.php
@@ -196,20 +196,23 @@ class ToArrayTest extends AbstractTestCase
     {
         $period = CarbonPeriodFactory::withEvenDaysFilter();
 
-        $expected = $this->standardizeDates(array('2012-07-04', '2012-07-10', '2012-07-16'));
+        $period->next();
 
-        $results = array();
+        $key = $period->key();
+        $current = $period->current();
 
-        foreach ($period as $key => $current) {
-            $results[$key] = $current;
+        $this->assertEquals(
+            $this->standardizeDates(array('2012-07-04', '2012-07-10', '2012-07-16')),
+            $this->standardizeDates($period->toArray())
+        );
 
-            $this->assertEquals($expected, $this->standardizeDates($period->toArray()));
+        $this->assertEquals(1, $period->key());
+        $this->assertEquals(new Carbon('2012-07-10'), $period->current());
 
-            $this->assertEquals($key, $period->key());
-            $this->assertEquals($current, $period->current());
-        }
+        $period->next();
 
-        $this->assertEquals($expected, $this->standardizeDates($results));
+        $this->assertEquals(2, $period->key());
+        $this->assertEquals(new Carbon('2012-07-16'), $period->current());
     }
 
     public function testIterationResultsCannotBeIndirectlyModified()

--- a/tests/CarbonPeriod/ToArrayTest.php
+++ b/tests/CarbonPeriod/ToArrayTest.php
@@ -116,35 +116,6 @@ class ToArrayTest extends AbstractTestCase
         $this->assertNull($period->last());
     }
 
-    public function testCacheArray()
-    {
-        $period = CarbonPeriodFactory::withCounter($counter);
-
-        $period->addFilter(CarbonPeriod::END_ITERATION);
-
-        $period->toArray();
-        $period->count();
-        $period->first();
-        $period->last();
-
-        $this->assertEquals(1, $counter);
-    }
-
-    public function testPreserveCachedArrayAfterRewind()
-    {
-        $period = CarbonPeriodFactory::withCounter($counter);
-
-        $expected = $this->standardizeDates(array('2012-10-01', '2012-10-02', '2012-10-03'));
-
-        $this->assertEquals($expected, $this->standardizeDates($period->toArray()));
-        $this->assertEquals(3, $counter);
-
-        $period->rewind();
-
-        $this->assertEquals($expected, $this->standardizeDates($period->toArray()));
-        $this->assertEquals(3, $counter);
-    }
-
     public function testClearCachedArrayWhenPropertiesAreChanged()
     {
         $period = CarbonPeriod::create('2012-10-01', 3);
@@ -154,17 +125,6 @@ class ToArrayTest extends AbstractTestCase
         $period->addFilter(CarbonPeriod::END_ITERATION);
 
         $this->assertCount(0, $period->toArray());
-    }
-
-    public function testContinueUninterruptedIteration()
-    {
-        $period = CarbonPeriodFactory::withCounter($counter);
-
-        $period->next();
-        $this->assertEquals(2, $counter);
-
-        $period->toArray();
-        $this->assertEquals(3, $counter);
     }
 
     public function testRestartInterruptedIteration()
@@ -177,19 +137,6 @@ class ToArrayTest extends AbstractTestCase
 
         $period->toArray();
         $this->assertEquals(5, $counter);
-    }
-
-    public function testReuseIterationResultsAfterToArrayConversion()
-    {
-        $period = CarbonPeriodFactory::withCounter($counter);
-
-        $expected = $this->standardizeDates(array('2012-10-01', '2012-10-02', '2012-10-03'));
-
-        $this->assertEquals($expected, $this->standardizeDates($period->toArray()));
-        $this->assertEquals(3, $counter);
-
-        $this->assertEquals($expected, $this->standardizeDates(iterator_to_array($period)));
-        $this->assertEquals(3, $counter);
     }
 
     public function testRestoreIterationStateAfterCallingToArray()
@@ -265,23 +212,6 @@ class ToArrayTest extends AbstractTestCase
 
         $this->assertEquals(
             $this->standardizeDates(array('2018-05-13 22:00', '2018-05-14 22:00')),
-            $this->standardizeDates($period->toArray())
-        );
-    }
-
-    public function testDisableCachingOfIterationResults()
-    {
-        $period = CarbonPeriodFactory::withStackFilter();
-
-        $period->setOptions(CarbonPeriod::DISABLE_RESULTS_CACHE);
-
-        $this->assertEquals(
-            $this->standardizeDates(array('2001-01-01', '2001-01-03')),
-            $this->standardizeDates($period->toArray())
-        );
-
-        $this->assertEquals(
-            $this->standardizeDates(array('2001-01-03', '2001-01-04')),
             $this->standardizeDates($period->toArray())
         );
     }

--- a/tests/CarbonPeriod/ToArrayTest.php
+++ b/tests/CarbonPeriod/ToArrayTest.php
@@ -89,7 +89,7 @@ class ToArrayTest extends AbstractTestCase
 
     public function testToArrayOfEmptyPeriod()
     {
-        $result = CarbonPeriod::create()->toArray();
+        $result = CarbonPeriod::create(0)->toArray();
 
         $this->assertInternalType('array', $result);
         $this->assertEmpty($result);
@@ -97,21 +97,21 @@ class ToArrayTest extends AbstractTestCase
 
     public function testCountOfEmptyPeriod()
     {
-        $period = CarbonPeriod::create();
+        $period = CarbonPeriod::create(0);
 
         $this->assertEquals(0, $period->count());
     }
 
     public function testFirstOfEmptyPeriod()
     {
-        $period = CarbonPeriod::create();
+        $period = CarbonPeriod::create(0);
 
         $this->assertNull($period->first());
     }
 
     public function testLastOfEmptyPeriod()
     {
-        $period = CarbonPeriod::create();
+        $period = CarbonPeriod::create(0);
 
         $this->assertNull($period->last());
     }

--- a/tests/CarbonPeriod/ToArrayTest.php
+++ b/tests/CarbonPeriod/ToArrayTest.php
@@ -116,29 +116,6 @@ class ToArrayTest extends AbstractTestCase
         $this->assertNull($period->last());
     }
 
-    public function testClearCachedArrayWhenPropertiesAreChanged()
-    {
-        $period = CarbonPeriod::create('2012-10-01', 3);
-
-        $this->assertCount(3, $period->toArray());
-
-        $period->addFilter(CarbonPeriod::END_ITERATION);
-
-        $this->assertCount(0, $period->toArray());
-    }
-
-    public function testRestartInterruptedIteration()
-    {
-        $period = CarbonPeriodFactory::withCounter($counter);
-
-        $period->next();
-        $period->setStartDate($period->getStartDate());
-        $this->assertEquals(2, $counter);
-
-        $period->toArray();
-        $this->assertEquals(5, $counter);
-    }
-
     public function testRestoreIterationStateAfterCallingToArray()
     {
         $period = CarbonPeriodFactory::withEvenDaysFilter();
@@ -162,20 +139,6 @@ class ToArrayTest extends AbstractTestCase
         $this->assertEquals(new Carbon('2012-07-16'), $period->current());
     }
 
-    public function testIterationResultsCannotBeIndirectlyModified()
-    {
-        $period = CarbonPeriod::create('2012-10-01', '2012-10-02');
-
-        foreach ($period->toArray() as $date) {
-            $date->addDay();
-        }
-
-        $this->assertEquals(
-            $this->standardizeDates(array('2012-10-01', '2012-10-02')),
-            $this->standardizeDates($period->toArray())
-        );
-    }
-
     public function testToArrayResultsAreInTheExpectedTimezone()
     {
         $period = CarbonPeriod::create('2018-05-13 12:00 Asia/Kabul', 'PT1H', 3);
@@ -187,32 +150,5 @@ class ToArrayTest extends AbstractTestCase
         );
 
         $this->assertEquals($expected, $this->standardizeDates($period->toArray()));
-    }
-
-    public function testRefreshToArrayResultsAfterChangingProperties()
-    {
-        $period = CarbonPeriod::create('2018-05-13 22:00', 'PT1H');
-
-        $results = array();
-
-        while ($current = $period->current()) {
-            $results[] = $current;
-
-            if ($current->format('Y-m-d') != '2018-05-13') {
-                $period->interval('P1D')->end('2018-05-15');
-            }
-
-            $period->next();
-        }
-
-        $this->assertEquals(
-            $this->standardizeDates(array('2018-05-13 22:00', '2018-05-13 23:00', '2018-05-14 00:00', '2018-05-15 00:00')),
-            $this->standardizeDates($results)
-        );
-
-        $this->assertEquals(
-            $this->standardizeDates(array('2018-05-13 22:00', '2018-05-14 22:00')),
-            $this->standardizeDates($period->toArray())
-        );
     }
 }

--- a/tests/CarbonPeriod/ToStringTest.php
+++ b/tests/CarbonPeriod/ToStringTest.php
@@ -30,6 +30,8 @@ class ToStringTest extends AbstractTestCase
 
     public function provideToString()
     {
+        Carbon::setTestNow(new Carbon('2015-09-01', 'America/Toronto'));
+
         return array(
             array(
                 CarbonPeriod::create('R4/2012-07-01T12:00:00/P7D'),
@@ -56,11 +58,7 @@ class ToStringTest extends AbstractTestCase
             ),
             array(
                 CarbonPeriod::create('P1M14D'),
-                'Every 1 month 2 weeks',
-            ),
-            array(
-                CarbonPeriod::create('P5D', 4)->setEndDate('2015-09-30'),
-                '4 times every 5 days to 2015-09-30',
+                'Every 1 month 2 weeks from 2015-09-01',
             ),
             array(
                 CarbonPeriod::create('2015-09-30 13:30', 'P17D')->setRecurrences(1),
@@ -98,6 +96,8 @@ class ToStringTest extends AbstractTestCase
 
     public function provideToIso8601String()
     {
+        Carbon::setTestNow(new Carbon('2015-09-01', 'America/Toronto'));
+
         return array(
             array(
                 CarbonPeriod::create('R4/2012-07-01T00:00:00-04:00/P7D'),
@@ -126,12 +126,8 @@ class ToStringTest extends AbstractTestCase
                 '2015-09-30T12:50:00-04:00/P3D',
             ),
             array(
-                CarbonPeriod::create()->setEndDate(Carbon::parse('2015-09-30 12:50', 'America/Toronto')),
-                'P1D/2015-09-30T12:50:00-04:00',
-            ),
-            array(
                 CarbonPeriod::create(),
-                'P1D',
+                '2015-09-01T00:00:00-04:00/P1D',
             ),
         );
     }


### PR DESCRIPTION
Changes:

1. Removed caching of iteration results.
     - Every `toArray`, `count`, `first`, `last` call will cause a full iteration.
     - Initialization is done when current is null (only before first iteration).
     - Validation result is still cached per iteration.

2. Removed start date filter.
    - Start date is used only for initialization during rewind. Changing it during the iteration will have no effect whatsoever.
    - DateInterval can now be inverted during iteration.

3. Start date is now required.
    - Exception will be thrown when null is passed to setter, similarly to DateInterval.
    - By default start date is set to now.
