### PR TITLE
Fix history for version 1.28

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -129,7 +129,7 @@ if (strtotime($string) === false) {
 <p>To accompany <code>now()</code>, a few other static instantiation helpers exist to create widely known instances.  The only thing to really notice here is that <code>today()</code>, <code>tomorrow()</code> and <code>yesterday()</code>, besides behaving as expected, all accept a timezone parameter and each has their time value set to <code>00:00:00</code>.</p>
 
 <p><pre><code class="php">$now = Carbon::now();
-echo $now;                               // 2018-05-29 06:18:52
+echo $now;                               // 2018-05-29 18:25:27
 $today = Carbon::today();
 echo $today;                             // 2018-05-29 00:00:00
 $tomorrow = Carbon::tomorrow('Europe/London');
@@ -204,7 +204,7 @@ echo $dt->diffInYears($dt->copy()->addYear());  // 1
 // 19:15 in Johannesburg
 echo 'Meeting starts at '.$meeting->format('H:i').' in Johannesburg.';                  // Meeting starts at 19:15 in Johannesburg.
 // now in Johannesburg
-echo "It's ".$meeting->nowWithSameTz()->format('H:i').' right now in Johannesburg.';    // It's 12:18 right now in Johannesburg.
+echo "It's ".$meeting->nowWithSameTz()->format('H:i').' right now in Johannesburg.';    // It's 00:25 right now in Johannesburg.
 </code></pre></p>
 
 <p>Finally, if you find yourself inheriting a <code>\DateTime</code> instance from another library, fear not!  You can create a <code>Carbon</code> instance via a friendly <code>instance()</code> method.  Or use the even more flexible method <code>make()</code> which can return a new Carbon instance from a DateTime, Carbon or from a string, else it just returns null.</p>
@@ -345,7 +345,7 @@ echo Carbon::create(2001, 4, 21, 12)->diffForHumans(); // 1 month ago
 var_dump(Carbon::hasTestNow());                        // bool(true)
 Carbon::setTestNow();                                  // clear the mock
 var_dump(Carbon::hasTestNow());                        // bool(false)
-echo Carbon::now();                                    // 2018-05-29 06:18:52
+echo Carbon::now();                                    // 2018-05-29 18:25:27
 </code></pre></p>
 
 <p>A more meaning full example:</p>
@@ -715,8 +715,8 @@ echo $dt1->maximum($dt2);                          // 2014-01-30 00:00:00
 
 // now is the default param
 $dt1 = Carbon::createMidnightDate(2000, 1, 1);
-echo $dt1->max();                                  // 2018-05-29 06:18:52
-echo $dt1->maximum();                              // 2018-05-29 06:18:52
+echo $dt1->max();                                  // 2018-05-29 18:25:27
+echo $dt1->maximum();                              // 2018-05-29 18:25:27
 
 $dt1 = Carbon::createMidnightDate(2010, 4, 1);
 $dt2 = Carbon::createMidnightDate(2010, 3, 28);

--- a/history/index.html
+++ b/history/index.html
@@ -66,14 +66,17 @@
 <h1>1.28.0 / 2018-05-22</h1>
   <ul>
     <li>Added isStartOfDay, isEndOfDay, isMidnight, isMidday methods</li>
+    <li>Added make methods to Carbon and CarbonInterval</li>
+    <li>Added workaround for timezone bug: https://bugs.php.net/bug.php?id=45528</li>
+    <li>Added cascading CarbonInterval and custom carry-over points</li>
+    <li>Added total method and total getters to CarbonInterval</li>
+    <li>Added macro support to CarbonInterval</li>
+    <li>Added invert method to CarbonInterval</li>
+    <li>Added $short argument to CarbonInterval::forHumans to display short formats</li>
     <li>Added locales bs_BA, hi, is, ne, oc, sh, sw</li>
     <li>Added diff translations for ca, es, nl, no, pl, sl, sr*</li>
-    <li>Fixed ko, pl translations</li>
     <li>Fixed createFromFormat with partial format and mock now instance</li>
-    <li>Added CarbonPeriod and related methods in Carbon and CarbonInterval</li>
-    <li>Added make methods to Carbon and CarbonInterval</li>
-    <li>Added getCascadeFactors, setCascadeFactors, getFactor, getDaysPerWeek, getHoursPerDay, getMinutesPerHours, getSecondsPerMinutes, cascade, total methods and total getters to CarbonInterval</li>
-    <li>Added $short argument to CarbonInterval::forHumans to display short formats</li>
+    <li>Fixed ko, pl translations</li>
   </ul>
 <h1>1.27.0 / 2018-04-23</h1>
   <ul>

--- a/history/index.src.html
+++ b/history/index.src.html
@@ -13,14 +13,17 @@
 <h1>1.28.0 / 2018-05-22</h1>
   <ul>
     <li>Added isStartOfDay, isEndOfDay, isMidnight, isMidday methods</li>
+    <li>Added make methods to Carbon and CarbonInterval</li>
+    <li>Added workaround for timezone bug: https://bugs.php.net/bug.php?id=45528</li>
+    <li>Added cascading CarbonInterval and custom carry-over points</li>
+    <li>Added total method and total getters to CarbonInterval</li>
+    <li>Added macro support to CarbonInterval</li>
+    <li>Added invert method to CarbonInterval</li>
+    <li>Added $short argument to CarbonInterval::forHumans to display short formats</li>
     <li>Added locales bs_BA, hi, is, ne, oc, sh, sw</li>
     <li>Added diff translations for ca, es, nl, no, pl, sl, sr*</li>
-    <li>Fixed ko, pl translations</li>
     <li>Fixed createFromFormat with partial format and mock now instance</li>
-    <li>Added CarbonPeriod and related methods in Carbon and CarbonInterval</li>
-    <li>Added make methods to Carbon and CarbonInterval</li>
-    <li>Added getCascadeFactors, setCascadeFactors, getFactor, getDaysPerWeek, getHoursPerDay, getMinutesPerHours, getSecondsPerMinutes, cascade, total methods and total getters to CarbonInterval</li>
-    <li>Added $short argument to CarbonInterval::forHumans to display short formats</li>
+    <li>Fixed ko, pl translations</li>
   </ul>
 <h1>1.27.0 / 2018-04-23</h1>
   <ul>


### PR DESCRIPTION
- removed CarbonPeriod entry
- summarized "Added getCascadeFactors, setCascadeFactors, ..."
- added workaround for timezone bug, supprt for macros and invert method
- reordered

https://github.com/briannesbitt/Carbon/compare/version-1.27...version-1.28