### PR TITLE
Implement #1364 diffForHumans can be forced to relative/absolute mode

### DIFF
--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -434,10 +434,21 @@ use JsonSerializable;
  */
 interface CarbonInterface extends DateTimeInterface, JsonSerializable
 {
+    /**
+     * Diff wording options.
+     */
     public const NO_ZERO_DIFF = 01;
     public const JUST_NOW = 02;
     public const ONE_DAY_WORDS = 04;
     public const TWO_DAY_WORDS = 010;
+
+    /**
+     * Diff syntax options.
+     */
+    public const DIFF_ABSOLUTE = 1; // backward compatibility with true
+    public const DIFF_RELATIVE_AUTO = 0; // backward compatibility with false
+    public const DIFF_RELATIVE_TO_NOW = 2;
+    public const DIFF_RELATIVE_TO_OTHER = 3;
 
     /**
      * The day constants.

--- a/src/Carbon/Traits/Difference.php
+++ b/src/Carbon/Traits/Difference.php
@@ -311,23 +311,25 @@ trait Difference
      * 5 months after
      *
      * @param Carbon|null $other
-     * @param bool        $absolute removes time difference modifiers ago, after, etc
-     * @param bool        $short    displays short format of time units
-     * @param int         $parts    displays number of parts in the interval
+     * @param int         $syntax difference modifiers (ago, after, etc) rules
+     * @param bool        $short  displays short format of time units
+     * @param int         $parts  displays number of parts in the interval
      *
      * @return string
      */
-    public function diffForHumans($other = null, $absolute = false, $short = false, $parts = 1)
+    public function diffForHumans($other = null, $syntax = CarbonInterface::DIFF_RELATIVE_AUTO, $short = false, $parts = 1)
     {
         /* @var CarbonInterface $this */
-        $isNow = $other === null;
         $interval = [];
+        $syntax = (int) $syntax;
+        $absolute = ($syntax === CarbonInterface::DIFF_ABSOLUTE);
+        $isNow = $syntax === CarbonInterface::DIFF_RELATIVE_TO_NOW || $syntax === CarbonInterface::DIFF_RELATIVE_AUTO && $other === null;
 
         $parts = min(6, max(1, (int) $parts));
         $count = 1;
         $unit = $short ? 's' : 'second';
 
-        if ($isNow) {
+        if ($other === null) {
             $other = $this->nowWithSameTz();
         } elseif (!$other instanceof DateTimeInterface) {
             $other = static::parse($other);

--- a/tests/Carbon/DiffTest.php
+++ b/tests/Carbon/DiffTest.php
@@ -50,9 +50,8 @@ class DiffTest extends AbstractTestCase
 
     public function testDiffInYearsVsDefaultNow()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame(1, Carbon::now()->subYear()->diffInYears());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(1, Carbon::now()->subYear()->diffInYears());
         });
     }
 
@@ -82,9 +81,8 @@ class DiffTest extends AbstractTestCase
 
     public function testDiffInMonthsVsDefaultNow()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame(12, Carbon::now()->subYear()->diffInMonths());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(12, Carbon::now()->subYear()->diffInMonths());
         });
     }
 
@@ -114,9 +112,8 @@ class DiffTest extends AbstractTestCase
 
     public function testDiffInDaysVsDefaultNow()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame(7, Carbon::now()->subWeek()->diffInDays());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(7, Carbon::now()->subWeek()->diffInDays());
         });
     }
 
@@ -358,9 +355,8 @@ class DiffTest extends AbstractTestCase
 
     public function testDiffInWeeksVsDefaultNow()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame(1, Carbon::now()->subWeek()->diffInWeeks());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(1, Carbon::now()->subWeek()->diffInWeeks());
         });
     }
 
@@ -390,9 +386,8 @@ class DiffTest extends AbstractTestCase
 
     public function testDiffInHoursVsDefaultNow()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame(48, Carbon::now()->subDays(2)->diffInHours());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(48, Carbon::now()->subDays(2)->diffInHours());
         }, Carbon::create(2012, 1, 15));
     }
 
@@ -447,9 +442,8 @@ class DiffTest extends AbstractTestCase
 
     public function testDiffInMinutesVsDefaultNow()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame(60, Carbon::now()->subHour()->diffInMinutes());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(60, Carbon::now()->subHour()->diffInMinutes());
         });
     }
 
@@ -485,9 +479,8 @@ class DiffTest extends AbstractTestCase
 
     public function testDiffInSecondsVsDefaultNow()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame(3600, Carbon::now()->subHour()->diffInSeconds());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(3600, Carbon::now()->subHour()->diffInSeconds());
         });
     }
 
@@ -508,18 +501,15 @@ class DiffTest extends AbstractTestCase
     {
         $vanNow = Carbon::now('America/Vancouver');
         $hereNow = $vanNow->copy()->setTimezone(Carbon::now()->tz);
-
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($vanNow, $scope) {
-            $scope->assertSame(0, $vanNow->diffInSeconds());
+        $this->wrapWithTestNow(function () use ($vanNow) {
+            $this->assertSame(0, $vanNow->diffInSeconds());
         }, $hereNow);
     }
 
     public function testDiffForHumansNowAndSecond()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 second ago', Carbon::now()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 second ago', Carbon::now()->diffForHumans());
         });
     }
 
