### PR TITLE
Wrong day of a week exception

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1451,6 +1451,10 @@ class Carbon extends DateTime implements JsonSerializable
      */
     public static function setWeekStartsAt($day)
     {
+        if ($day > static::SATURDAY || $day < static::SUNDAY) {
+            throw new \InvalidArgumentException('Day of a week should be greater than or equal to 0 and less than or equal to 6.');
+        }
+        
         static::$weekStartsAt = $day;
     }
 
@@ -1473,6 +1477,10 @@ class Carbon extends DateTime implements JsonSerializable
      */
     public static function setWeekEndsAt($day)
     {
+        if ($day > static::SATURDAY || $day < static::SUNDAY) {
+            throw new \InvalidArgumentException('Day of a week should be greater than or equal to 0 and less than or equal to 6.');
+        }
+        
         static::$weekEndsAt = $day;
     }
 

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1447,12 +1447,14 @@ class Carbon extends DateTime implements JsonSerializable
      *
      * @param int $day week start day
      *
+     * @throws InvalidArgumentException
+     *
      * @return void
      */
     public static function setWeekStartsAt($day)
     {
         if ($day > static::SATURDAY || $day < static::SUNDAY) {
-            throw new \InvalidArgumentException('Day of a week should be greater than or equal to 0 and less than or equal to 6.');
+            throw new InvalidArgumentException('Day of a week should be greater than or equal to 0 and less than or equal to 6.');
         }
 
         static::$weekStartsAt = $day;
@@ -1473,12 +1475,14 @@ class Carbon extends DateTime implements JsonSerializable
      *
      * @param int $day
      *
+     * @throws InvalidArgumentException
+     *
      * @return void
      */
     public static function setWeekEndsAt($day)
     {
         if ($day > static::SATURDAY || $day < static::SUNDAY) {
-            throw new \InvalidArgumentException('Day of a week should be greater than or equal to 0 and less than or equal to 6.');
+            throw new InvalidArgumentException('Day of a week should be greater than or equal to 0 and less than or equal to 6.');
         }
 
         static::$weekEndsAt = $day;

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1454,7 +1454,7 @@ class Carbon extends DateTime implements JsonSerializable
         if ($day > static::SATURDAY || $day < static::SUNDAY) {
             throw new \InvalidArgumentException('Day of a week should be greater than or equal to 0 and less than or equal to 6.');
         }
-        
+
         static::$weekStartsAt = $day;
     }
 
@@ -1480,7 +1480,7 @@ class Carbon extends DateTime implements JsonSerializable
         if ($day > static::SATURDAY || $day < static::SUNDAY) {
             throw new \InvalidArgumentException('Day of a week should be greater than or equal to 0 and less than or equal to 6.');
         }
-        
+
         static::$weekEndsAt = $day;
     }
 

--- a/tests/Carbon/SetStartEndOfWeekTest
+++ b/tests/Carbon/SetStartEndOfWeekTest
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Carbon;
+
+use Carbon\Carbon;
+use Tests\AbstractTestCase;
+
+class SetStartEndOfWeekTest extends AbstractTestCase
+{
+    public function testSetStartOfWeekLessThanMin()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Carbon::setWeekStartsAt(Carbon::SUNDAY-1);
+    }
+
+    public function testSetStartOfWeekMoreThanMax()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Carbon::setWeekStartsAt(Carbon::SATURDAY+1);
+    }
+
+    public function testSetStartOfWeekValid()
+    {
+        for ($i = Carbon::SUNDAY; $i < Carbon::SATURDAY; $i++) {
+            Carbon::setWeekStartsAt($i);
+            $this->assertSame($i, Carbon::getWeekStartsAt());
+        }
+    }
+
+    public function testSetEndOfWeekLessThanMin()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Carbon::setWeekEndsAt(Carbon::SUNDAY-1);
+    }
+
+    public function testSetEndOfWeekMoreThanMax()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Carbon::setWeekEndsAt(Carbon::SATURDAY+1);
+    }
+
+    public function testSetEndOfWeekValid()
+    {
+        for ($i = Carbon::SUNDAY; $i < Carbon::SATURDAY; $i++) {
+            Carbon::setWeekEndsAt($i);
+            $this->assertSame($i, Carbon::getWeekEndsAt());
+        }
+    }
+}


### PR DESCRIPTION
If set start of a week more than 6 or less than 0 and then call startOfWeek we will get an infinite while loop... So, I think it is a good idea to throw Exception when a user sets start/end of a week.