### PR TITLE
Instance copy settings

### DIFF
--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -105,7 +105,13 @@ trait Creator
 
         static::expectDateTime($date);
 
-        return new static($date->format('Y-m-d H:i:s.u'), $date->getTimezone());
+        $instance = new static($date->format('Y-m-d H:i:s.u'), $date->getTimezone());
+
+        if ($date instanceof CarbonInterface || $date instanceof Options) {
+            $instance->settings($date->getSettings());
+        }
+
+        return $instance;
     }
 
     /**

--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -1422,7 +1422,7 @@ trait Date
         $offset = $this->offset;
         $date = $this->setTimezone($value);
 
-        return $date->addRealSeconds($offset - $date->offset);
+        return $date->addRealMicroseconds(($offset - $date->offset) * static::MICROSECONDS_PER_SECOND);
     }
 
     /**

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -217,6 +217,33 @@ abstract class AbstractTestCase extends TestCase
         $this->wrapWithTestNow($func, Carbon::now()->startOfYear());
     }
 
+    public function wrapWithUtf8LcTimeLocale($locale, Closure $func)
+    {
+        $currentLocale = setlocale(LC_TIME, '0');
+        $locales = ["$locale.UTF-8"];
+        $mapping = [
+            'fr_FR' => 'French_France',
+        ];
+        $windowsLocale = $mapping[$locale] ?? null;
+        if ($windowsLocale) {
+            $locales[] = "$windowsLocale.UTF8";
+        }
+        if (setlocale(LC_TIME, ...$locales) === false) {
+            $this->markTestSkipped("UTF-8 test need $locale.UTF-8 (a locale with accents).");
+        }
+        $exception = null;
+        try {
+            $func();
+        } catch (\Throwable $e) {
+            $exception = $e;
+        }
+        setlocale(LC_TIME, $currentLocale);
+
+        if ($exception) {
+            throw $exception;
+        }
+    }
+
     /**
      * Standardize given set of dates (or period) before assertion.
      *

--- a/tests/Carbon/InstanceTest.php
+++ b/tests/Carbon/InstanceTest.php
@@ -62,6 +62,13 @@ class InstanceTest extends AbstractTestCase
         $this->assertSame($micro, $carbon->micro);
     }
 
+    public function testTimezoneCopy()
+    {
+        $carbon = new Carbon('2017-06-27 13:14:15.123456', 'Europe/Paris');
+        $carbon = CarbonImmutable::instance($carbon);
+        $this->assertSame('2017-06-27 13:14:15.123456 Europe/Paris', $carbon->format('Y-m-d H:i:s.u e'));
+    }
+
     public function testInstanceStateSetBySetStateMethod()
     {
         $carbon = Carbon::__set_state([

--- a/tests/Carbon/InstanceTest.php
+++ b/tests/Carbon/InstanceTest.php
@@ -92,10 +92,12 @@ class InstanceTest extends AbstractTestCase
     public function testMutableConversions()
     {
         $carbon = new Carbon('2017-06-27 13:14:15.123456', 'Europe/Paris');
+        $carbon = $carbon->locale('en_CA');
         $copy = $carbon->toImmutable();
 
         self::assertEquals($copy, $carbon);
         self::assertNotSame($copy, $carbon);
+        self::assertSame('en_CA', $copy->locale());
         self::assertInstanceOf(CarbonImmutable::class, $copy);
         self::assertTrue($copy->isImmutable());
         self::assertFalse($copy->isMutable());
@@ -107,6 +109,7 @@ class InstanceTest extends AbstractTestCase
 
         self::assertEquals($copy, $carbon);
         self::assertNotSame($copy, $carbon);
+        self::assertSame('en_CA', $copy->locale());
         self::assertInstanceOf(Carbon::class, $copy);
         self::assertFalse($copy->isImmutable());
         self::assertTrue($copy->isMutable());

--- a/tests/Carbon/SettersTest.php
+++ b/tests/Carbon/SettersTest.php
@@ -298,11 +298,11 @@ class SettersTest extends AbstractTestCase
         $this->assertSame(0, $d2->getTimestamp() - $d->getTimestamp());
         $this->assertSame('04:53:12', $d2->format('H:i:s'));
 
-        $d = Carbon::parse('2018-08-13 10:53:12', 'Europe/Paris');
+        $d = Carbon::parse('2018-08-13 10:53:12.321654', 'Europe/Paris');
         $d2 = $d->copy()->shiftTimezone('America/Toronto');
         $this->assertSame(21600, $d2->getTimestamp() - $d->getTimestamp());
         $this->assertSame('America/Toronto', $d2->tzName);
-        $this->assertSame('10:53:12', $d2->format('H:i:s'));
+        $this->assertSame('10:53:12.321654', $d2->format('H:i:s.u'));
     }
 
     public function testTimezoneUsingString()

--- a/tests/Carbon/StringsTest.php
+++ b/tests/Carbon/StringsTest.php
@@ -110,33 +110,27 @@ class StringsTest extends AbstractTestCase
 
     public function testToLocalizedFormattedDateString()
     {
-        $currentLocale = setlocale(LC_TIME, '0');
-        if (setlocale(LC_TIME, 'fr_FR.UTF-8') === false) {
-            $this->markTestSkipped('UTF-8 test need fr_FR.UTF-8 (a locale with accents).');
-        }
-        $d = Carbon::create(1975, 12, 25, 14, 15, 16);
-        $date = $d->formatLocalized('%A %d %B %Y');
-        setlocale(LC_TIME, $currentLocale);
+        $this->wrapWithUtf8LcTimeLocale('fr_FR', function () {
+            $d = Carbon::create(1975, 12, 25, 14, 15, 16);
+            $date = $d->formatLocalized('%A %d %B %Y');
 
-        $this->assertSame('jeudi 25 décembre 1975', $date);
+            $this->assertSame('jeudi 25 décembre 1975', $date);
+        });
     }
 
     public function testToLocalizedFormattedDateStringWhenUtf8IsNedded()
     {
-        $currentLocale = setlocale(LC_TIME, '0');
-        if (setlocale(LC_TIME, 'fr_FR.UTF-8') === false) {
-            $this->markTestSkipped('UTF-8 test need fr_FR.UTF-8 (a locale with accents).');
-        }
-        $d = Carbon::create(1975, 12, 25, 14, 15, 16, 'Europe/Paris');
-        Carbon::setUtf8(false);
-        $nonUtf8Date = $d->formatLocalized('%B');
-        Carbon::setUtf8(true);
-        $utf8Date = $d->formatLocalized('%B');
-        Carbon::setUtf8(false);
-        setlocale(LC_TIME, $currentLocale);
+        $this->wrapWithUtf8LcTimeLocale('fr_FR', function () {
+            $d = Carbon::create(1975, 12, 25, 14, 15, 16, 'Europe/Paris');
+            Carbon::setUtf8(false);
+            $nonUtf8Date = $d->formatLocalized('%B');
+            Carbon::setUtf8(true);
+            $utf8Date = $d->formatLocalized('%B');
+            Carbon::setUtf8(false);
 
-        $this->assertSame('décembre', $nonUtf8Date);
-        $this->assertSame(utf8_encode('décembre'), $utf8Date);
+            $this->assertSame('décembre', $nonUtf8Date);
+            $this->assertSame(utf8_encode('décembre'), $utf8Date);
+        });
     }
 
     public function testToLocalizedFormattedTimezonedDateString()

--- a/tests/CarbonImmutable/InstanceTest.php
+++ b/tests/CarbonImmutable/InstanceTest.php
@@ -93,10 +93,12 @@ class InstanceTest extends AbstractTestCase
     public function testMutableConversions()
     {
         $carbon = new Carbon('2017-06-27 13:14:15.123456', 'Europe/Paris');
+        $carbon = $carbon->locale('en_CA');
         $copy = $carbon->toImmutable();
 
         self::assertEquals($copy, $carbon);
         self::assertNotSame($copy, $carbon);
+        self::assertSame('en_CA', $copy->locale());
         self::assertInstanceOf(CarbonImmutable::class, $copy);
         self::assertTrue($copy->isImmutable());
         self::assertFalse($copy->isMutable());
@@ -108,6 +110,7 @@ class InstanceTest extends AbstractTestCase
 
         self::assertEquals($copy, $carbon);
         self::assertNotSame($copy, $carbon);
+        self::assertSame('en_CA', $copy->locale());
         self::assertInstanceOf(CarbonMutable::class, $copy);
         self::assertFalse($copy->isImmutable());
         self::assertTrue($copy->isMutable());

--- a/tests/CarbonImmutable/InstanceTest.php
+++ b/tests/CarbonImmutable/InstanceTest.php
@@ -63,6 +63,13 @@ class InstanceTest extends AbstractTestCase
         $this->assertSame($micro, $carbon->micro);
     }
 
+    public function testTimezoneCopy()
+    {
+        $carbon = new Carbon('2017-06-27 13:14:15.123456', 'Europe/Paris');
+        $carbon = CarbonMutable::instance($carbon);
+        $this->assertSame('2017-06-27 13:14:15.123456 Europe/Paris', $carbon->format('Y-m-d H:i:s.u e'));
+    }
+
     public function testInstanceStateSetBySetStateMethod()
     {
         $carbon = Carbon::__set_state([

--- a/tests/CarbonImmutable/StringsTest.php
+++ b/tests/CarbonImmutable/StringsTest.php
@@ -90,33 +90,27 @@ class StringsTest extends AbstractTestCase
 
     public function testToLocalizedFormattedDateString()
     {
-        $currentLocale = setlocale(LC_TIME, '0');
-        if (setlocale(LC_TIME, 'fr_FR.UTF-8') === false) {
-            $this->markTestSkipped('UTF-8 test need fr_FR.UTF-8 (a locale with accents).');
-        }
-        $d = Carbon::create(1975, 12, 25, 14, 15, 16);
-        $date = $d->formatLocalized('%A %d %B %Y');
-        setlocale(LC_TIME, $currentLocale);
+        $this->wrapWithUtf8LcTimeLocale('fr_FR', function () {
+            $d = Carbon::create(1975, 12, 25, 14, 15, 16);
+            $date = $d->formatLocalized('%A %d %B %Y');
 
-        $this->assertSame('jeudi 25 décembre 1975', $date);
+            $this->assertSame('jeudi 25 décembre 1975', $date);
+        });
     }
 
     public function testToLocalizedFormattedDateStringWhenUtf8IsNedded()
     {
-        $currentLocale = setlocale(LC_TIME, '0');
-        if (setlocale(LC_TIME, 'fr_FR.UTF-8') === false) {
-            $this->markTestSkipped('UTF-8 test need fr_FR.UTF-8 (a locale with accents).');
-        }
-        $d = Carbon::create(1975, 12, 25, 14, 15, 16, 'Europe/Paris');
-        Carbon::setUtf8(false);
-        $nonUtf8Date = $d->formatLocalized('%B');
-        Carbon::setUtf8(true);
-        $utf8Date = $d->formatLocalized('%B');
-        Carbon::setUtf8(false);
-        setlocale(LC_TIME, $currentLocale);
+        $this->wrapWithUtf8LcTimeLocale('fr_FR', function () {
+            $d = Carbon::create(1975, 12, 25, 14, 15, 16, 'Europe/Paris');
+            Carbon::setUtf8(false);
+            $nonUtf8Date = $d->formatLocalized('%B');
+            Carbon::setUtf8(true);
+            $utf8Date = $d->formatLocalized('%B');
+            Carbon::setUtf8(false);
 
-        $this->assertSame('décembre', $nonUtf8Date);
-        $this->assertSame(utf8_encode('décembre'), $utf8Date);
+            $this->assertSame('décembre', $nonUtf8Date);
+            $this->assertSame(utf8_encode('décembre'), $utf8Date);
+        });
     }
 
     public function testToLocalizedFormattedTimezonedDateString()


### PR DESCRIPTION
- Keep settings through instance method
- Fix microseconds lost on shiftTimezone()
- Add instance() test with timezone
- Allow UTF-8 tests to run on Windows