@@ -527,733 +517,664 @@ class DiffTest extends AbstractTestCase
     {
         $vanNow = Carbon::now('America/Vancouver');
         $hereNow = $vanNow->copy()->setTimezone(Carbon::now()->tz);
-
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($vanNow, $scope) {
-            $scope->assertSame('1 second ago', $vanNow->diffForHumans());
+        $this->wrapWithTestNow(function () use ($vanNow) {
+            $this->assertSame('1 second ago', $vanNow->diffForHumans());
         }, $hereNow);
     }
 
     public function testDiffForHumansNowAndSeconds()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 seconds ago', Carbon::now()->subSeconds(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 seconds ago', Carbon::now()->subSeconds(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyMinute()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('59 seconds ago', Carbon::now()->subSeconds(59)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('59 seconds ago', Carbon::now()->subSeconds(59)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndMinute()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 minute ago', Carbon::now()->subMinute()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 minute ago', Carbon::now()->subMinute()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndMinutes()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 minutes ago', Carbon::now()->subMinutes(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 minutes ago', Carbon::now()->subMinutes(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyHour()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('59 minutes ago', Carbon::now()->subMinutes(59)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('59 minutes ago', Carbon::now()->subMinutes(59)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndHour()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 hour ago', Carbon::now()->subHour()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 hour ago', Carbon::now()->subHour()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndHours()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 hours ago', Carbon::now()->subHours(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 hours ago', Carbon::now()->subHours(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyDay()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('23 hours ago', Carbon::now()->subHours(23)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('23 hours ago', Carbon::now()->subHours(23)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndDay()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 day ago', Carbon::now()->subDay()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 day ago', Carbon::now()->subDay()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndDays()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 days ago', Carbon::now()->subDays(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 days ago', Carbon::now()->subDays(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyWeek()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('6 days ago', Carbon::now()->subDays(6)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('6 days ago', Carbon::now()->subDays(6)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndWeek()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 week ago', Carbon::now()->subWeek()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 week ago', Carbon::now()->subWeek()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndWeeks()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 weeks ago', Carbon::now()->subWeeks(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 weeks ago', Carbon::now()->subWeeks(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyMonth()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('3 weeks ago', Carbon::now()->subWeeks(3)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('3 weeks ago', Carbon::now()->subWeeks(3)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndMonth()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('4 weeks ago', Carbon::now()->subWeeks(4)->diffForHumans());
-            $scope->assertSame('1 month ago', Carbon::now()->subMonth()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('4 weeks ago', Carbon::now()->subWeeks(4)->diffForHumans());
+            $this->assertSame('1 month ago', Carbon::now()->subMonth()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndMonths()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 months ago', Carbon::now()->subMonths(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 months ago', Carbon::now()->subMonths(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyYear()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('11 months ago', Carbon::now()->subMonths(11)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('11 months ago', Carbon::now()->subMonths(11)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndYear()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 year ago', Carbon::now()->subYear()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 year ago', Carbon::now()->subYear()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndYears()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 years ago', Carbon::now()->subYears(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 years ago', Carbon::now()->subYears(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureSecond()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 second from now', Carbon::now()->addSecond()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 second from now', Carbon::now()->addSecond()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureSeconds()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 seconds from now', Carbon::now()->addSeconds(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 seconds from now', Carbon::now()->addSeconds(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyFutureMinute()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('59 seconds from now', Carbon::now()->addSeconds(59)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('59 seconds from now', Carbon::now()->addSeconds(59)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureMinute()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 minute from now', Carbon::now()->addMinute()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 minute from now', Carbon::now()->addMinute()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureMinutes()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 minutes from now', Carbon::now()->addMinutes(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 minutes from now', Carbon::now()->addMinutes(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyFutureHour()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('59 minutes from now', Carbon::now()->addMinutes(59)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('59 minutes from now', Carbon::now()->addMinutes(59)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureHour()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 hour from now', Carbon::now()->addHour()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 hour from now', Carbon::now()->addHour()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureHours()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 hours from now', Carbon::now()->addHours(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 hours from now', Carbon::now()->addHours(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyFutureDay()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('23 hours from now', Carbon::now()->addHours(23)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('23 hours from now', Carbon::now()->addHours(23)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureDay()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 day from now', Carbon::now()->addDay()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 day from now', Carbon::now()->addDay()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureDays()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 days from now', Carbon::now()->addDays(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 days from now', Carbon::now()->addDays(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyFutureWeek()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('6 days from now', Carbon::now()->addDays(6)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('6 days from now', Carbon::now()->addDays(6)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureWeek()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 week from now', Carbon::now()->addWeek()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 week from now', Carbon::now()->addWeek()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureWeeks()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 weeks from now', Carbon::now()->addWeeks(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 weeks from now', Carbon::now()->addWeeks(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyFutureMonth()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('3 weeks from now', Carbon::now()->addWeeks(3)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('3 weeks from now', Carbon::now()->addWeeks(3)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureMonth()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('4 weeks from now', Carbon::now()->addWeeks(4)->diffForHumans());
-            $scope->assertSame('1 month from now', Carbon::now()->addMonth()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('4 weeks from now', Carbon::now()->addWeeks(4)->diffForHumans());
+            $this->assertSame('1 month from now', Carbon::now()->addMonth()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureMonths()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 months from now', Carbon::now()->addMonths(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 months from now', Carbon::now()->addMonths(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyFutureYear()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('11 months from now', Carbon::now()->addMonths(11)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('11 months from now', Carbon::now()->addMonths(11)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureYear()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 year from now', Carbon::now()->addYear()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 year from now', Carbon::now()->addYear()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureYears()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 years from now', Carbon::now()->addYears(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 years from now', Carbon::now()->addYears(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansOtherAndSecond()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 second before', Carbon::now()->diffForHumans(Carbon::now()->addSecond()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 second before', Carbon::now()->diffForHumans(Carbon::now()->addSecond()));
         });
     }
 
     public function testDiffForHumansOtherAndSeconds()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 seconds before', Carbon::now()->diffForHumans(Carbon::now()->addSeconds(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 seconds before', Carbon::now()->diffForHumans(Carbon::now()->addSeconds(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyMinute()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('59 seconds before', Carbon::now()->diffForHumans(Carbon::now()->addSeconds(59)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('59 seconds before', Carbon::now()->diffForHumans(Carbon::now()->addSeconds(59)));
         });
     }
 
     public function testDiffForHumansOtherAndMinute()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 minute before', Carbon::now()->diffForHumans(Carbon::now()->addMinute()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 minute before', Carbon::now()->diffForHumans(Carbon::now()->addMinute()));
         });
     }
 
     public function testDiffForHumansOtherAndMinutes()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 minutes before', Carbon::now()->diffForHumans(Carbon::now()->addMinutes(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 minutes before', Carbon::now()->diffForHumans(Carbon::now()->addMinutes(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyHour()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('59 minutes before', Carbon::now()->diffForHumans(Carbon::now()->addMinutes(59)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('59 minutes before', Carbon::now()->diffForHumans(Carbon::now()->addMinutes(59)));
         });
     }
 
     public function testDiffForHumansOtherAndHour()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 hour before', Carbon::now()->diffForHumans(Carbon::now()->addHour()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 hour before', Carbon::now()->diffForHumans(Carbon::now()->addHour()));
         });
     }
 
     public function testDiffForHumansOtherAndHours()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 hours before', Carbon::now()->diffForHumans(Carbon::now()->addHours(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 hours before', Carbon::now()->diffForHumans(Carbon::now()->addHours(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyDay()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('23 hours before', Carbon::now()->diffForHumans(Carbon::now()->addHours(23)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('23 hours before', Carbon::now()->diffForHumans(Carbon::now()->addHours(23)));
         });
     }
 
     public function testDiffForHumansOtherAndDay()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 day before', Carbon::now()->diffForHumans(Carbon::now()->addDay()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 day before', Carbon::now()->diffForHumans(Carbon::now()->addDay()));
         });
     }
 
     public function testDiffForHumansOtherAndDays()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 days before', Carbon::now()->diffForHumans(Carbon::now()->addDays(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 days before', Carbon::now()->diffForHumans(Carbon::now()->addDays(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyWeek()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('6 days before', Carbon::now()->diffForHumans(Carbon::now()->addDays(6)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('6 days before', Carbon::now()->diffForHumans(Carbon::now()->addDays(6)));
         });
     }
 
     public function testDiffForHumansOverWeekWithDefaultPartsCount()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 week ago', Carbon::now()->subDays(8)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 week ago', Carbon::now()->subDays(8)->diffForHumans());
         });
     }
 
     public function testDiffForHumansOverWeekWithPartsCount1()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 week ago', Carbon::now()->subDays(8)->diffForHumans(null, false, false, 1));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 week ago', Carbon::now()->subDays(8)->diffForHumans(null, false, false, 1));
         });
     }
 
     public function testDiffForHumansOverWeekWithPartsCount2()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 week 1 day ago', Carbon::now()->subDays(8)->diffForHumans(null, false, false, 2));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 week 1 day ago', Carbon::now()->subDays(8)->diffForHumans(null, false, false, 2));
         });
     }
 
     public function testDiffForHumansOtherAndWeek()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 week before', Carbon::now()->diffForHumans(Carbon::now()->addWeek()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 week before', Carbon::now()->diffForHumans(Carbon::now()->addWeek()));
         });
     }
 
     public function testDiffForHumansOtherAndWeeks()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 weeks before', Carbon::now()->diffForHumans(Carbon::now()->addWeeks(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 weeks before', Carbon::now()->diffForHumans(Carbon::now()->addWeeks(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyMonth()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('3 weeks before', Carbon::now()->diffForHumans(Carbon::now()->addWeeks(3)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('3 weeks before', Carbon::now()->diffForHumans(Carbon::now()->addWeeks(3)));
         });
     }
 
     public function testDiffForHumansOtherAndMonth()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('4 weeks before', Carbon::now()->diffForHumans(Carbon::now()->addWeeks(4)));
-            $scope->assertSame('1 month before', Carbon::now()->diffForHumans(Carbon::now()->addMonth()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('4 weeks before', Carbon::now()->diffForHumans(Carbon::now()->addWeeks(4)));
+            $this->assertSame('1 month before', Carbon::now()->diffForHumans(Carbon::now()->addMonth()));
         });
     }
 
     public function testDiffForHumansOtherAndMonths()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 months before', Carbon::now()->diffForHumans(Carbon::now()->addMonths(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 months before', Carbon::now()->diffForHumans(Carbon::now()->addMonths(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyYear()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('11 months before', Carbon::now()->diffForHumans(Carbon::now()->addMonths(11)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('11 months before', Carbon::now()->diffForHumans(Carbon::now()->addMonths(11)));
         });
     }
 
     public function testDiffForHumansOtherAndYear()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 year before', Carbon::now()->diffForHumans(Carbon::now()->addYear()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 year before', Carbon::now()->diffForHumans(Carbon::now()->addYear()));
         });
     }
 
     public function testDiffForHumansOtherAndYears()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 years before', Carbon::now()->diffForHumans(Carbon::now()->addYears(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 years before', Carbon::now()->diffForHumans(Carbon::now()->addYears(2)));
         });
     }
 
     public function testDiffForHumansOtherAndFutureSecond()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 second after', Carbon::now()->diffForHumans(Carbon::now()->subSecond()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 second after', Carbon::now()->diffForHumans(Carbon::now()->subSecond()));
         });
     }
 
     public function testDiffForHumansOtherAndFutureSeconds()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 seconds after', Carbon::now()->diffForHumans(Carbon::now()->subSeconds(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 seconds after', Carbon::now()->diffForHumans(Carbon::now()->subSeconds(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyFutureMinute()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('59 seconds after', Carbon::now()->diffForHumans(Carbon::now()->subSeconds(59)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('59 seconds after', Carbon::now()->diffForHumans(Carbon::now()->subSeconds(59)));
         });
     }
 
     public function testDiffForHumansOtherAndFutureMinute()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 minute after', Carbon::now()->diffForHumans(Carbon::now()->subMinute()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 minute after', Carbon::now()->diffForHumans(Carbon::now()->subMinute()));
         });
     }
 
     public function testDiffForHumansOtherAndFutureMinutes()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 minutes after', Carbon::now()->diffForHumans(Carbon::now()->subMinutes(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 minutes after', Carbon::now()->diffForHumans(Carbon::now()->subMinutes(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyFutureHour()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('59 minutes after', Carbon::now()->diffForHumans(Carbon::now()->subMinutes(59)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('59 minutes after', Carbon::now()->diffForHumans(Carbon::now()->subMinutes(59)));
         });
     }
 
     public function testDiffForHumansOtherAndFutureHour()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 hour after', Carbon::now()->diffForHumans(Carbon::now()->subHour()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 hour after', Carbon::now()->diffForHumans(Carbon::now()->subHour()));
         });
     }
 
     public function testDiffForHumansOtherAndFutureHours()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 hours after', Carbon::now()->diffForHumans(Carbon::now()->subHours(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 hours after', Carbon::now()->diffForHumans(Carbon::now()->subHours(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyFutureDay()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('23 hours after', Carbon::now()->diffForHumans(Carbon::now()->subHours(23)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('23 hours after', Carbon::now()->diffForHumans(Carbon::now()->subHours(23)));
         });
     }
 
     public function testDiffForHumansOtherAndFutureDay()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 day after', Carbon::now()->diffForHumans(Carbon::now()->subDay()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 day after', Carbon::now()->diffForHumans(Carbon::now()->subDay()));
         });
     }
 
     public function testDiffForHumansOtherAndFutureDays()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 days after', Carbon::now()->diffForHumans(Carbon::now()->subDays(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 days after', Carbon::now()->diffForHumans(Carbon::now()->subDays(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyFutureWeek()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('6 days after', Carbon::now()->diffForHumans(Carbon::now()->subDays(6)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('6 days after', Carbon::now()->diffForHumans(Carbon::now()->subDays(6)));
         });
     }
 
     public function testDiffForHumansOtherAndFutureWeek()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 week after', Carbon::now()->diffForHumans(Carbon::now()->subWeek()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 week after', Carbon::now()->diffForHumans(Carbon::now()->subWeek()));
         });
     }
 
     public function testDiffForHumansOtherAndFutureWeeks()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 weeks after', Carbon::now()->diffForHumans(Carbon::now()->subWeeks(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 weeks after', Carbon::now()->diffForHumans(Carbon::now()->subWeeks(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyFutureMonth()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('3 weeks after', Carbon::now()->diffForHumans(Carbon::now()->subWeeks(3)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('3 weeks after', Carbon::now()->diffForHumans(Carbon::now()->subWeeks(3)));
         });
     }
 
     public function testDiffForHumansOtherAndFutureMonth()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('4 weeks after', Carbon::now()->diffForHumans(Carbon::now()->subWeeks(4)));
-            $scope->assertSame('1 month after', Carbon::now()->diffForHumans(Carbon::now()->subMonth()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('4 weeks after', Carbon::now()->diffForHumans(Carbon::now()->subWeeks(4)));
+            $this->assertSame('1 month after', Carbon::now()->diffForHumans(Carbon::now()->subMonth()));
         });
     }
 
     public function testDiffForHumansOtherAndFutureMonths()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 months after', Carbon::now()->diffForHumans(Carbon::now()->subMonths(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 months after', Carbon::now()->diffForHumans(Carbon::now()->subMonths(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyFutureYear()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('11 months after', Carbon::now()->diffForHumans(Carbon::now()->subMonths(11)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('11 months after', Carbon::now()->diffForHumans(Carbon::now()->subMonths(11)));
         });
     }
 
     public function testDiffForHumansOtherAndFutureYear()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 year after', Carbon::now()->diffForHumans(Carbon::now()->subYear()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 year after', Carbon::now()->diffForHumans(Carbon::now()->subYear()));
         });
     }
 
     public function testDiffForHumansOtherAndFutureYears()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 years after', Carbon::now()->diffForHumans(Carbon::now()->subYears(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 years after', Carbon::now()->diffForHumans(Carbon::now()->subYears(2)));
         });
     }
 
     public function testDiffForHumansAbsoluteSeconds()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('59 seconds', Carbon::now()->diffForHumans(Carbon::now()->subSeconds(59), true));
