### PR TITLE
Fix character escaping in hasFormat()

### DIFF
--- a/src/Carbon/Traits/Comparison.php
+++ b/src/Carbon/Traits/Comparison.php
@@ -579,7 +579,7 @@ trait Comparison
                 // Backslash – the next character does not represent a date token so add it on as-is and continue.
                 // We're doing an extra ++$i here to increment the loop by 2.
                 if ($quotedFormat[$i] === '\\') {
-                    $regex .= '\\' . $quotedFormat[++$i];
+                    $regex .= '\\'.$quotedFormat[++$i];
                     continue;
                 }
 

--- a/src/Carbon/Traits/Comparison.php
+++ b/src/Carbon/Traits/Comparison.php
@@ -568,10 +568,23 @@ trait Comparison
             // createFromFormat() is known to handle edge cases silently.
             // E.g. "1975-5-1" (Y-n-j) will still be parsed correctly when "Y-m-d" is supplied as the format.
             // To ensure we're really testing against our desired format, perform an additional regex validation.
-            $regex = strtr(
-                preg_quote($format, '/'),
-                static::$regexFormats
-            );
+
+            // Preg quote, but remove escaped backslashes since we'll deal with escaped characters in the format string.
+            $quotedFormat = str_replace('\\\\', '\\',
+                preg_quote($format, '/'));
+
+            // Build the regex string
+            $regex = '';
+            for ($i = 0; $i < strlen($quotedFormat); ++$i) {
+                // Backslash – the next character does not represent a date token so add it on as-is and continue.
+                // We're doing an extra ++$i here to increment the loop by 2.
+                if ($quotedFormat[$i] === '\\') {
+                    $regex .= '\\' . $quotedFormat[++$i];
+                    continue;
+                }
+
+                $regex .= strtr($quotedFormat[$i], static::$regexFormats);
+            }
 
             return (bool) preg_match('/^'.$regex.'$/', $date);
         } catch (InvalidArgumentException $e) {

--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -844,6 +844,9 @@ class IsTest extends AbstractTestCase
         $this->assertTrue(Carbon::hasFormat('1975-05-01', 'Y-m-d'));
         $this->assertTrue(Carbon::hasFormat('Sun 21st', 'D jS'));
 
+        $this->assertTrue(Carbon::hasFormat('2000-07-01T00:00:00+00:00', Carbon::ATOM));
+        $this->assertTrue(Carbon::hasFormat('Y-01-30\\', '\\Y-m-d\\\\'));
+
         // Format failure
         $this->assertFalse(Carbon::hasFormat('1975-05-01', 'd m Y'));
         $this->assertFalse(Carbon::hasFormat('Foo 21st', 'D jS'));


### PR DESCRIPTION
Fixes the regex validation of the format string, which previously didn't correctly deal with escaped characters.