### PR TITLE
Support closure based $toStringFormat

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1847,7 +1847,7 @@ class Carbon extends DateTime implements JsonSerializable
     /**
      * Set the default format used when type juggling a Carbon instance to a string
      *
-     * @param mixed $format
+     * @param string|Closure $format
      *
      * @return void
      */

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -1847,7 +1847,7 @@ class Carbon extends DateTime implements JsonSerializable
     /**
      * Set the default format used when type juggling a Carbon instance to a string
      *
-     * @param string $format
+     * @param mixed $format
      *
      * @return void
      */
@@ -1863,7 +1863,9 @@ class Carbon extends DateTime implements JsonSerializable
      */
     public function __toString()
     {
-        return $this->format(static::$toStringFormat);
+        $format = static::$toStringFormat;
+
+        return $this->format($format instanceof Closure ? $format($this) : $format);
     }
 
     /**

--- a/tests/Carbon/StringsTest.php
+++ b/tests/Carbon/StringsTest.php
@@ -24,9 +24,24 @@ class StringsTest extends AbstractTestCase
         $this->assertSame(Carbon::now()->toDateTimeString(), ''.$d);
     }
 
-    public function testSetToStringFormat()
+    public function testSetToStringFormatString()
     {
         Carbon::setToStringFormat('jS \o\f F, Y g:i:s a');
+        $d = Carbon::create(1975, 12, 25, 14, 15, 16);
+        $this->assertSame('25th of December, 1975 2:15:16 pm', ''.$d);
+    }
+
+    public function testSetToStringFormatClosure()
+    {
+        Carbon::setToStringFormat(function ($d) {
+            return $d->year === 1976 ?
+                'jS \o\f F g:i:s a' :
+                'jS \o\f F, Y g:i:s a';
+        });
+
+        $d = Carbon::create(1976, 12, 25, 14, 15, 16);
+        $this->assertSame('25th of December 2:15:16 pm', ''.$d);
+
         $d = Carbon::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('25th of December, 1975 2:15:16 pm', ''.$d);
     }


### PR DESCRIPTION
Currently you can only use a string to set a default __toString() format.

This allows a closure to be used, which will execute whenever the instance is converted to a string.

This allows conditional formatting based on the current value.

For example:

```php
Carbon::setToStringFormat(function ($dateTime) {
    return $dateTime->isCurrentYear() ? 'M jS' : 'M jS, Y';
});

echo Carbon::now(); // July 19th

echo Carbon::now()->subYears(2); // July 19th, 2016
```