-            $scope->assertSame('59 seconds', Carbon::now()->diffForHumans(Carbon::now()->addSeconds(59), true));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('59 seconds', Carbon::now()->diffForHumans(Carbon::now()->subSeconds(59), true));
+            $this->assertSame('59 seconds', Carbon::now()->diffForHumans(Carbon::now()->addSeconds(59), true));
         });
     }
 
     public function testDiffForHumansAbsoluteMinutes()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('30 minutes', Carbon::now()->diffForHumans(Carbon::now()->subMinutes(30), true));
-            $scope->assertSame('30 minutes', Carbon::now()->diffForHumans(Carbon::now()->addMinutes(30), true));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('30 minutes', Carbon::now()->diffForHumans(Carbon::now()->subMinutes(30), true));
+            $this->assertSame('30 minutes', Carbon::now()->diffForHumans(Carbon::now()->addMinutes(30), true));
         });
     }
 
     public function testDiffForHumansAbsoluteHours()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('3 hours', Carbon::now()->diffForHumans(Carbon::now()->subHours(3), true));
-            $scope->assertSame('3 hours', Carbon::now()->diffForHumans(Carbon::now()->addHours(3), true));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('3 hours', Carbon::now()->diffForHumans(Carbon::now()->subHours(3), true));
+            $this->assertSame('3 hours', Carbon::now()->diffForHumans(Carbon::now()->addHours(3), true));
         });
     }
 
     public function testDiffForHumansAbsoluteDays()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 days', Carbon::now()->diffForHumans(Carbon::now()->subDays(2), true));
