### PR TITLE
Run locale update only if services are registered

### DIFF
--- a/src/Carbon/Laravel/ServiceProvider.php
+++ b/src/Carbon/Laravel/ServiceProvider.php
@@ -12,6 +12,9 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
     public function boot()
     {
+        if (! $this->app->bound('events') || ! $this->app->bound('translator')) {
+            return;
+        }
         $service = $this;
         $events = $this->app['events'];
         if ($events instanceof EventDispatcher || $events instanceof Dispatcher) {

--- a/src/Carbon/Laravel/ServiceProvider.php
+++ b/src/Carbon/Laravel/ServiceProvider.php
@@ -12,7 +12,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
     public function boot()
     {
-        if (! $this->app->bound('events') || ! $this->app->bound('translator')) {
+        if (!$this->app->bound('events') || !$this->app->bound('translator')) {
             return;
         }
         $service = $this;

--- a/tests/Laravel/App.php
+++ b/tests/Laravel/App.php
@@ -20,7 +20,7 @@ class App implements ArrayAccess
      */
     public $events;
 
-    public function __construct()
+    public function register()
     {
         include_once __DIR__.'/EventDispatcher.php';
         $this->translator = new Translator('de');

--- a/tests/Laravel/App.php
+++ b/tests/Laravel/App.php
@@ -47,6 +47,11 @@ class App implements ArrayAccess
         $this->events->dispatch(static::getLocaleChangeEventName());
     }
 
+    public function bound($service)
+    {
+        return isset($this->{$service});
+    }
+
     public function offsetExists($offset)
     {
         return isset($this->$offset);

--- a/tests/Laravel/ServiceProviderTest.php
+++ b/tests/Laravel/ServiceProviderTest.php
@@ -17,6 +17,7 @@ class ServiceProviderTest extends TestCase
         $service->boot();
         $this->assertSame('en', Carbon::getLocale());
         $service->app->register();
+        $service->boot();
         $this->assertSame('de', Carbon::getLocale());
         $service->app->setLocale('fr');
         $this->assertSame('fr', Carbon::getLocale());

--- a/tests/Laravel/ServiceProviderTest.php
+++ b/tests/Laravel/ServiceProviderTest.php
@@ -15,6 +15,8 @@ class ServiceProviderTest extends TestCase
 
         $this->assertSame('en', Carbon::getLocale());
         $service->boot();
+        $this->assertSame('en', Carbon::getLocale());
+        $service->app->register();
         $this->assertSame('de', Carbon::getLocale());
         $service->app->setLocale('fr');
         $this->assertSame('fr', Carbon::getLocale());


### PR DESCRIPTION
Only run the locale update if the 'events' and 'translator' services are registered in the container.