### PR TITLE
Correct Easter macro implemention used by test suite

### DIFF
--- a/tests/Carbon/MacroTest.php
+++ b/tests/Carbon/MacroTest.php
@@ -46,7 +46,7 @@ class MacroTest extends AbstractTestCase
     public function testCarbonIsMacroableWhenNotCalledStatically()
     {
         Carbon::macro('diffFromEaster', function ($year = 2019, $self = null) {
-            $instance = Carbon::create($year);
+            $instance = Carbon::create($year, 1, 1);
 
             $a = $instance->year % 19;
             $b = floor($instance->year / 100);
@@ -85,7 +85,7 @@ class MacroTest extends AbstractTestCase
         }
 
         Carbon::macro('diffFromEaster2', function ($year) {
-            $instance = Carbon::create($year);
+            $instance = Carbon::create($year, 1, 1);
 
             $a = $instance->year % 19;
             $b = floor($instance->year / 100);
@@ -113,7 +113,7 @@ class MacroTest extends AbstractTestCase
     public function testCarbonIsMacroableWhenCalledStatically()
     {
         Carbon::macro('easterDate', function ($year) {
-            $instance = Carbon::create($year);
+            $instance = Carbon::create($year, 1, 1);
 
             $a = $instance->year % 19;
             $b = floor($instance->year / 100);


### PR DESCRIPTION
The Easter macro in the test suite would actually fail on a day like today that falls on the 31st. The tests are run as June 27, 2017 so a bug in that macro wouldn't be apparent to anyone that used this implementation in their own codebase.

```php
Carbon\Carbon::setTestNow('2018-05-31 11:30')

Carbon\Carbon::create('2019')->month(4)->day(21);
// { date: 2019-05-21 11:30:00.0 UTC (+00:00) }

$easter = Carbon\Carbon::create('2019');
// { date: 2019-05-31 11:30:00.0 UTC (+00:00) }

$easter->month(4);
// { date: 2019-05-01 11:30:00.0 UTC (+00:00) }
// there is no April 31, 2019

$easter->day(21);
// { date: 2019-05-21 11:30:00.0 UTC (+00:00) }
```

I'd argue such a macro should use midnight as the Easter timestamp but that affected day diff assertions being off by one so I left them as-is.