-            $scope->assertSame('2 days', Carbon::now()->diffForHumans(Carbon::now()->addDays(2), true));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 days', Carbon::now()->diffForHumans(Carbon::now()->subDays(2), true));
+            $this->assertSame('2 days', Carbon::now()->diffForHumans(Carbon::now()->addDays(2), true));
         });
     }
 
     public function testDiffForHumansAbsoluteWeeks()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 weeks', Carbon::now()->diffForHumans(Carbon::now()->subWeeks(2), true));
-            $scope->assertSame('2 weeks', Carbon::now()->diffForHumans(Carbon::now()->addWeeks(2), true));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 weeks', Carbon::now()->diffForHumans(Carbon::now()->subWeeks(2), true));
+            $this->assertSame('2 weeks', Carbon::now()->diffForHumans(Carbon::now()->addWeeks(2), true));
         });
     }
 
     public function testDiffForHumansAbsoluteMonths()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 months', Carbon::now()->diffForHumans(Carbon::now()->subMonths(2), true));
-            $scope->assertSame('2 months', Carbon::now()->diffForHumans(Carbon::now()->addMonths(2), true));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 months', Carbon::now()->diffForHumans(Carbon::now()->subMonths(2), true));
+            $this->assertSame('2 months', Carbon::now()->diffForHumans(Carbon::now()->addMonths(2), true));
         });
     }
 
     public function testDiffForHumansAbsoluteYears()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 year', Carbon::now()->diffForHumans(Carbon::now()->subYears(1), true));
-            $scope->assertSame('1 year', Carbon::now()->diffForHumans(Carbon::now()->addYears(1), true));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 year', Carbon::now()->diffForHumans(Carbon::now()->subYears(1), true));
+            $this->assertSame('1 year', Carbon::now()->diffForHumans(Carbon::now()->addYears(1), true));
+        });
+    }
+
+    public function testDiffForHumansWithOptions()
+    {
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 year', Carbon::now()->diffForHumans(Carbon::now()->subYears(1), CarbonInterface::DIFF_ABSOLUTE));
+            $this->assertSame('1 year', Carbon::now()->diffForHumans(Carbon::now()->addYears(1), CarbonInterface::DIFF_ABSOLUTE));
+            $this->assertSame('1 year after', Carbon::now()->diffForHumans(Carbon::now()->subYears(1), CarbonInterface::DIFF_RELATIVE_AUTO));
+            $this->assertSame('1 year before', Carbon::now()->diffForHumans(Carbon::now()->addYears(1), CarbonInterface::DIFF_RELATIVE_AUTO));
+            $this->assertSame('1 year from now', Carbon::now()->diffForHumans(Carbon::now()->subYears(1), CarbonInterface::DIFF_RELATIVE_TO_NOW));
+            $this->assertSame('1 year ago', Carbon::now()->diffForHumans(Carbon::now()->addYears(1), CarbonInterface::DIFF_RELATIVE_TO_NOW));
+            $this->assertSame('1 year after', Carbon::now()->diffForHumans(Carbon::now()->subYears(1), CarbonInterface::DIFF_RELATIVE_TO_OTHER));
+            $this->assertSame('1 year before', Carbon::now()->diffForHumans(Carbon::now()->addYears(1), CarbonInterface::DIFF_RELATIVE_TO_OTHER));
+            $this->assertSame('1 year', Carbon::now()->subYears(1)->diffForHumans(null, CarbonInterface::DIFF_ABSOLUTE));
+            $this->assertSame('1 year', Carbon::now()->addYears(1)->diffForHumans(null, CarbonInterface::DIFF_ABSOLUTE));
+            $this->assertSame('1 year ago', Carbon::now()->subYears(1)->diffForHumans(null, CarbonInterface::DIFF_RELATIVE_AUTO));
+            $this->assertSame('1 year from now', Carbon::now()->addYears(1)->diffForHumans(null, CarbonInterface::DIFF_RELATIVE_AUTO));
+            $this->assertSame('1 year ago', Carbon::now()->subYears(1)->diffForHumans(null, CarbonInterface::DIFF_RELATIVE_TO_NOW));
+            $this->assertSame('1 year from now', Carbon::now()->addYears(1)->diffForHumans(null, CarbonInterface::DIFF_RELATIVE_TO_NOW));
+            $this->assertSame('1 year before', Carbon::now()->subYears(1)->diffForHumans(null, CarbonInterface::DIFF_RELATIVE_TO_OTHER));
+            $this->assertSame('1 year after', Carbon::now()->addYears(1)->diffForHumans(null, CarbonInterface::DIFF_RELATIVE_TO_OTHER));
         });
     }
 

