### PR TITLE
Add $weekStartsAt/$weekEndsAt optional arguments for week methods

### DIFF
--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -1557,7 +1557,7 @@ trait Date
 
             // @property-read int 1 through 5
             case $name === 'weekNumberInMonth':
-                return (int) ceil(($this->day + $this->copy()->startOfMonth()->dayOfWeek - 1) / static::DAYS_PER_WEEK);
+                return (int) ceil(($this->day + $this->copy()->startOfMonth()->dayOfWeekIso - 1) / static::DAYS_PER_WEEK);
 
             // @property int does a diffInYears() with default parameters
             case $name === 'age':

--- a/src/Carbon/Traits/Difference.php
+++ b/src/Carbon/Traits/Difference.php
@@ -292,7 +292,8 @@ trait Difference
     }
 
     /**
-     * Get the difference in a human readable format in the current locale.
+     * Get the difference in a human readable format in the current locale from current instance to an other
+     * instance given (or now if null given).
      *
      * When comparing a value in the past to default now:
      * 1 hour ago
@@ -433,5 +434,100 @@ trait Difference
         }
 
         return static::translator()->trans($transId, [':time' => $time]);
+    }
+
+    /**
+     * @alias diffForHumans
+     *
+     * Get the difference in a human readable format in the current locale from current instance to an other
+     * instance given (or now if null given).
+     */
+    public function from($other = null, $syntax = null, $short = false, $parts = 1)
+    {
+        return $this->diffForHumans($other, $syntax, $short, $parts);
+    }
+
+    /**
+     * Get the difference in a human readable format in the current locale from an other
+     * instance given (or now if null given) to current instance.
+     *
+     * When comparing a value in the past to default now:
+     * 1 hour from now
+     * 5 months from now
+     *
+     * When comparing a value in the future to default now:
+     * 1 hour ago
+     * 5 months ago
+     *
+     * When comparing a value in the past to another value:
+     * 1 hour after
+     * 5 months after
+     *
+     * When comparing a value in the future to another value:
+     * 1 hour before
+     * 5 months before
+     *
+     * @param Carbon|null $other
+     * @param int         $syntax difference modifiers (ago, after, etc) rules
+     *                            Possible values:
+     *                            - CarbonInterface::DIFF_ABSOLUTE
+     *                            - CarbonInterface::DIFF_RELATIVE_AUTO
+     *                            - CarbonInterface::DIFF_RELATIVE_TO_NOW
+     *                            - CarbonInterface::DIFF_RELATIVE_TO_OTHER
+     *                            Default value: CarbonInterface::DIFF_RELATIVE_AUTO
+     * @param bool        $short  displays short format of time units
+     * @param int         $parts  displays number of parts in the interval
+     *
+     * @return string
+     */
+    public function to($other = null, $syntax = null, $short = false, $parts = 1)
+    {
+        if (!$syntax && !$other) {
+            $syntax = CarbonInterface::DIFF_RELATIVE_TO_NOW;
+        }
+
+        return $this->resolveCarbon($other)->diffForHumans($this, $syntax, $short, $parts);
+    }
+
+    /**
+     * Get the difference in a human readable format in the current locale from current
+     * instance to now.
+     *
+     * @param int  $syntax difference modifiers (ago, after, etc) rules
+     *                     Possible values:
+     *                     - CarbonInterface::DIFF_ABSOLUTE
+     *                     - CarbonInterface::DIFF_RELATIVE_AUTO
+     *                     - CarbonInterface::DIFF_RELATIVE_TO_NOW
+     *                     - CarbonInterface::DIFF_RELATIVE_TO_OTHER
+     *                     Default value: CarbonInterface::DIFF_RELATIVE_AUTO
+     * @param bool $short  displays short format of time units
+     * @param int  $parts  displays number of parts in the interval
+     *
+     * @return string
+     */
+    public function fromNow($syntax = null, $short = false, $parts = 1)
+    {
+        return $this->from(null, $syntax, $short, $parts);
+    }
+
+    /**
+     * Get the difference in a human readable format in the current locale from an other
+     * instance given to now
+     *
+     * @param int  $syntax difference modifiers (ago, after, etc) rules
+     *                     Possible values:
+     *                     - CarbonInterface::DIFF_ABSOLUTE
+     *                     - CarbonInterface::DIFF_RELATIVE_AUTO
+     *                     - CarbonInterface::DIFF_RELATIVE_TO_NOW
+     *                     - CarbonInterface::DIFF_RELATIVE_TO_OTHER
+     *                     Default value: CarbonInterface::DIFF_RELATIVE_AUTO
+     * @param bool $short  displays short format of time units
+     * @param int  $parts  displays number of parts in the interval
+     *
+     * @return string
+     */
+    public function toNow($syntax = null, $short = false, $parts = 1)
+    {
+        return $this->to(null, $syntax, $short, $parts);
     }
 }

