### PR TITLE
CarbonPeriod final touches

### DIFF
--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -149,7 +149,7 @@ class CarbonPeriod implements Iterator, Countable
      *
      * @var bool
      */
-    protected $defaultInterval;
+    protected $isDefaultInterval;
 
     /**
      * The filters stack.
@@ -481,7 +481,7 @@ class CarbonPeriod implements Iterator, Countable
         if ($this->dateInterval === null) {
             $this->setDateInterval(CarbonInterval::day());
 
-            $this->defaultInterval = true;
+            $this->isDefaultInterval = true;
         }
 
         if ($this->options === null) {
@@ -510,7 +510,7 @@ class CarbonPeriod implements Iterator, Countable
 
         $this->dateInterval = $interval;
 
-        $this->defaultInterval = false;
+        $this->isDefaultInterval = false;
 
         $this->handleChangedParameters();
 
@@ -1433,7 +1433,7 @@ class CarbonPeriod implements Iterator, Countable
             case 'second':
                 return $this->setDateInterval(call_user_func(
                     // Override default P1D when instantiating via fluent setters.
-                    array($this->defaultInterval ? new CarbonInterval('PT0S') : $this->dateInterval, $method),
+                    array($this->isDefaultInterval ? new CarbonInterval('PT0S') : $this->dateInterval, $method),
                     count($parameters) === 0 ? 1 : $first
                 ));
         }

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -305,6 +305,19 @@ class CarbonPeriod implements Iterator, Countable
     }
 
     /**
+     * Return whether given callable is a string pointing to one of Carbon's is* methods
+     * and should be automatically converted to a filter callback.
+     *
+     * @param callable $callable
+     *
+     * @return bool
+     */
+    protected static function isCarbonPredicateMethod($callable)
+    {
+        return is_string($callable) && substr($callable, 0, 2) === 'is' && method_exists('Carbon\Carbon', $callable);
+    }
+
+    /**
      * Return whether given variable is an ISO 8601 specification.
      *
      * Note: Check is very basic, as actual validation will be done later when parsing.
@@ -736,7 +749,7 @@ class CarbonPeriod implements Iterator, Countable
     {
         $method = array_shift($parameters);
 
-        if (!is_string($method) || substr($method, 0, 2) !== 'is' || !method_exists('Carbon\Carbon', $method)) {
+        if (!$this->isCarbonPredicateMethod($method)) {
             return array($method, array_shift($parameters));
         }
 

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -263,33 +263,6 @@ class CarbonPeriod implements Iterator, Countable
     }
 
     /**
-     * Create a CarbonPeriod between given dates.
-     *
-     * @param DateTime|DateTimeInterface|string      $start
-     * @param DateTime|DateTimeInterface|string|null $end
-     * @param DateInterval|string|null               $interval
-     * @param int|null                               $options
-     *
-     * @return static
-     */
-    public static function createBetween($start, $end, $interval = null, $options = null)
-    {
-        $instance = new static;
-
-        $instance->setDates($start, $end);
-
-        if ($interval !== null) {
-            $instance->setDateInterval($interval);
-        }
-
-        if ($options !== null) {
-            $instance->setOptions($options);
-        }
-
-        return $instance;
-    }
-
-    /**
      * Return whether given interval contains non zero value of any time unit.
      *
      * @param \DateInterval $interval

--- a/tests/CarbonPeriod/CreateTest.php
+++ b/tests/CarbonPeriod/CreateTest.php
@@ -421,16 +421,6 @@ class CreateTest extends AbstractTestCase
         $this->assertSame(CarbonPeriod::EXCLUDE_END_DATE, $period->getOptions());
     }
 
-    public function testCreateBetween()
-    {
-        $period = CarbonPeriod::createBetween('2018-03-25', '2018-04-01', 'P2D', CarbonPeriod::EXCLUDE_END_DATE);
-
-        $this->assertSame('2018-03-25', $period->getStartDate()->toDateString());
-        $this->assertSame('P2D', $period->getDateInterval()->spec());
-        $this->assertSame('2018-04-01', $period->getEndDate()->toDateString());
-        $this->assertSame(CarbonPeriod::EXCLUDE_END_DATE, $period->getOptions());
-    }
-
     public function testCreateFromIso()
     {
         $period = CarbonPeriod::createFromIso('R3/2018-03-25/P2D/2018-04-01', CarbonPeriod::EXCLUDE_END_DATE);

--- a/tests/CarbonPeriod/SettersTest.php
+++ b/tests/CarbonPeriod/SettersTest.php
@@ -313,14 +313,6 @@ class SettersTest extends AbstractTestCase
 
         $someDateTime = new DateTime('2010-05-06 02:00:00');
         $someCarbon = new Carbon('2010-05-06 13:00:00');
-        $period = CarbonPeriod::createBetween($someDateTime, $someCarbon, '2 hours', CarbonPeriod::EXCLUDE_START_DATE);
-        $hours = array();
-        foreach ($period as $date) {
-            $hours[] = $date->format('H');
-        }
-
-        $this->assertSame(array('04', '06', '08', '10', '12'), $hours);
-
         $period = CarbonPeriod::every('2 hours')->between($someDateTime, $someCarbon)->options(CarbonPeriod::EXCLUDE_START_DATE);
         $hours = array();
         foreach ($period as $date) {
@@ -357,7 +349,7 @@ class SettersTest extends AbstractTestCase
             "$d3 03",
         ), $hours);
 
-        $period = CarbonPeriod::createBetween('first day of january this year', 'first day of next month')->interval('1 week');
+        $period = CarbonPeriod::between('first day of january this year', 'first day of next month')->interval('1 week');
 
         $this->assertEquals(new Carbon('first day of january this year'), $period->getStartDate());
         $this->assertEquals(new Carbon('first day of next month'), $period->getEndDate());


### PR DESCRIPTION
I looked through the code to check if everything looks good and ended up changing a few things here ad there.

@kylekatarnls Did you think about renaming "recurrences" to "limit"? I think it describes what the filter does better and avoids confusion with how DatePeriod recurrences work. This would give us freedom to implement native recurrences filter later and avoid conflict with DatePeriod if we decide to extend it after it's fixed.