--- a/tests/CarbonImmutable/DiffTest.php
+++ b/tests/CarbonImmutable/DiffTest.php
@@ -50,9 +50,8 @@ class DiffTest extends AbstractTestCase
 
     public function testDiffInYearsVsDefaultNow()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame(1, Carbon::now()->subYear()->diffInYears());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(1, Carbon::now()->subYear()->diffInYears());
         });
     }
 
@@ -82,9 +81,8 @@ class DiffTest extends AbstractTestCase
 
     public function testDiffInMonthsVsDefaultNow()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame(12, Carbon::now()->subYear()->diffInMonths());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(12, Carbon::now()->subYear()->diffInMonths());
         });
     }
 
@@ -114,9 +112,8 @@ class DiffTest extends AbstractTestCase
 
     public function testDiffInDaysVsDefaultNow()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame(7, Carbon::now()->subWeek()->diffInDays());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(7, Carbon::now()->subWeek()->diffInDays());
         });
     }
 
@@ -358,9 +355,8 @@ class DiffTest extends AbstractTestCase
 
     public function testDiffInWeeksVsDefaultNow()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame(1, Carbon::now()->subWeek()->diffInWeeks());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(1, Carbon::now()->subWeek()->diffInWeeks());
         });
     }
 
@@ -390,9 +386,8 @@ class DiffTest extends AbstractTestCase
 
     public function testDiffInHoursVsDefaultNow()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame(48, Carbon::now()->subDays(2)->diffInHours());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(48, Carbon::now()->subDays(2)->diffInHours());
         }, Carbon::create(2012, 1, 15));
     }
 
@@ -447,9 +442,8 @@ class DiffTest extends AbstractTestCase
 
     public function testDiffInMinutesVsDefaultNow()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame(60, Carbon::now()->subHour()->diffInMinutes());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(60, Carbon::now()->subHour()->diffInMinutes());
         });
     }
 
@@ -485,9 +479,8 @@ class DiffTest extends AbstractTestCase
 
     public function testDiffInSecondsVsDefaultNow()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame(3600, Carbon::now()->subHour()->diffInSeconds());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(3600, Carbon::now()->subHour()->diffInSeconds());
         });
     }
 
@@ -508,18 +501,15 @@ class DiffTest extends AbstractTestCase
     {
         $vanNow = Carbon::now('America/Vancouver');
         $hereNow = $vanNow->copy()->setTimezone(Carbon::now()->tz);
-
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($vanNow, $scope) {
-            $scope->assertSame(0, $vanNow->diffInSeconds());
+        $this->wrapWithTestNow(function () use ($vanNow) {
+            $this->assertSame(0, $vanNow->diffInSeconds());
         }, $hereNow);
     }
 
     public function testDiffForHumansNowAndSecond()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 second ago', Carbon::now()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 second ago', Carbon::now()->diffForHumans());
         });
     }
 
