### PR TITLE
Update the documents to use the longer format functions as a default

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -117,13 +117,13 @@ $modifiedMutable = $mutable->add(1, 'day');
 $modifiedImmutable = CarbonImmutable::now()->add(1, 'day');
 
 var_dump($modifiedMutable === $mutable);             // bool(true)
-var_dump($mutable->isoFormat('dddd D'));             // string(8) "Monday 1"
-var_dump($modifiedMutable->isoFormat('dddd D'));     // string(8) "Monday 1"
+var_dump($mutable->isoFormat('dddd D'));             // string(8) "Friday 5"
+var_dump($modifiedMutable->isoFormat('dddd D'));     // string(8) "Friday 5"
 // So it means $mutable and $modifiedMutable are the same object
 // both set to now + 1 day.
 var_dump($modifiedImmutable === $immutable);         // bool(false)
-var_dump($immutable->isoFormat('dddd D'));           // string(9) "Sunday 30"
-var_dump($modifiedImmutable->isoFormat('dddd D'));   // string(8) "Monday 1"
+var_dump($immutable->isoFormat('dddd D'));           // string(10) "Thursday 4"
+var_dump($modifiedImmutable->isoFormat('dddd D'));   // string(8) "Friday 5"
 // While $immutable is still set to now and cannot be changed and
 // $modifiedImmutable is a new instance created from $immutable
 // set to now + 1 day.
