### PR TITLE
Fix testFluentSetters() day comparison

### DIFF
--- a/tests/CarbonPeriod/SettersTest.php
+++ b/tests/CarbonPeriod/SettersTest.php
@@ -324,7 +324,7 @@ class SettersTest extends AbstractTestCase
         $period = CarbonPeriod::options(CarbonPeriod::EXCLUDE_START_DATE)->stepBy(CarbonInterval::hours(2))->since('yesterday 19:00')->until('tomorrow 03:30');
         $hours = array();
         foreach ($period as $date) {
-            $hours[] = $date->format('d H');
+            $hours[] = $date->format('j H');
         }
         $d1 = Carbon::yesterday()->day;
         $d2 = Carbon::today()->day;


### PR DESCRIPTION
This test would fail last day of the month up until the 10th into the next month, when single-digit days of the month are being compared.

```php
Carbon::today()->format('d H')
// '01 01'
```

```php
$d2 = Carbon::today()->day
// 1

"$d2 01"
// '1 01', doesn't match above
```

Instead format without the leading zero:

```php
Carbon::today()->format('j H')
// '1 01'
```