@@ -527,733 +517,664 @@ class DiffTest extends AbstractTestCase
     {
         $vanNow = Carbon::now('America/Vancouver');
         $hereNow = $vanNow->copy()->setTimezone(Carbon::now()->tz);
-
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($vanNow, $scope) {
-            $scope->assertSame('1 second ago', $vanNow->diffForHumans());
+        $this->wrapWithTestNow(function () use ($vanNow) {
+            $this->assertSame('1 second ago', $vanNow->diffForHumans());
         }, $hereNow);
     }
 
     public function testDiffForHumansNowAndSeconds()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 seconds ago', Carbon::now()->subSeconds(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 seconds ago', Carbon::now()->subSeconds(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyMinute()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('59 seconds ago', Carbon::now()->subSeconds(59)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('59 seconds ago', Carbon::now()->subSeconds(59)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndMinute()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 minute ago', Carbon::now()->subMinute()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 minute ago', Carbon::now()->subMinute()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndMinutes()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 minutes ago', Carbon::now()->subMinutes(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 minutes ago', Carbon::now()->subMinutes(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyHour()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('59 minutes ago', Carbon::now()->subMinutes(59)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('59 minutes ago', Carbon::now()->subMinutes(59)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndHour()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 hour ago', Carbon::now()->subHour()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 hour ago', Carbon::now()->subHour()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndHours()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 hours ago', Carbon::now()->subHours(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 hours ago', Carbon::now()->subHours(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyDay()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('23 hours ago', Carbon::now()->subHours(23)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('23 hours ago', Carbon::now()->subHours(23)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndDay()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 day ago', Carbon::now()->subDay()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 day ago', Carbon::now()->subDay()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndDays()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 days ago', Carbon::now()->subDays(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 days ago', Carbon::now()->subDays(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyWeek()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('6 days ago', Carbon::now()->subDays(6)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('6 days ago', Carbon::now()->subDays(6)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndWeek()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 week ago', Carbon::now()->subWeek()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 week ago', Carbon::now()->subWeek()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndWeeks()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 weeks ago', Carbon::now()->subWeeks(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 weeks ago', Carbon::now()->subWeeks(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyMonth()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('3 weeks ago', Carbon::now()->subWeeks(3)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('3 weeks ago', Carbon::now()->subWeeks(3)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndMonth()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('4 weeks ago', Carbon::now()->subWeeks(4)->diffForHumans());
-            $scope->assertSame('1 month ago', Carbon::now()->subMonth()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('4 weeks ago', Carbon::now()->subWeeks(4)->diffForHumans());
+            $this->assertSame('1 month ago', Carbon::now()->subMonth()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndMonths()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 months ago', Carbon::now()->subMonths(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 months ago', Carbon::now()->subMonths(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyYear()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('11 months ago', Carbon::now()->subMonths(11)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('11 months ago', Carbon::now()->subMonths(11)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndYear()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 year ago', Carbon::now()->subYear()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 year ago', Carbon::now()->subYear()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndYears()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 years ago', Carbon::now()->subYears(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 years ago', Carbon::now()->subYears(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureSecond()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 second from now', Carbon::now()->addSecond()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 second from now', Carbon::now()->addSecond()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureSeconds()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 seconds from now', Carbon::now()->addSeconds(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 seconds from now', Carbon::now()->addSeconds(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyFutureMinute()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('59 seconds from now', Carbon::now()->addSeconds(59)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('59 seconds from now', Carbon::now()->addSeconds(59)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureMinute()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 minute from now', Carbon::now()->addMinute()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 minute from now', Carbon::now()->addMinute()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureMinutes()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 minutes from now', Carbon::now()->addMinutes(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 minutes from now', Carbon::now()->addMinutes(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyFutureHour()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('59 minutes from now', Carbon::now()->addMinutes(59)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('59 minutes from now', Carbon::now()->addMinutes(59)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureHour()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 hour from now', Carbon::now()->addHour()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 hour from now', Carbon::now()->addHour()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureHours()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 hours from now', Carbon::now()->addHours(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 hours from now', Carbon::now()->addHours(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyFutureDay()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('23 hours from now', Carbon::now()->addHours(23)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('23 hours from now', Carbon::now()->addHours(23)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureDay()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 day from now', Carbon::now()->addDay()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 day from now', Carbon::now()->addDay()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureDays()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 days from now', Carbon::now()->addDays(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 days from now', Carbon::now()->addDays(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyFutureWeek()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('6 days from now', Carbon::now()->addDays(6)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('6 days from now', Carbon::now()->addDays(6)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureWeek()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 week from now', Carbon::now()->addWeek()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 week from now', Carbon::now()->addWeek()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureWeeks()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 weeks from now', Carbon::now()->addWeeks(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 weeks from now', Carbon::now()->addWeeks(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyFutureMonth()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('3 weeks from now', Carbon::now()->addWeeks(3)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('3 weeks from now', Carbon::now()->addWeeks(3)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureMonth()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('4 weeks from now', Carbon::now()->addWeeks(4)->diffForHumans());
-            $scope->assertSame('1 month from now', Carbon::now()->addMonth()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('4 weeks from now', Carbon::now()->addWeeks(4)->diffForHumans());
+            $this->assertSame('1 month from now', Carbon::now()->addMonth()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureMonths()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 months from now', Carbon::now()->addMonths(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 months from now', Carbon::now()->addMonths(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndNearlyFutureYear()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('11 months from now', Carbon::now()->addMonths(11)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('11 months from now', Carbon::now()->addMonths(11)->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureYear()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 year from now', Carbon::now()->addYear()->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 year from now', Carbon::now()->addYear()->diffForHumans());
         });
     }
 
     public function testDiffForHumansNowAndFutureYears()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 years from now', Carbon::now()->addYears(2)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 years from now', Carbon::now()->addYears(2)->diffForHumans());
         });
     }
 
     public function testDiffForHumansOtherAndSecond()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 second before', Carbon::now()->diffForHumans(Carbon::now()->addSecond()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 second before', Carbon::now()->diffForHumans(Carbon::now()->addSecond()));
         });
     }
 
     public function testDiffForHumansOtherAndSeconds()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 seconds before', Carbon::now()->diffForHumans(Carbon::now()->addSeconds(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 seconds before', Carbon::now()->diffForHumans(Carbon::now()->addSeconds(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyMinute()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('59 seconds before', Carbon::now()->diffForHumans(Carbon::now()->addSeconds(59)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('59 seconds before', Carbon::now()->diffForHumans(Carbon::now()->addSeconds(59)));
         });
     }
 
     public function testDiffForHumansOtherAndMinute()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 minute before', Carbon::now()->diffForHumans(Carbon::now()->addMinute()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 minute before', Carbon::now()->diffForHumans(Carbon::now()->addMinute()));
         });
     }
 
     public function testDiffForHumansOtherAndMinutes()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 minutes before', Carbon::now()->diffForHumans(Carbon::now()->addMinutes(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 minutes before', Carbon::now()->diffForHumans(Carbon::now()->addMinutes(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyHour()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('59 minutes before', Carbon::now()->diffForHumans(Carbon::now()->addMinutes(59)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('59 minutes before', Carbon::now()->diffForHumans(Carbon::now()->addMinutes(59)));
         });
     }
 
     public function testDiffForHumansOtherAndHour()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 hour before', Carbon::now()->diffForHumans(Carbon::now()->addHour()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 hour before', Carbon::now()->diffForHumans(Carbon::now()->addHour()));
         });
     }
 
     public function testDiffForHumansOtherAndHours()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 hours before', Carbon::now()->diffForHumans(Carbon::now()->addHours(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 hours before', Carbon::now()->diffForHumans(Carbon::now()->addHours(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyDay()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('23 hours before', Carbon::now()->diffForHumans(Carbon::now()->addHours(23)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('23 hours before', Carbon::now()->diffForHumans(Carbon::now()->addHours(23)));
         });
     }
 
     public function testDiffForHumansOtherAndDay()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 day before', Carbon::now()->diffForHumans(Carbon::now()->addDay()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 day before', Carbon::now()->diffForHumans(Carbon::now()->addDay()));
         });
     }
 
     public function testDiffForHumansOtherAndDays()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 days before', Carbon::now()->diffForHumans(Carbon::now()->addDays(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 days before', Carbon::now()->diffForHumans(Carbon::now()->addDays(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyWeek()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('6 days before', Carbon::now()->diffForHumans(Carbon::now()->addDays(6)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('6 days before', Carbon::now()->diffForHumans(Carbon::now()->addDays(6)));
         });
     }
 
     public function testDiffForHumansOverWeekWithDefaultPartsCount()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 week ago', Carbon::now()->subDays(8)->diffForHumans());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 week ago', Carbon::now()->subDays(8)->diffForHumans());
         });
     }
 
     public function testDiffForHumansOverWeekWithPartsCount1()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 week ago', Carbon::now()->subDays(8)->diffForHumans(null, false, false, 1));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 week ago', Carbon::now()->subDays(8)->diffForHumans(null, false, false, 1));
         });
     }
 
     public function testDiffForHumansOverWeekWithPartsCount2()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 week 1 day ago', Carbon::now()->subDays(8)->diffForHumans(null, false, false, 2));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 week 1 day ago', Carbon::now()->subDays(8)->diffForHumans(null, false, false, 2));
         });
     }
 
     public function testDiffForHumansOtherAndWeek()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 week before', Carbon::now()->diffForHumans(Carbon::now()->addWeek()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 week before', Carbon::now()->diffForHumans(Carbon::now()->addWeek()));
         });
     }
 
     public function testDiffForHumansOtherAndWeeks()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 weeks before', Carbon::now()->diffForHumans(Carbon::now()->addWeeks(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 weeks before', Carbon::now()->diffForHumans(Carbon::now()->addWeeks(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyMonth()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('3 weeks before', Carbon::now()->diffForHumans(Carbon::now()->addWeeks(3)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('3 weeks before', Carbon::now()->diffForHumans(Carbon::now()->addWeeks(3)));
         });
     }
 
     public function testDiffForHumansOtherAndMonth()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('4 weeks before', Carbon::now()->diffForHumans(Carbon::now()->addWeeks(4)));
-            $scope->assertSame('1 month before', Carbon::now()->diffForHumans(Carbon::now()->addMonth()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('4 weeks before', Carbon::now()->diffForHumans(Carbon::now()->addWeeks(4)));
+            $this->assertSame('1 month before', Carbon::now()->diffForHumans(Carbon::now()->addMonth()));
         });
     }
 
     public function testDiffForHumansOtherAndMonths()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 months before', Carbon::now()->diffForHumans(Carbon::now()->addMonths(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 months before', Carbon::now()->diffForHumans(Carbon::now()->addMonths(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyYear()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('11 months before', Carbon::now()->diffForHumans(Carbon::now()->addMonths(11)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('11 months before', Carbon::now()->diffForHumans(Carbon::now()->addMonths(11)));
         });
     }
 
     public function testDiffForHumansOtherAndYear()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 year before', Carbon::now()->diffForHumans(Carbon::now()->addYear()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 year before', Carbon::now()->diffForHumans(Carbon::now()->addYear()));
         });
     }
 
     public function testDiffForHumansOtherAndYears()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 years before', Carbon::now()->diffForHumans(Carbon::now()->addYears(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 years before', Carbon::now()->diffForHumans(Carbon::now()->addYears(2)));
         });
     }
 
     public function testDiffForHumansOtherAndFutureSecond()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 second after', Carbon::now()->diffForHumans(Carbon::now()->subSecond()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 second after', Carbon::now()->diffForHumans(Carbon::now()->subSecond()));
         });
     }
 
     public function testDiffForHumansOtherAndFutureSeconds()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 seconds after', Carbon::now()->diffForHumans(Carbon::now()->subSeconds(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 seconds after', Carbon::now()->diffForHumans(Carbon::now()->subSeconds(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyFutureMinute()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('59 seconds after', Carbon::now()->diffForHumans(Carbon::now()->subSeconds(59)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('59 seconds after', Carbon::now()->diffForHumans(Carbon::now()->subSeconds(59)));
         });
     }
 
     public function testDiffForHumansOtherAndFutureMinute()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 minute after', Carbon::now()->diffForHumans(Carbon::now()->subMinute()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 minute after', Carbon::now()->diffForHumans(Carbon::now()->subMinute()));
         });
     }
 
     public function testDiffForHumansOtherAndFutureMinutes()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 minutes after', Carbon::now()->diffForHumans(Carbon::now()->subMinutes(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 minutes after', Carbon::now()->diffForHumans(Carbon::now()->subMinutes(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyFutureHour()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('59 minutes after', Carbon::now()->diffForHumans(Carbon::now()->subMinutes(59)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('59 minutes after', Carbon::now()->diffForHumans(Carbon::now()->subMinutes(59)));
         });
     }
 
     public function testDiffForHumansOtherAndFutureHour()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 hour after', Carbon::now()->diffForHumans(Carbon::now()->subHour()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 hour after', Carbon::now()->diffForHumans(Carbon::now()->subHour()));
         });
     }
 
     public function testDiffForHumansOtherAndFutureHours()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 hours after', Carbon::now()->diffForHumans(Carbon::now()->subHours(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 hours after', Carbon::now()->diffForHumans(Carbon::now()->subHours(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyFutureDay()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('23 hours after', Carbon::now()->diffForHumans(Carbon::now()->subHours(23)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('23 hours after', Carbon::now()->diffForHumans(Carbon::now()->subHours(23)));
         });
     }
 
     public function testDiffForHumansOtherAndFutureDay()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 day after', Carbon::now()->diffForHumans(Carbon::now()->subDay()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 day after', Carbon::now()->diffForHumans(Carbon::now()->subDay()));
         });
     }
 
     public function testDiffForHumansOtherAndFutureDays()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 days after', Carbon::now()->diffForHumans(Carbon::now()->subDays(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 days after', Carbon::now()->diffForHumans(Carbon::now()->subDays(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyFutureWeek()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('6 days after', Carbon::now()->diffForHumans(Carbon::now()->subDays(6)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('6 days after', Carbon::now()->diffForHumans(Carbon::now()->subDays(6)));
         });
     }
 
     public function testDiffForHumansOtherAndFutureWeek()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 week after', Carbon::now()->diffForHumans(Carbon::now()->subWeek()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 week after', Carbon::now()->diffForHumans(Carbon::now()->subWeek()));
         });
     }
 
     public function testDiffForHumansOtherAndFutureWeeks()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 weeks after', Carbon::now()->diffForHumans(Carbon::now()->subWeeks(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 weeks after', Carbon::now()->diffForHumans(Carbon::now()->subWeeks(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyFutureMonth()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('3 weeks after', Carbon::now()->diffForHumans(Carbon::now()->subWeeks(3)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('3 weeks after', Carbon::now()->diffForHumans(Carbon::now()->subWeeks(3)));
         });
     }
 
     public function testDiffForHumansOtherAndFutureMonth()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('4 weeks after', Carbon::now()->diffForHumans(Carbon::now()->subWeeks(4)));
-            $scope->assertSame('1 month after', Carbon::now()->diffForHumans(Carbon::now()->subMonth()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('4 weeks after', Carbon::now()->diffForHumans(Carbon::now()->subWeeks(4)));
+            $this->assertSame('1 month after', Carbon::now()->diffForHumans(Carbon::now()->subMonth()));
         });
     }
 
     public function testDiffForHumansOtherAndFutureMonths()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 months after', Carbon::now()->diffForHumans(Carbon::now()->subMonths(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 months after', Carbon::now()->diffForHumans(Carbon::now()->subMonths(2)));
         });
     }
 
     public function testDiffForHumansOtherAndNearlyFutureYear()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('11 months after', Carbon::now()->diffForHumans(Carbon::now()->subMonths(11)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('11 months after', Carbon::now()->diffForHumans(Carbon::now()->subMonths(11)));
         });
     }
 
     public function testDiffForHumansOtherAndFutureYear()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 year after', Carbon::now()->diffForHumans(Carbon::now()->subYear()));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 year after', Carbon::now()->diffForHumans(Carbon::now()->subYear()));
         });
     }
 
     public function testDiffForHumansOtherAndFutureYears()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 years after', Carbon::now()->diffForHumans(Carbon::now()->subYears(2)));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 years after', Carbon::now()->diffForHumans(Carbon::now()->subYears(2)));
         });
     }
 
     public function testDiffForHumansAbsoluteSeconds()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('59 seconds', Carbon::now()->diffForHumans(Carbon::now()->subSeconds(59), true));
