### PR TITLE
day of week string

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -4642,4 +4642,47 @@ class Carbon extends DateTime implements JsonSerializable
 
         return call_user_func_array($macro, $parameters);
     }
+
+    /**
+     * Use Carbon::now() to determine day of week as a string.
+     *
+     *
+     * @return string $day
+     */
+    public function dayOfWeek()
+    {
+        switch ($this->dayOfWeek) {
+            case 0:
+                return self::$days[0];
+                break;
+
+            case 1:
+                return self::$days[1];
+                break;
+
+            case 2:
+                return self::$days[2];
+                break;
+
+            case 3:
+                return self::$days[3];
+                break;
+
+            case 4:
+                return self::$days[4];
+                break;
+
+            case 5:
+                return self::$days[5];
+                break;
+
+            case 6:
+                return self::$days[6];
+                break;
+
+            default:
+                return 'Wrong date format';
+                break;
+        }
+    }
 }

--- a/tests/Carbon/DayOfWeekTest.php
+++ b/tests/Carbon/DayOfWeekTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Carbon;
+
+use Carbon\Carbon;
+use Tests\AbstractTestCase;
+
+class DayOfWeekTest extends AbstractTestCase
+{
+    public function testDayOfWeekReturnsString()
+    {
+        $d = Carbon::createFromDate(2018, 6, 3)->dayOfWeek(); //Sunday
+        $this->assertSame($d, 'Sunday');
+        $d = Carbon::createFromDate(2018, 6, 4)->dayOfWeek(); //Monday
+        $this->assertSame($d, 'Monday');
+        $d = Carbon::createFromDate(2018, 6, 5)->dayOfWeek(); //Tuesday
+        $this->assertSame($d, 'Tuesday');
+        $d = Carbon::createFromDate(2018, 6, 6)->dayOfWeek(); //Wednesday
+        $this->assertSame($d, 'Wednesday');
+        $d = Carbon::createFromDate(2018, 6, 7)->dayOfWeek(); //Thursday
+        $this->assertSame($d, 'Thursday');
+        $d = Carbon::createFromDate(2018, 6, 8)->dayOfWeek(); //Friday
+        $this->assertSame($d, 'Friday');
+        $d = Carbon::createFromDate(2018, 6, 9)->dayOfWeek(); //Saturday
+        $this->assertSame($d, 'Saturday');
+    }
+}


### PR DESCRIPTION
Currently days of the week are defined in constants.
```php
// These getters specifically return integers, ie intval()
var_dump(Carbon::SUNDAY);                          // int(0)
var_dump(Carbon::MONDAY);                          // int(1)
var_dump(Carbon::TUESDAY);                         // int(2)
var_dump(Carbon::WEDNESDAY);                       // int(3)
var_dump(Carbon::THURSDAY);                        // int(4)
var_dump(Carbon::FRIDAY);                          // int(5)
var_dump(Carbon::SATURDAY);                        // int(6)
```

So if say someone uses `Carbon::now()->dayOfWeek`, it returns an index of the array days. 

With this function, it uses the array index to return a day as a string 