### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Carbon/LocalizationTest.php
+++ b/tests/Carbon/LocalizationTest.php
@@ -636,7 +636,7 @@ class LocalizationTest extends AbstractTestCase
         /** @var Translator $translator */
         $translator = Carbon::getTranslator();
         $translator->setMessages('zz_ZZ', []);
-        $this->assertTrue(in_array('zz_ZZ', Carbon::getAvailableLocales()));
+        $this->assertContains('zz_ZZ', Carbon::getAvailableLocales());
 
         Carbon::setTranslator(new \Symfony\Component\Translation\Translator('en'));
         $this->assertSame(['en'], Carbon::getAvailableLocales());

--- a/tests/CarbonPeriod/ToArrayTest.php
+++ b/tests/CarbonPeriod/ToArrayTest.php
@@ -70,7 +70,7 @@ class ToArrayTest extends AbstractTestCase
     {
         $period = CarbonPeriodFactory::withEvenDaysFilter();
 
-        $this->assertSame(3, count($period));
+        $this->assertCount(3, $period);
     }
 
     public function testFirst()


### PR DESCRIPTION
Looking at some tests I saw that they can be refactored for better understanding, either from the one who reads the tests or when a test fails and show a error message.

Some tests were refactoring using:

`assertArrayHasKey`, `assertArrayNotHasKey` instead of isset function;
`assertCount`