-            $scope->assertSame('59 seconds', Carbon::now()->diffForHumans(Carbon::now()->addSeconds(59), true));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('59 seconds', Carbon::now()->diffForHumans(Carbon::now()->subSeconds(59), true));
+            $this->assertSame('59 seconds', Carbon::now()->diffForHumans(Carbon::now()->addSeconds(59), true));
         });
     }
 
     public function testDiffForHumansAbsoluteMinutes()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('30 minutes', Carbon::now()->diffForHumans(Carbon::now()->subMinutes(30), true));
-            $scope->assertSame('30 minutes', Carbon::now()->diffForHumans(Carbon::now()->addMinutes(30), true));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('30 minutes', Carbon::now()->diffForHumans(Carbon::now()->subMinutes(30), true));
+            $this->assertSame('30 minutes', Carbon::now()->diffForHumans(Carbon::now()->addMinutes(30), true));
         });
     }
 
     public function testDiffForHumansAbsoluteHours()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('3 hours', Carbon::now()->diffForHumans(Carbon::now()->subHours(3), true));
-            $scope->assertSame('3 hours', Carbon::now()->diffForHumans(Carbon::now()->addHours(3), true));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('3 hours', Carbon::now()->diffForHumans(Carbon::now()->subHours(3), true));
+            $this->assertSame('3 hours', Carbon::now()->diffForHumans(Carbon::now()->addHours(3), true));
         });
     }
 
     public function testDiffForHumansAbsoluteDays()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 days', Carbon::now()->diffForHumans(Carbon::now()->subDays(2), true));