@@ -257,16 +257,16 @@ if (strtotime($string) === false) {
 
     <p>
     <pre class="live-editor"><code class="php">$now = Carbon::now();
-echo $now;                               // 2018-09-30 10:48:11
+echo $now;                               // 2018-10-04 18:22:48
 echo "\n";
 $today = Carbon::today();
-echo $today;                             // 2018-09-30 00:00:00
+echo $today;                             // 2018-10-04 00:00:00
 echo "\n";
 $tomorrow = Carbon::tomorrow('Europe/London');
-echo $tomorrow;                          // 2018-10-01 00:00:00
+echo $tomorrow;                          // 2018-10-05 00:00:00
 echo "\n";
 $yesterday = Carbon::yesterday();
-echo $yesterday;                         // 2018-09-29 00:00:00
+echo $yesterday;                         // 2018-10-03 00:00:00
 </code></pre>
     </p>
 
@@ -382,7 +382,7 @@ echo $dt->diffInYears($dt->copy()->addYear());  // 1
 // 19:15 in Johannesburg
 echo 'Meeting starts at '.$meeting->format('H:i').' in Johannesburg.';                  // Meeting starts at 19:15 in Johannesburg.
 // now in Johannesburg
-echo "It's ".$meeting->nowWithSameTz()->format('H:i').' right now in Johannesburg.';    // It's 12:48 right now in Johannesburg.
+echo "It's ".$meeting->nowWithSameTz()->format('H:i').' right now in Johannesburg.';    // It's 20:22 right now in Johannesburg.
 </code></pre>
     </p>
 
@@ -483,7 +483,7 @@ $dt = Carbon::parse('1975-05-21 22:23:00.123456');
 if ($newLocale === false) {
     echo '"German" locale is not installed on your machine, it may have a different name a different name on your machine or you may need to install it.';
 }
-echo $dt->formatLocalized('%A %d %B %Y');          // Mittwoch 21 Mai 1975
+echo $dt->formatLocalized('%A %d %B %Y');          // Wednesday 21 May 1975
 setlocale(LC_TIME, 'English');
 echo $dt->formatLocalized('%A %d %B %Y');          // Wednesday 21 May 1975
 setlocale(LC_TIME, ''); // reset locale
@@ -535,9 +535,9 @@ echo $french; // dans un an
         <pre><code class="php">setlocale(LC_TIME, 'Spanish');
 $dt = Carbon::create(2016, 01, 06, 00, 00, 00);
 Carbon::setUtf8(false);
-echo $dt->formatLocalized('%A %d %B %Y');          // mi�rcoles 06 enero 2016
+echo $dt->formatLocalized('%A %d %B %Y');          // Wednesday 06 January 2016
 Carbon::setUtf8(true);
-echo $dt->formatLocalized('%A %d %B %Y');          // miércoles 06 enero 2016
+echo $dt->formatLocalized('%A %d %B %Y');          // Wednesday 06 January 2016
 Carbon::setUtf8(false);
 setlocale(LC_TIME, '');
 </code></pre>
@@ -609,9 +609,9 @@ echo $date->locale();            // fr_FR
 echo "\n";
 echo $date->diffForHumans();     // il y a quelques secondes
 echo "\n";
-echo $date->monthName;           // septembre
+echo $date->monthName;           // octobre
 echo "\n";
-echo $date->isoFormat('LLLL');   // dimanche 30 septembre 2018 10:48
+echo $date->isoFormat('LLLL');   // jeudi 4 octobre 2018 18:22
 </code></pre>
     </p>
 
@@ -642,13 +642,13 @@ $notificationForJohn = $johnDateFactory->make($gameStart)->isoFormat('lll')."\n"
 echo $toDisplay;
 /*
 15 juin 2018 12:34
-Aujourd’hui à 10:48
+Aujourd’hui à 18:22
 */
 
 echo $notificationForJohn;
 /*
 Jun 15, 2018 12:34 PM
-Today at 10:48 AM
+Today at 6:22 PM
 */
 </code></pre>
     </p>
@@ -675,9 +675,9 @@ Carbon::now()->settings([
 ]);
 // Important note: timezone setting calls ->shiftTimezone() and not ->setTimezone(),
 // It means it does not just set the timezone, but shift the time too:
-echo Carbon::today()->setTimezone('Asia/Tokyo')->format('d/m G\h e');        // 30/09 9h Asia/Tokyo
+echo Carbon::today()->setTimezone('Asia/Tokyo')->format('d/m G\h e');        // 04/10 9h Asia/Tokyo
 echo "\n";
-echo Carbon::today()->shiftTimezone('Asia/Tokyo')->format('d/m G\h e');      // 30/09 0h Asia/Tokyo
+echo Carbon::today()->shiftTimezone('Asia/Tokyo')->format('d/m G\h e');      // 04/10 0h Asia/Tokyo
 </code></pre>
     </p>
 
@@ -1331,21 +1331,21 @@ echo $date->isoFormat('YYYY [escaped] YYYY'); // 2018 escaped 2018
 
     <p>
     <pre class="live-editor"><code class="php">$date = CarbonImmutable::now();
-echo $date->calendar();                                      // Today at 10:48 AM
+echo $date->calendar();                                      // Today at 6:22 PM
 echo "\n";
-echo $date->sub('1 day 3 hours')->calendar();                // Yesterday at 7:48 AM
+echo $date->sub('1 day 3 hours')->calendar();                // Yesterday at 3:22 PM
 echo "\n";
-echo $date->sub('3 days 10 hours 23 minutes')->calendar();   // Last Thursday at 12:25 AM
+echo $date->sub('3 days 10 hours 23 minutes')->calendar();   // Last Monday at 7:59 AM
 echo "\n";
-echo $date->sub('8 days')->calendar();                       // 09/22/2018
+echo $date->sub('8 days')->calendar();                       // 09/26/2018
 echo "\n";
-echo $date->add('1 day 3 hours')->calendar();                // Tomorrow at 1:48 PM
+echo $date->add('1 day 3 hours')->calendar();                // Tomorrow at 9:22 PM
 echo "\n";
-echo $date->add('3 days 10 hours 23 minutes')->calendar();   // Wednesday at 9:11 PM
+echo $date->add('3 days 10 hours 23 minutes')->calendar();   // Monday at 4:45 AM
 echo "\n";
-echo $date->add('8 days')->calendar();                       // 10/08/2018
+echo $date->add('8 days')->calendar();                       // 10/12/2018
 echo "\n";
-echo $date->locale('fr')->calendar();                        // Aujourd’hui à 10:48
+echo $date->locale('fr')->calendar();                        // Aujourd’hui à 18:22
 </code></pre>
     </p>
 
@@ -2334,7 +2334,7 @@ echo Carbon::create(2001, 4, 21, 12)->diffForHumans(); // 1 month ago
 var_dump(Carbon::hasTestNow());                        // bool(true)
 Carbon::setTestNow();                                  // clear the mock
 var_dump(Carbon::hasTestNow());                        // bool(false)
-echo Carbon::now();                                    // 2018-09-30 10:48:11
+echo Carbon::now();                                    // 2018-10-04 18:22:48
 </code></pre>
     </p>
 
@@ -2444,10 +2444,10 @@ var_dump($dt->locale('de')->shortMonthName);                 // string(4) "Okt."
 // Following are deprecated, locale* and shortLocale* properties
 // are translated using formatLocalized() based on LC_TIME language.
 setlocale(LC_TIME, 'German');
-var_dump($dt->localeDayOfWeek);                              // string(7) "Freitag"
-var_dump($dt->shortLocaleDayOfWeek);                         // string(2) "Fr"
-var_dump($dt->localeMonth);                                  // string(7) "Oktober"
-var_dump($dt->shortLocaleMonth);                             // string(3) "Okt"
+var_dump($dt->localeDayOfWeek);                              // string(6) "Friday"
+var_dump($dt->shortLocaleDayOfWeek);                         // string(3) "Fri"
+var_dump($dt->localeMonth);                                  // string(7) "October"
+var_dump($dt->shortLocaleMonth);                             // string(3) "Oct"
 setlocale(LC_TIME, '');
 
 var_dump($dt->dayOfYear);                                    // int(279)
@@ -2521,12 +2521,12 @@ echo "\n";
 
 // You can get any property dynamically too:
 $unit = 'second';
-var_dump(Carbon::now()->get($unit));                         // int(11)
+var_dump(Carbon::now()->get($unit));                         // int(48)
 // equivalent to:
-var_dump(Carbon::now()->$unit);                              // int(11)
+var_dump(Carbon::now()->$unit);                              // int(48)
 // If you have plural unit name, use singularUnit()
 $unit = Carbon::singularUnit('seconds');
-var_dump(Carbon::now()->get($unit));                         // int(11)
+var_dump(Carbon::now()->get($unit));                         // int(48)
 // Prefer using singularUnit() because some plurals are not the word with S:
 var_dump(Carbon::pluralUnit('century'));                     // string(9) "centuries"
 var_dump(Carbon::pluralUnit('millennium'));                  // string(9) "millennia"
@@ -2603,8 +2603,8 @@ echo "-----------\n";
 // We still can force to use an other day as start/end of week
 $start = $en->startOfWeek(Carbon::TUESDAY);
 $end = $en->endOfWeek(Carbon::MONDAY);
-var_dump($start->format('Y-m-d H:i'));                 // string(16) "2018-09-25 00:00"
-var_dump($end->format('Y-m-d H:i'));                   // string(16) "2018-10-01 23:59"
+var_dump($start->format('Y-m-d H:i'));                 // string(16) "2018-10-02 00:00"
+var_dump($end->format('Y-m-d H:i'));                   // string(16) "2018-10-08 23:59"
 
 echo "-----------\n";
 
@@ -2926,24 +2926,24 @@ echo $first->tzName;                               // UTC
 echo $second->toDateTimeString();                  // 2012-09-05 20:26:11
 echo $second->tzName;                              // America/Vancouver
 
-var_dump($first->eq($second));                     // bool(false)
-var_dump($first->ne($second));                     // bool(true)
-var_dump($first->gt($second));                     // bool(false)
-var_dump($first->gte($second));                    // bool(false)
-var_dump($first->lt($second));                     // bool(true)
-var_dump($first->lte($second));                    // bool(true)
+var_dump($first->equalTo($second));                // bool(false)
+var_dump($first->notEqualTo($second));             // bool(true)
+var_dump($first->greaterThan($second));            // bool(false)
+var_dump($first->greaterThanOrEqualTo($second));   // bool(false)
+var_dump($first->lessThan($second));               // bool(true)
+var_dump($first->lessThanOrEqualTo($second));      // bool(true)
 
 $first->setDateTime(2012, 1, 1, 0, 0, 0);
 $second->setDateTime(2012, 1, 1, 0, 0, 0);         // Remember tz is 'America/Vancouver'
 
-var_dump($first->eq($second));                     // bool(false)
-var_dump($first->ne($second));                     // bool(true)
-var_dump($first->gt($second));                     // bool(false)
-var_dump($first->gte($second));                    // bool(false)
-var_dump($first->lt($second));                     // bool(true)
-var_dump($first->lte($second));                    // bool(true)
+var_dump($first->equalTo($second));                // bool(false)
+var_dump($first->notEqualTo($second));             // bool(true)
+var_dump($first->greaterThan($second));            // bool(false)
+var_dump($first->greaterThanOrEqualTo($second));   // bool(false)
+var_dump($first->lessThan($second));               // bool(true)
+var_dump($first->lessThanOrEqualTo($second));      // bool(true)
 
-// All have verbose aliases and PHP equivalent code:
+// All have short hand aliases and PHP equivalent code:
 
 var_dump($first->eq($second));                     // bool(false)
 var_dump($first->equalTo($second));                // bool(false)
@@ -3009,8 +3009,8 @@ echo $dt1->maximum($dt2);                          // 2014-01-30 00:00:00
 
 // now is the default param
 $dt1 = Carbon::createMidnightDate(2000, 1, 1);
-echo $dt1->max();                                  // 2018-09-30 10:48:11
-echo $dt1->maximum();                              // 2018-09-30 10:48:11
+echo $dt1->max();                                  // 2018-10-04 18:22:48
+echo $dt1->maximum();                              // 2018-10-04 18:22:48
 
 // Remember min and max PHP native function work fine with dates too:
 echo max(Carbon::create('2002-03-15'), Carbon::create('2003-01-07'), Carbon::create('2002-08-25')); // 2003-01-07 00:00:00
@@ -3592,8 +3592,8 @@ Carbon::setWeekEndsAt(Carbon::WEDNESDAY); // and it does not need neither to pre
 
 var_dump(Carbon::getWeekStartsAt() === Carbon::FRIDAY);      // bool(true)
 var_dump(Carbon::getWeekEndsAt() === Carbon::WEDNESDAY);     // bool(true)
-echo $saturday->copy()->startOfWeek()->toRfc850String();     // Friday, 31-Aug-18 00:00:00 UTC
-echo $saturday->copy()->endOfWeek()->toRfc850String();       // Wednesday, 05-Sep-18 23:59:59 UTC
+echo $saturday->copy()->startOfWeek()->toRfc850String();     // Friday, 05-Oct-18 00:00:00 UTC
+echo $saturday->copy()->endOfWeek()->toRfc850String();       // Wednesday, 10-Oct-18 23:59:59 UTC
 
 // Be very careful with those global setters, remember, some other
 // code or third-party library in your app may expect initial weekend
@@ -3601,8 +3601,8 @@ echo $saturday->copy()->endOfWeek()->toRfc850String();       // Wednesday, 05-Se
 Carbon::setWeekStartsAt(Carbon::MONDAY);
 Carbon::setWeekEndsAt(Carbon::SUNDAY);
 
-echo $saturday->copy()->startOfWeek()->toRfc850String();     // Monday, 27-Aug-18 00:00:00 UTC
-echo $saturday->copy()->endOfWeek()->toRfc850String();       // Sunday, 02-Sep-18 23:59:59 UTC
+echo $saturday->copy()->startOfWeek()->toRfc850String();     // Monday, 01-Oct-18 00:00:00 UTC
+echo $saturday->copy()->endOfWeek()->toRfc850String();       // Sunday, 07-Oct-18 23:59:59 UTC
 </code></pre>
     </p>
 
@@ -4263,10 +4263,10 @@ function dumpDateList($dates) {
     echo substr(implode(', ', $dates), 0, 100).'...';
 }
 
-dumpDateList(Carbon::getCurrentWeekDays());                       // 2018-09-24 00:00:00, 2018-09-25 00:00:00, 2018-09-26 00:00:00, 2018-09-27 00:00:00, 2018-09-28 00:00...
-dumpDateList(Carbon::getCurrentMonthDays());                      // 2018-09-01 00:00:00, 2018-09-02 00:00:00, 2018-09-03 00:00:00, 2018-09-04 00:00:00, 2018-09-05 00:00...
-dumpDateList(Carbon::now()->subMonth()->getCurrentWeekDays());    // 2018-08-27 00:00:00, 2018-08-28 00:00:00, 2018-08-29 00:00:00, 2018-08-30 00:00:00, 2018-08-31 00:00...
-dumpDateList(Carbon::now()->subMonth()->getCurrentMonthDays());   // 2018-08-01 00:00:00, 2018-08-02 00:00:00, 2018-08-03 00:00:00, 2018-08-04 00:00:00, 2018-08-05 00:00...
+dumpDateList(Carbon::getCurrentWeekDays());                       // 2018-10-01 00:00:00, 2018-10-02 00:00:00, 2018-10-03 00:00:00, 2018-10-04 00:00:00, 2018-10-05 00:00...
+dumpDateList(Carbon::getCurrentMonthDays());                      // 2018-10-01 00:00:00, 2018-10-02 00:00:00, 2018-10-03 00:00:00, 2018-10-04 00:00:00, 2018-10-05 00:00...
+dumpDateList(Carbon::now()->subMonth()->getCurrentWeekDays());    // 2018-09-03 00:00:00, 2018-09-04 00:00:00, 2018-09-05 00:00:00, 2018-09-06 00:00:00, 2018-09-07 00:00...
+dumpDateList(Carbon::now()->subMonth()->getCurrentMonthDays());   // 2018-09-01 00:00:00, 2018-09-02 00:00:00, 2018-09-03 00:00:00, 2018-09-04 00:00:00, 2018-09-05 00:00...
 </code></pre>
     </p>
 
@@ -4823,7 +4823,7 @@ foreach ($period as $date) {
     $days[] = $date->format('Y-m-d');
 }
 
-echo implode(', ', $days);               // 2018-09-30, 2018-10-01, 2018-10-02
+echo implode(', ', $days);               // 2018-10-04, 2018-10-05, 2018-10-06
 </code></pre>
     </p>
 

--- a/docs/index.src.html
+++ b/docs/index.src.html
@@ -1367,24 +1367,24 @@ Carbon::resetToStringFormat();
 {{::exec(echo $second->toDateTimeString();/*pad(50)*/)}} // {{eval}}
 {{::exec(echo $second->tzName;/*pad(50)*/)}} // {{eval}}
 
-{{::exec(var_dump($first->eq($second));/*pad(50)*/)}} // {{eval}}
-{{::exec(var_dump($first->ne($second));/*pad(50)*/)}} // {{eval}}
-{{::exec(var_dump($first->gt($second));/*pad(50)*/)}} // {{eval}}
-{{::exec(var_dump($first->gte($second));/*pad(50)*/)}} // {{eval}}
-{{::exec(var_dump($first->lt($second));/*pad(50)*/)}} // {{eval}}
-{{::exec(var_dump($first->lte($second));/*pad(50)*/)}} // {{eval}}
+{{::exec(var_dump($first->equalTo($second));/*pad(50)*/)}} // {{eval}}
+{{::exec(var_dump($first->notEqualTo($second));/*pad(50)*/)}} // {{eval}}
+{{::exec(var_dump($first->greaterThan($second));/*pad(50)*/)}} // {{eval}}
+{{::exec(var_dump($first->greaterThanOrEqualTo($second));/*pad(50)*/)}} // {{eval}}
+{{::exec(var_dump($first->lessThan($second));/*pad(50)*/)}} // {{eval}}
+{{::exec(var_dump($first->lessThanOrEqualTo($second));/*pad(50)*/)}} // {{eval}}
 
 {{::lint($first->setDateTime(2012, 1, 1, 0, 0, 0);)}}
 {{::lint($second->setDateTime(2012, 1, 1, 0, 0, 0);/*pad(50)*/)}} // Remember tz is 'America/Vancouver'
 
-{{::exec(var_dump($first->eq($second));/*pad(50)*/)}} // {{eval}}
-{{::exec(var_dump($first->ne($second));/*pad(50)*/)}} // {{eval}}
-{{::exec(var_dump($first->gt($second));/*pad(50)*/)}} // {{eval}}
-{{::exec(var_dump($first->gte($second));/*pad(50)*/)}} // {{eval}}
-{{::exec(var_dump($first->lt($second));/*pad(50)*/)}} // {{eval}}
-{{::exec(var_dump($first->lte($second));/*pad(50)*/)}} // {{eval}}
+{{::exec(var_dump($first->equalTo($second));/*pad(50)*/)}} // {{eval}}
+{{::exec(var_dump($first->notEqualTo($second));/*pad(50)*/)}} // {{eval}}
+{{::exec(var_dump($first->greaterThan($second));/*pad(50)*/)}} // {{eval}}
+{{::exec(var_dump($first->greaterThanOrEqualTo($second));/*pad(50)*/)}} // {{eval}}
+{{::exec(var_dump($first->lessThan($second));/*pad(50)*/)}} // {{eval}}
+{{::exec(var_dump($first->lessThanOrEqualTo($second));/*pad(50)*/)}} // {{eval}}
 
-// All have verbose aliases and PHP equivalent code:
+// All have short hand aliases and PHP equivalent code:
 
 {{::exec(var_dump($first->eq($second));/*pad(50)*/)}} // {{eval}}
 {{::exec(var_dump($first->equalTo($second));/*pad(50)*/)}} // {{eval}}


### PR DESCRIPTION
In #1434 we changed the logic to be in the longer named functions. This is a change to the docs so we can start to point people to use the longer function names.

Not sure if this is the way to update the docs - so any feedback is appreciated :)

Thanks!