--- a/tests/Carbon/DiffTest.php
+++ b/tests/Carbon/DiffTest.php
@@ -1323,6 +1323,58 @@ class DiffTest extends AbstractTestCase
         Carbon::setHumanDiffOptions($options);
     }
 
+    public function testFromNow()
+    {
+        Carbon::setLocale('en');
+        $this->assertSame('2 days from now', Carbon::now()->addDays(2)->fromNow());
+        Carbon::setLocale('fr');
+        $this->assertSame('dans 2 jours', Carbon::now()->addDays(2)->fromNow());
+        Carbon::setLocale('en');
+        $this->assertSame('2 days after', Carbon::now()->addDays(2)->fromNow(CarbonInterface::DIFF_RELATIVE_TO_OTHER));
+        $this->assertSame('2d from now', Carbon::now()->addDays(2)->addHours(5)->fromNow(null, true));
+        $this->assertSame('2 days 5 hours', Carbon::now()->addDays(2)->addHours(5)->fromNow(true, false, 2));
+    }
+
+    public function testFrom()
+    {
+        Carbon::setLocale('en');
+        $this->assertSame('2 days from now', Carbon::now()->addDays(2)->from());
+        $this->assertSame('2 days from now', Carbon::now()->addDays(2)->from(null));
+        $this->assertSame('2 days after', Carbon::now()->addDay()->from(Carbon::now()->subDay()));
+        Carbon::setLocale('fr');
+        $this->assertSame('2 jours après', Carbon::now()->addDay()->from(Carbon::now()->subDay()));
+        Carbon::setLocale('en');
+        $this->assertSame('2 days from now', Carbon::now()->addDay()->from(Carbon::now()->subDay(), CarbonInterface::DIFF_RELATIVE_TO_NOW));
+        $this->assertSame('2d after', Carbon::now()->addDay()->addHours(5)->from(Carbon::now()->subDay(), null, true));
+        $this->assertSame('2 days 5 hours', Carbon::now()->addDay()->addHours(5)->from(Carbon::now()->subDay(), true, false, 2));
+    }
+
+    public function testToNow()
+    {
+        Carbon::setLocale('en');
+        $this->assertSame('2 days ago', Carbon::now()->addDays(2)->toNow());
+        Carbon::setLocale('fr');
+        $this->assertSame('il y a 2 jours', Carbon::now()->addDays(2)->toNow());
+        Carbon::setLocale('en');
+        $this->assertSame('2 days before', Carbon::now()->addDays(2)->toNow(CarbonInterface::DIFF_RELATIVE_TO_OTHER));
+        $this->assertSame('2d ago', Carbon::now()->addDays(2)->addHours(5)->toNow(null, true));
+        $this->assertSame('2 days 5 hours', Carbon::now()->addDays(2)->addHours(5)->toNow(true, false, 2));
+    }
+
+    public function testTo()
+    {
+        Carbon::setLocale('en');
+        $this->assertSame('2 days ago', Carbon::now()->addDays(2)->to());
+        $this->assertSame('2 days ago', Carbon::now()->addDays(2)->to(null));
+        $this->assertSame('2 days before', Carbon::now()->addDay()->to(Carbon::now()->subDay()));
+        Carbon::setLocale('fr');
+        $this->assertSame('2 jours avant', Carbon::now()->addDay()->to(Carbon::now()->subDay()));
+        Carbon::setLocale('en');
+        $this->assertSame('2 days ago', Carbon::now()->addDay()->to(Carbon::now()->subDay(), CarbonInterface::DIFF_RELATIVE_TO_NOW));
+        $this->assertSame('2d before', Carbon::now()->addDay()->addHours(5)->to(Carbon::now()->subDay(), null, true));
+        $this->assertSame('2 days 5 hours', Carbon::now()->addDay()->addHours(5)->to(Carbon::now()->subDay(), true, false, 2));
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Expected null, string, DateTime or DateTimeInterface, integer given

--- a/tests/Carbon/GettersTest.php
+++ b/tests/Carbon/GettersTest.php
@@ -407,6 +407,13 @@ class GettersTest extends AbstractTestCase
         $this->assertSame(2, Carbon::createFromDate(2017, 2, 12)->weekNumberInMonth);
         $this->assertSame(2, Carbon::createFromDate(2017, 2, 6)->weekNumberInMonth);
         $this->assertSame(1, Carbon::createFromDate(2017, 2, 1)->weekNumberInMonth);
+        $this->assertSame(1, Carbon::createFromDate(2018, 7, 1)->weekNumberInMonth);
+        $this->assertSame(2, Carbon::createFromDate(2018, 7, 2)->weekNumberInMonth);
+        $this->assertSame(2, Carbon::createFromDate(2018, 7, 5)->weekNumberInMonth);
+        $this->assertSame(2, Carbon::createFromDate(2018, 7, 8)->weekNumberInMonth);
+        $this->assertSame(3, Carbon::createFromDate(2018, 7, 9)->weekNumberInMonth);
+        $this->assertSame(5, Carbon::createFromDate(2018, 7, 29)->weekNumberInMonth);
+        $this->assertSame(6, Carbon::createFromDate(2018, 7, 30)->weekNumberInMonth);
     }
 
     public function testWeekOfYearFirstWeek()