-            $scope->assertSame('2 days', Carbon::now()->diffForHumans(Carbon::now()->addDays(2), true));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 days', Carbon::now()->diffForHumans(Carbon::now()->subDays(2), true));
+            $this->assertSame('2 days', Carbon::now()->diffForHumans(Carbon::now()->addDays(2), true));
         });
     }
 
     public function testDiffForHumansAbsoluteWeeks()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 weeks', Carbon::now()->diffForHumans(Carbon::now()->subWeeks(2), true));
-            $scope->assertSame('2 weeks', Carbon::now()->diffForHumans(Carbon::now()->addWeeks(2), true));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 weeks', Carbon::now()->diffForHumans(Carbon::now()->subWeeks(2), true));
+            $this->assertSame('2 weeks', Carbon::now()->diffForHumans(Carbon::now()->addWeeks(2), true));
         });
     }
 
     public function testDiffForHumansAbsoluteMonths()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('2 months', Carbon::now()->diffForHumans(Carbon::now()->subMonths(2), true));
-            $scope->assertSame('2 months', Carbon::now()->diffForHumans(Carbon::now()->addMonths(2), true));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('2 months', Carbon::now()->diffForHumans(Carbon::now()->subMonths(2), true));
+            $this->assertSame('2 months', Carbon::now()->diffForHumans(Carbon::now()->addMonths(2), true));
         });
     }
 
     public function testDiffForHumansAbsoluteYears()
     {
-        $scope = $this;
-        $this->wrapWithTestNow(function () use ($scope) {
-            $scope->assertSame('1 year', Carbon::now()->diffForHumans(Carbon::now()->subYears(1), true));
-            $scope->assertSame('1 year', Carbon::now()->diffForHumans(Carbon::now()->addYears(1), true));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 year', Carbon::now()->diffForHumans(Carbon::now()->subYears(1), true));
+            $this->assertSame('1 year', Carbon::now()->diffForHumans(Carbon::now()->addYears(1), true));
+        });
+    }
+
+    public function testDiffForHumansWithOptions()
+    {
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('1 year', Carbon::now()->diffForHumans(Carbon::now()->subYears(1), CarbonInterface::DIFF_ABSOLUTE));
+            $this->assertSame('1 year', Carbon::now()->diffForHumans(Carbon::now()->addYears(1), CarbonInterface::DIFF_ABSOLUTE));
+            $this->assertSame('1 year after', Carbon::now()->diffForHumans(Carbon::now()->subYears(1), CarbonInterface::DIFF_RELATIVE_AUTO));
+            $this->assertSame('1 year before', Carbon::now()->diffForHumans(Carbon::now()->addYears(1), CarbonInterface::DIFF_RELATIVE_AUTO));
+            $this->assertSame('1 year from now', Carbon::now()->diffForHumans(Carbon::now()->subYears(1), CarbonInterface::DIFF_RELATIVE_TO_NOW));
+            $this->assertSame('1 year ago', Carbon::now()->diffForHumans(Carbon::now()->addYears(1), CarbonInterface::DIFF_RELATIVE_TO_NOW));
+            $this->assertSame('1 year after', Carbon::now()->diffForHumans(Carbon::now()->subYears(1), CarbonInterface::DIFF_RELATIVE_TO_OTHER));
+            $this->assertSame('1 year before', Carbon::now()->diffForHumans(Carbon::now()->addYears(1), CarbonInterface::DIFF_RELATIVE_TO_OTHER));
+            $this->assertSame('1 year', Carbon::now()->subYears(1)->diffForHumans(null, CarbonInterface::DIFF_ABSOLUTE));
+            $this->assertSame('1 year', Carbon::now()->addYears(1)->diffForHumans(null, CarbonInterface::DIFF_ABSOLUTE));
+            $this->assertSame('1 year ago', Carbon::now()->subYears(1)->diffForHumans(null, CarbonInterface::DIFF_RELATIVE_AUTO));
+            $this->assertSame('1 year from now', Carbon::now()->addYears(1)->diffForHumans(null, CarbonInterface::DIFF_RELATIVE_AUTO));
+            $this->assertSame('1 year ago', Carbon::now()->subYears(1)->diffForHumans(null, CarbonInterface::DIFF_RELATIVE_TO_NOW));
+            $this->assertSame('1 year from now', Carbon::now()->addYears(1)->diffForHumans(null, CarbonInterface::DIFF_RELATIVE_TO_NOW));
+            $this->assertSame('1 year before', Carbon::now()->subYears(1)->diffForHumans(null, CarbonInterface::DIFF_RELATIVE_TO_OTHER));
+            $this->assertSame('1 year after', Carbon::now()->addYears(1)->diffForHumans(null, CarbonInterface::DIFF_RELATIVE_TO_OTHER));
         });
     }
 


### PR DESCRIPTION
The `$absolute` boolean parameter for `diffForHumans` become a `$syntax` integer flag:

```php
CarbonInterface::DIFF_ABSOLUTE // no difference modifiers: match the old $absolute = true
CarbonInterface::DIFF_RELATIVE_AUTO // add before/after if a date is given as second argument, add ago/from now if no other date is given: match the old $absolute = false
CarbonInterface::DIFF_RELATIVE_TO_NOW // add ago/from now
CarbonInterface::DIFF_RELATIVE_TO_OTHER // add before/after
```