### PR TITLE
Patch catalan translation

### DIFF
--- a/src/Carbon/Lang/ca.php
+++ b/src/Carbon/Lang/ca.php
@@ -25,7 +25,7 @@ return array(
     'second' => ':count segon|:count segons',
     's' => ':count segon|:count segons',
     'ago' => 'fa :time',
-    'from_now' => 'dins de :time',
+    'from_now' => 'd\'aquí :time',
     'after' => ':time després',
     'before' => ':time abans',
     'diff_now' => 'ara mateix',

--- a/tests/Localization/CaTest.php
+++ b/tests/Localization/CaTest.php
@@ -65,7 +65,7 @@ class CaTest extends AbstractTestCase
             $scope->assertSame('fa 2 anys', $d->diffForHumans());
 
             $d = Carbon::now()->addSecond();
-            $scope->assertSame('dins de 1 segon', $d->diffForHumans());
+            $scope->assertSame('d\'aquí 1 segon', $d->diffForHumans());
 
             $d = Carbon::now()->addSecond();
             $d2 = Carbon::now();


### PR DESCRIPTION
'from_now' current translation is wrong. It is a literal spanish translation from "dentro de x días / semanas" that can be understood in Catalan but is grammatically wrong.