### PR TITLE
Corrected translations

### DIFF
--- a/src/Carbon/Lang/da.php
+++ b/src/Carbon/Lang/da.php
@@ -25,7 +25,7 @@ return [
     'second' => 'få sekunder|:count sekunder',
     's' => ':count sekund|:count sekunder',
     'ago' => ':time siden',
-    'from_now' => 'om :time',
+    'from_now' => ':time siden',
     'after' => ':time efter',
     'before' => ':time før',
     'formats' => [


### PR DESCRIPTION
'from_now' => 'om :time',
to
'from_now' => ':time siden',