--- a/tests/Carbon/RoundTest.php
+++ b/tests/Carbon/RoundTest.php
@@ -103,6 +103,11 @@ class RoundTest extends AbstractTestCase
         $this->assertCarbon($dt->copy()->ceilWeek(), 2315, 7, 19, 0, 0, 0, 0);
         $this->assertCarbon($dt->copy()->roundWeek(), 2315, 7, 19, 0, 0, 0, 0);
 
+        $dt = Carbon::create(2315, 7, 19, 0, 0, 0, 0);
+        $this->assertCarbon($dt->copy()->floorWeek(), 2315, 7, 19, 0, 0, 0, 0);
+        $this->assertCarbon($dt->copy()->ceilWeek(), 2315, 7, 19, 0, 0, 0, 0);
+        $this->assertCarbon($dt->copy()->roundWeek(), 2315, 7, 19, 0, 0, 0, 0);
+
         Carbon::setWeekStartsAt(Carbon::SUNDAY);
         Carbon::setWeekEndsAt(Carbon::SATURDAY);
 

--- a/tests/CarbonImmutable/RoundTest.php
+++ b/tests/CarbonImmutable/RoundTest.php
@@ -107,6 +107,11 @@ class RoundTest extends AbstractTestCase
         $this->assertCarbon($dt->copy()->ceilWeek(), 2315, 7, 19, 0, 0, 0, 0);
         $this->assertCarbon($dt->copy()->roundWeek(), 2315, 7, 19, 0, 0, 0, 0);
 
+        $dt = Carbon::create(2315, 7, 19, 0, 0, 0, 0);
+        $this->assertCarbon($dt->copy()->floorWeek(), 2315, 7, 19, 0, 0, 0, 0);
+        $this->assertCarbon($dt->copy()->ceilWeek(), 2315, 7, 19, 0, 0, 0, 0);
+        $this->assertCarbon($dt->copy()->roundWeek(), 2315, 7, 19, 0, 0, 0, 0);
+
         Carbon::setWeekStartsAt(Carbon::SUNDAY);
         Carbon::setWeekEndsAt(Carbon::SATURDAY);
 


### PR DESCRIPTION
- Add $weekStartsAt/$weekEndsAt optional arguments for week methods
- Deprecate many static setters
- Fix #1386 weekNumberInMonth for months starting a sunday
- Implement methods from, fromNow, to, toNow