### PR TITLE
Allow numeric (hour/minute offset) timezone as names

### DIFF
--- a/src/Carbon/CarbonTimeZone.php
+++ b/src/Carbon/CarbonTimeZone.php
@@ -36,11 +36,12 @@ class CarbonTimeZone extends DateTimeZone
     /**
      * Create a CarbonTimeZone from mixed input.
      *
-     * @param DateTimeZone|string|int|null $object
+     * @param DateTimeZone|string|int|null $object     original value to get CarbonTimeZone from it.
+     * @param DateTimeZone|string|int|null $objectDump dump of the object for error messages.
      *
      * @return false|static
      */
-    public static function instance($object = null)
+    public static function instance($object = null, $objectDump = null)
     {
         $tz = $object;
 
@@ -58,7 +59,7 @@ class CarbonTimeZone extends DateTimeZone
 
         if ($tz === false) {
             if (Carbon::isStrictModeEnabled()) {
-                throw new InvalidArgumentException('Unknown or bad timezone ('.$object.')');
+                throw new InvalidArgumentException('Unknown or bad timezone ('.($objectDump ?: $object).')');
             }
 
             return false;

--- a/src/Carbon/CarbonTimeZone.php
+++ b/src/Carbon/CarbonTimeZone.php
@@ -103,6 +103,13 @@ class CarbonTimeZone extends DateTimeZone
         return $this->getAbbreviatedName($dst);
     }
 
+    /**
+     * Get the offset as string "sHH:MM" (such as "+00:00" or "-12:30").
+     *
+     * @param DateTimeInterface|null $date
+     *
+     * @return string
+     */
     public function toOffsetName(DateTimeInterface $date = null)
     {
         $minutes = floor($this->getOffset($date ?: Carbon::now($this)) / 60);
@@ -114,12 +121,29 @@ class CarbonTimeZone extends DateTimeZone
         return ($hours < 0 ? '-' : '+').str_pad(abs($hours), 2, '0', STR_PAD_LEFT).":$minutes";
     }
 
+    /**
+     * Returns a new CarbonTimeZone object using the offset string instead of region string.
+     *
+     * @param DateTimeInterface|null $date
+     *
+     * @return CarbonTimeZone
+     */
     public function toOffsetTimeZone(DateTimeInterface $date = null)
     {
         return new static($this->toOffsetName($date));
     }
 
-    public function toRegionName(DateTimeInterface $date = null)
+    /**
+     * Returns the first region string (such as "America/Toronto") that matches the current timezone.
+     *
+     * @see timezone_name_from_abbr native PHP function.
+     *
+     * @param DateTimeInterface|null $date
+     * @param int                    $isDst
+     *
+     * @return string
+     */
+    public function toRegionName(DateTimeInterface $date = null, $isDst = 1)
     {
         $name = $this->getName();
         $firstChar = substr($name, 0, 1);
@@ -128,9 +152,16 @@ class CarbonTimeZone extends DateTimeZone
             return $name;
         }
 
-        return @timezone_name_from_abbr(null, $this->getOffset($date ?: Carbon::now($this)), true);
+        return @timezone_name_from_abbr(null, $this->getOffset($date ?: Carbon::now($this)), $isDst);
     }
 
+    /**
+     * Returns a new CarbonTimeZone object using the region string instead of offset string.
+     *
+     * @param DateTimeInterface|null $date
+     *
+     * @return CarbonTimeZone|false
+     */
     public function toRegionTimeZone(DateTimeInterface $date = null)
     {
         $tz = $this->toRegionName($date);

--- a/src/Carbon/CarbonTimeZone.php
+++ b/src/Carbon/CarbonTimeZone.php
@@ -9,28 +9,27 @@ class CarbonTimeZone extends DateTimeZone
 {
     public function __construct($timezone = null)
     {
+        parent::__construct(static::getDateTimeZoneNameFromMixed($timezone));
+    }
+
+    protected static function getDateTimeZoneNameFromMixed($timezone)
+    {
         if (is_null($timezone)) {
             $timezone = date_default_timezone_get();
-        } elseif (is_int($timezone)) {
-            $timezone = timezone_name_from_abbr(null, floatval($timezone) * 3600, true);
+        } elseif (is_numeric($timezone)) {
+            if ($timezone <= -100 || $timezone >= 100) {
+                throw new InvalidArgumentException('Absolute timezone offset cannot be greater than 100.');
+            }
+
+            $timezone = ($timezone >= 0 ? '+' : '').$timezone.':00';
         }
 
-        parent::__construct($timezone);
+        return $timezone;
     }
 
     protected static function getDateTimeZoneFromName(&$name)
     {
-        if (is_numeric($name)) {
-            $tzName = timezone_name_from_abbr(null, floatval($name) * 3600, true);
-
-            if ($tzName === false) {
-                return false;
-            }
-
-            $name = $tzName;
-        }
-
-        return @timezone_open($name = (string) $name);
+        return @timezone_open($name = (string) static::getDateTimeZoneNameFromMixed($name));
     }
 
     /**

--- a/src/Carbon/Traits/Comparison.php
+++ b/src/Carbon/Traits/Comparison.php
@@ -380,7 +380,7 @@ trait Comparison
             // @call isSameUnit
             'year' => 'Y',
             // @call isSameUnit
-            'week' => 'Y-W',
+            'week' => 'o-W',
             // @call isSameUnit
             'day' => 'Y-m-d',
             // @call isSameUnit

--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -415,17 +415,17 @@ trait Creator
         return static::today($tz)->setTimeFromTimeString($time);
     }
 
-    private static function createFromFormatAndTimezone($format, $time, $tz)
+    private static function createFromFormatAndTimezone($format, $time, $originalTz)
     {
-        if ($tz === null) {
+        if ($originalTz === null) {
             return parent::createFromFormat($format, $time);
         }
 
-        if (is_int($tz)) {
-            $tz = @timezone_name_from_abbr(null, floatval($tz * 3600), 1);
-        }
+        $tz = is_int($originalTz)
+            ? @timezone_name_from_abbr(null, floatval($originalTz * 3600), 1)
+            : $originalTz;
 
-        $tz = static::safeCreateDateTimeZone($tz);
+        $tz = static::safeCreateDateTimeZone($tz, $originalTz);
 
         if ($tz === false) {
             return false;

--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -14,6 +14,7 @@ namespace Carbon\Traits;
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
+use Carbon\CarbonTimeZone;
 use Carbon\Exceptions\InvalidDateException;
 use DateTimeInterface;
 use InvalidArgumentException;
@@ -76,6 +77,7 @@ trait Creator
             $time = $testInstance->format(static::MOCK_DATETIME_FORMAT);
         }
 
+        /** @var CarbonTimeZone $timezone */
         $timezone = static::safeCreateDateTimeZone($tz);
 
         // Work-around for PHP bug https://bugs.php.net/bug.php?id=67127

--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -52,6 +52,8 @@ trait Creator
             $time = "@$time";
         }
 
+        $originalTz = $tz;
+
         // If the class has a test now set and we are trying to create a now()
         // instance then override as required
         $isNow = empty($time) || $time === 'now';
@@ -78,7 +80,7 @@ trait Creator
         }
 
         /** @var CarbonTimeZone $timezone */
-        $timezone = static::safeCreateDateTimeZone($tz);
+        $timezone = $this->autoDetectTimeZone($tz, $originalTz);
 
         // Work-around for PHP bug https://bugs.php.net/bug.php?id=67127
         if (strpos((string) .1, '.') === false) {
@@ -244,7 +246,7 @@ trait Creator
     public static function create($year = 0, $month = 1, $day = 1, $hour = 0, $minute = 0, $second = 0, $tz = null)
     {
         if (is_string($year) && !is_numeric($year)) {
-            return static::parse($year);
+            return static::parse($year, $tz);
         }
 
         $defaults = null;
@@ -417,6 +419,10 @@ trait Creator
     {
         if ($tz === null) {
             return parent::createFromFormat($format, $time);
+        }
+
+        if (is_int($tz)) {
+            $tz = @timezone_name_from_abbr(null, floatval($tz * 3600), 1);
         }
 
         $tz = static::safeCreateDateTimeZone($tz);

--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -604,6 +604,28 @@ trait Date
     }
 
     /**
+     * Creates a DateTimeZone from a string, DateTimeZone or integer offset then convert it as region timezone
+     * if integer.
+     *
+     * @param \DateTimeZone|string|int|null $object
+     * @param \DateTimeZone|string|int|null $originalObject if different
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return CarbonTimeZone|false
+     */
+    protected function autoDetectTimeZone($object, $originalObject = null)
+    {
+        /** @var CarbonTimeZone $timezone */
+        $timezone = CarbonTimeZone::instance($object);
+        if ($timezone && is_int($originalObject ?: $object)) {
+            $timezone = $timezone->toRegionTimeZone($this);
+        }
+
+        return $timezone;
+    }
+
+    /**
      * Get the TimeZone associated with the Carbon instance (as CarbonTimeZone).
      *
      * @return CarbonTimeZone

--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -592,15 +592,16 @@ trait Date
     /**
      * Creates a DateTimeZone from a string, DateTimeZone or integer offset.
      *
-     * @param \DateTimeZone|string|int|null $object
+     * @param \DateTimeZone|string|int|null $object     original value to get CarbonTimeZone from it.
+     * @param \DateTimeZone|string|int|null $objectDump dump of the object for error messages.
      *
      * @throws \InvalidArgumentException
      *
      * @return CarbonTimeZone|false
      */
-    protected static function safeCreateDateTimeZone($object)
+    protected static function safeCreateDateTimeZone($object, $objectDump = null)
     {
-        return CarbonTimeZone::instance($object);
+        return CarbonTimeZone::instance($object, $objectDump);
     }
 
     /**

--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -596,7 +596,7 @@ trait Date
      *
      * @throws \InvalidArgumentException
      *
-     * @return \DateTimeZone|false
+     * @return CarbonTimeZone|false
      */
     protected static function safeCreateDateTimeZone($object)
     {

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -212,9 +212,13 @@ abstract class AbstractTestCase extends TestCase
     public function wrapWithTestNow(Closure $func, CarbonInterface $dt = null)
     {
         $test = Carbon::getTestNow();
-        Carbon::setTestNow($dt ?: Carbon::now());
+        $immutableTest = CarbonImmutable::getTestNow();
+        $dt = $dt ?: Carbon::now();
+        Carbon::setTestNow($dt);
+        CarbonImmutable::setTestNow($dt);
         $func();
         Carbon::setTestNow($test);
+        CarbonImmutable::setTestNow($immutableTest);
     }
 
     public function wrapWithNonDstDate(Closure $func)

--- a/tests/Carbon/CreateTest.php
+++ b/tests/Carbon/CreateTest.php
@@ -204,6 +204,9 @@ class CreateTest extends AbstractTestCase
     public function testCreateWithValidTimezoneOffset()
     {
         $dt = Carbon::createFromDate(2000, 1, 1, -4);
+        $this->assertSame('America/New_York', $dt->tzName);
+
+        $dt = Carbon::createFromDate(2000, 1, 1, '-4');
         $this->assertSame('-04:00', $dt->tzName);
     }
 }

--- a/tests/Carbon/CreateTest.php
+++ b/tests/Carbon/CreateTest.php
@@ -204,6 +204,6 @@ class CreateTest extends AbstractTestCase
     public function testCreateWithValidTimezoneOffset()
     {
         $dt = Carbon::createFromDate(2000, 1, 1, -4);
-        $this->assertSame('America/New_York', $dt->tzName);
+        $this->assertSame('-04:00', $dt->tzName);
     }
 }

--- a/tests/Carbon/GettersTest.php
+++ b/tests/Carbon/GettersTest.php
@@ -454,7 +454,7 @@ class GettersTest extends AbstractTestCase
         $this->assertSame('America/Toronto', $dt->timezone->getName());
 
         $dt = Carbon::createFromDate(2000, 1, 1, -5);
-        $this->assertSame('America/Chicago', $dt->timezone->getName());
+        $this->assertSame('-05:00', $dt->timezone->getName());
     }
 
     public function testGetTz()
@@ -463,7 +463,7 @@ class GettersTest extends AbstractTestCase
         $this->assertSame('America/Toronto', $dt->tz->getName());
 
         $dt = Carbon::createFromDate(2000, 1, 1, -5);
-        $this->assertSame('America/Chicago', $dt->tz->getName());
+        $this->assertSame('-05:00', $dt->tz->getName());
     }
 
     public function testGetTimezoneName()
@@ -472,7 +472,7 @@ class GettersTest extends AbstractTestCase
         $this->assertSame('America/Toronto', $dt->timezoneName);
 
         $dt = Carbon::createFromDate(2000, 1, 1, -5);
-        $this->assertSame('America/Chicago', $dt->timezoneName);
+        $this->assertSame('-05:00', $dt->timezoneName);
     }
 
     public function testGetTzName()
@@ -481,7 +481,7 @@ class GettersTest extends AbstractTestCase
         $this->assertSame('America/Toronto', $dt->tzName);
 
         $dt = Carbon::createFromDate(2000, 1, 1, -5);
-        $this->assertSame('America/Chicago', $dt->timezoneName);
+        $this->assertSame('-05:00', $dt->timezoneName);
     }
 
     public function testShortDayName()

--- a/tests/Carbon/GettersTest.php
+++ b/tests/Carbon/GettersTest.php
@@ -454,6 +454,9 @@ class GettersTest extends AbstractTestCase
         $this->assertSame('America/Toronto', $dt->timezone->getName());
 
         $dt = Carbon::createFromDate(2000, 1, 1, -5);
+        $this->assertSame('America/Chicago', $dt->timezone->getName());
+
+        $dt = Carbon::createFromDate(2000, 1, 1, '-5');
         $this->assertSame('-05:00', $dt->timezone->getName());
     }
 
@@ -463,6 +466,9 @@ class GettersTest extends AbstractTestCase
         $this->assertSame('America/Toronto', $dt->tz->getName());
 
         $dt = Carbon::createFromDate(2000, 1, 1, -5);
+        $this->assertSame('America/Chicago', $dt->tz->getName());
+
+        $dt = Carbon::createFromDate(2000, 1, 1, '-5');
         $this->assertSame('-05:00', $dt->tz->getName());
     }
 
@@ -472,6 +478,9 @@ class GettersTest extends AbstractTestCase
         $this->assertSame('America/Toronto', $dt->timezoneName);
 
         $dt = Carbon::createFromDate(2000, 1, 1, -5);
+        $this->assertSame('America/Chicago', $dt->timezoneName);
+
+        $dt = Carbon::createFromDate(2000, 1, 1, '-5');
         $this->assertSame('-05:00', $dt->timezoneName);
     }
 
@@ -481,6 +490,9 @@ class GettersTest extends AbstractTestCase
         $this->assertSame('America/Toronto', $dt->tzName);
 
         $dt = Carbon::createFromDate(2000, 1, 1, -5);
+        $this->assertSame('America/Chicago', $dt->timezoneName);
+
+        $dt = Carbon::createFromDate(2000, 1, 1, '-5');
         $this->assertSame('-05:00', $dt->timezoneName);
     }
 

--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -73,6 +73,7 @@ class IsTest extends AbstractTestCase
         $this->assertTrue(Carbon::now()->isSameWeek(Carbon::now()));
         $this->assertTrue(Carbon::now()->startOfWeek()->isSameWeek(Carbon::now()));
         $this->assertTrue(Carbon::now()->endOfWeek()->isSameWeek(Carbon::now()));
+        $this->assertTrue(Carbon::parse('2019-01-01')->isSameWeek(Carbon::parse('2018-12-31')));
     }
 
     public function testIsNextWeekTrue()

--- a/tests/Carbon/StrictModeTest.php
+++ b/tests/Carbon/StrictModeTest.php
@@ -30,15 +30,6 @@ class StrictModeTest extends AbstractTestCase
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Unknown or bad timezone (-15)
-     */
-    public function testSafeCreateDateTimeZoneWithStrictMode1()
-    {
-        Carbon::createFromDate(2001, 1, 1, -15);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Unknown or bad timezone (foobar)
      */
     public function testSafeCreateDateTimeZoneWithStrictMode2()
@@ -49,7 +40,6 @@ class StrictModeTest extends AbstractTestCase
     public function testSafeCreateDateTimeZoneWithoutStrictMode()
     {
         Carbon::useStrictMode(false);
-        $this->assertFalse(Carbon::createFromDate(2001, 1, 1, -15));
         $this->assertFalse(Carbon::createFromDate(2001, 1, 1, 'foobar'));
     }
 

--- a/tests/Carbon/StrictModeTest.php
+++ b/tests/Carbon/StrictModeTest.php
@@ -30,6 +30,15 @@ class StrictModeTest extends AbstractTestCase
 
     /**
      * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Unknown or bad timezone (-15)
+     */
+    public function testSafeCreateDateTimeZoneWithStrictMode1()
+    {
+        Carbon::createFromDate(2001, 1, 1, -15);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Unknown or bad timezone (foobar)
      */
     public function testSafeCreateDateTimeZoneWithStrictMode2()
@@ -40,6 +49,7 @@ class StrictModeTest extends AbstractTestCase
     public function testSafeCreateDateTimeZoneWithoutStrictMode()
     {
         Carbon::useStrictMode(false);
+        $this->assertFalse(Carbon::createFromDate(2001, 1, 1, -15));
         $this->assertFalse(Carbon::createFromDate(2001, 1, 1, 'foobar'));
     }
 

--- a/tests/CarbonImmutable/CreateTest.php
+++ b/tests/CarbonImmutable/CreateTest.php
@@ -194,6 +194,9 @@ class CreateTest extends AbstractTestCase
     public function testCreateWithValidTimezoneOffset()
     {
         $dt = Carbon::createFromDate(2000, 1, 1, -4);
+        $this->assertSame('America/New_York', $dt->tzName);
+
+        $dt = Carbon::createFromDate(2000, 1, 1, '-4');
         $this->assertSame('-04:00', $dt->tzName);
     }
 }

--- a/tests/CarbonImmutable/CreateTest.php
+++ b/tests/CarbonImmutable/CreateTest.php
@@ -194,6 +194,6 @@ class CreateTest extends AbstractTestCase
     public function testCreateWithValidTimezoneOffset()
     {
         $dt = Carbon::createFromDate(2000, 1, 1, -4);
-        $this->assertSame('America/New_York', $dt->tzName);
+        $this->assertSame('-04:00', $dt->tzName);
     }
 }

--- a/tests/CarbonImmutable/DiffTest.php
+++ b/tests/CarbonImmutable/DiffTest.php
@@ -21,7 +21,7 @@ class DiffTest extends AbstractTestCase
 {
     public function wrapWithTestNow(Closure $func, CarbonInterface $dt = null)
     {
-        parent::wrapWithTestNow($func, $dt ?: Carbon::createFromDate(2012, 1, 1));
+        parent::wrapWithTestNow($func, $dt ?: Carbon::createMidnightDate(2012, 1, 1));
     }
 
     public function testDiffAsCarbonInterval()

--- a/tests/CarbonImmutable/GettersTest.php
+++ b/tests/CarbonImmutable/GettersTest.php
@@ -356,7 +356,7 @@ class GettersTest extends AbstractTestCase
         $this->assertSame('America/Toronto', $dt->timezone->getName());
 
         $dt = Carbon::createFromDate(2000, 1, 1, -5);
-        $this->assertSame('America/Chicago', $dt->timezone->getName());
+        $this->assertSame('-05:00', $dt->timezone->getName());
     }
 
     public function testGetTz()
@@ -365,7 +365,7 @@ class GettersTest extends AbstractTestCase
         $this->assertSame('America/Toronto', $dt->tz->getName());
 
         $dt = Carbon::createFromDate(2000, 1, 1, -5);
-        $this->assertSame('America/Chicago', $dt->tz->getName());
+        $this->assertSame('-05:00', $dt->tz->getName());
     }
 
     public function testGetTimezoneName()
@@ -374,7 +374,7 @@ class GettersTest extends AbstractTestCase
         $this->assertSame('America/Toronto', $dt->timezoneName);
 
         $dt = Carbon::createFromDate(2000, 1, 1, -5);
-        $this->assertSame('America/Chicago', $dt->timezoneName);
+        $this->assertSame('-05:00', $dt->timezoneName);
     }
 
     public function testGetTzName()
@@ -383,7 +383,7 @@ class GettersTest extends AbstractTestCase
         $this->assertSame('America/Toronto', $dt->tzName);
 
         $dt = Carbon::createFromDate(2000, 1, 1, -5);
-        $this->assertSame('America/Chicago', $dt->timezoneName);
+        $this->assertSame('-05:00', $dt->timezoneName);
     }
 
     public function testShortDayName()

--- a/tests/CarbonImmutable/GettersTest.php
+++ b/tests/CarbonImmutable/GettersTest.php
@@ -356,6 +356,9 @@ class GettersTest extends AbstractTestCase
         $this->assertSame('America/Toronto', $dt->timezone->getName());
 
         $dt = Carbon::createFromDate(2000, 1, 1, -5);
+        $this->assertSame('America/Chicago', $dt->timezone->getName());
+
+        $dt = Carbon::createFromDate(2000, 1, 1, '-5');
         $this->assertSame('-05:00', $dt->timezone->getName());
     }
 
@@ -365,6 +368,9 @@ class GettersTest extends AbstractTestCase
         $this->assertSame('America/Toronto', $dt->tz->getName());
 
         $dt = Carbon::createFromDate(2000, 1, 1, -5);
+        $this->assertSame('America/Chicago', $dt->tz->getName());
+
+        $dt = Carbon::createFromDate(2000, 1, 1, '-5');
         $this->assertSame('-05:00', $dt->tz->getName());
     }
 
@@ -374,6 +380,9 @@ class GettersTest extends AbstractTestCase
         $this->assertSame('America/Toronto', $dt->timezoneName);
 
         $dt = Carbon::createFromDate(2000, 1, 1, -5);
+        $this->assertSame('America/Chicago', $dt->timezoneName);
+
+        $dt = Carbon::createFromDate(2000, 1, 1, '-5');
         $this->assertSame('-05:00', $dt->timezoneName);
     }
 
@@ -383,6 +392,9 @@ class GettersTest extends AbstractTestCase
         $this->assertSame('America/Toronto', $dt->tzName);
 
         $dt = Carbon::createFromDate(2000, 1, 1, -5);
+        $this->assertSame('America/Chicago', $dt->timezoneName);
+
+        $dt = Carbon::createFromDate(2000, 1, 1, '-5');
         $this->assertSame('-05:00', $dt->timezoneName);
     }
 

--- a/tests/CarbonImmutable/IsTest.php
+++ b/tests/CarbonImmutable/IsTest.php
@@ -57,6 +57,25 @@ class IsTest extends AbstractTestCase
         $this->assertTrue(Carbon::now()->isToday());
     }
 
+    public function testIsCurrentWeek()
+    {
+        $this->assertFalse(Carbon::now()->subWeek()->isCurrentWeek());
+        $this->assertFalse(Carbon::now()->addWeek()->isCurrentWeek());
+        $this->assertTrue(Carbon::now()->isCurrentWeek());
+        $this->assertTrue(Carbon::now()->startOfWeek()->isCurrentWeek());
+        $this->assertTrue(Carbon::now()->endOfWeek()->isCurrentWeek());
+    }
+
+    public function testIsSameWeek()
+    {
+        $this->assertFalse(Carbon::now()->subWeek()->isSameWeek(Carbon::now()));
+        $this->assertFalse(Carbon::now()->addWeek()->isSameWeek(Carbon::now()));
+        $this->assertTrue(Carbon::now()->isSameWeek(Carbon::now()));
+        $this->assertTrue(Carbon::now()->startOfWeek()->isSameWeek(Carbon::now()));
+        $this->assertTrue(Carbon::now()->endOfWeek()->isSameWeek(Carbon::now()));
+        $this->assertTrue(Carbon::parse('2019-01-01')->isSameWeek(Carbon::parse('2018-12-31')));
+    }
+
     public function testIsNextWeekTrue()
     {
         $this->assertTrue(Carbon::now()->addWeek()->isNextWeek());

--- a/tests/CarbonTimeZone/ConversionsTest.php
+++ b/tests/CarbonTimeZone/ConversionsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonTimeZone;
+
+use Carbon\Carbon;
+use Carbon\CarbonTimeZone;
+use Tests\AbstractTestCase;
+
+class ConversionsTest extends AbstractTestCase
+{
+    protected $oldNow = true;
+
+    public function testToString()
+    {
+        $this->assertSame('+06:00', strval(new CarbonTimeZone(6)));
+        $this->assertSame('Europe/Paris', strval(new CarbonTimeZone('Europe/Paris')));
+    }
+
+    public function testToRegionName()
+    {
+        $this->assertSame('America/Chicago', (new CarbonTimeZone(-5))->toRegionName());
+        $this->assertSame('America/Toronto', (new CarbonTimeZone('America/Toronto'))->toRegionName());
+        $this->assertSame('America/New_York', (new CarbonTimeZone('America/Toronto'))->toOffsetTimeZone()->toRegionName());
+        $this->assertFalse((new CarbonTimeZone(-15))->toRegionName());
+        $date = Carbon::parse('2018-12-20');
+        $this->assertSame('America/Chicago', (new CarbonTimeZone('America/Toronto'))->toOffsetTimeZone($date)->toRegionName($date));
+    }
+
+    public function testToRegionTimeZone()
+    {
+        $this->assertSame('America/Chicago', (new CarbonTimeZone(-5))->toRegionTimeZone()->getName());
+        $this->assertSame('America/Toronto', (new CarbonTimeZone('America/Toronto'))->toRegionTimeZone()->getName());
+        $this->assertSame('America/New_York', (new CarbonTimeZone('America/Toronto'))->toOffsetTimeZone()->toRegionTimeZone()->getName());
+        $date = Carbon::parse('2018-12-20');
+        $this->assertSame('America/Chicago', (new CarbonTimeZone('America/Toronto'))->toOffsetTimeZone($date)->toRegionTimeZone($date)->getName());
+    }
+
+    public function testToOffsetName()
+    {
+        $this->assertSame('-05:00', (new CarbonTimeZone(-5))->toOffsetName());
+        $this->assertSame('-04:00', (new CarbonTimeZone('America/Toronto'))->toOffsetName());
+        $this->assertSame('-05:00', (new CarbonTimeZone(-5))->toRegionTimeZone()->toOffsetName());
+        $date = Carbon::parse('2018-12-20');
+        $this->assertSame('-05:00', (new CarbonTimeZone('America/Toronto'))->toOffsetName($date));
+        $this->assertSame('-06:00', (new CarbonTimeZone(-5))->toRegionTimeZone($date)->toOffsetName($date));
+        $this->assertSame('+00:00', (new CarbonTimeZone('UTC'))->toOffsetName());
+        $this->assertSame('+02:00', (new CarbonTimeZone('Europe/Paris'))->toOffsetName());
+        $this->assertSame('+05:30', (new CarbonTimeZone('Asia/Calcutta'))->toOffsetName());
+    }
+
+    public function testInvalidRegionForOffset()
+    {
+        Carbon::useStrictMode(false);
+        $this->assertFalse((new CarbonTimeZone(-15))->toRegionTimeZone());
+        Carbon::useStrictMode(true);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Unknown timezone for offset -54000 seconds.
+     */
+    public function testInvalidRegionForOffsetInStrictMode()
+    {
+        (new CarbonTimeZone(-15))->toRegionTimeZone();
+    }
+}

--- a/tests/CarbonTimeZone/CreateTest.php
+++ b/tests/CarbonTimeZone/CreateTest.php
@@ -21,11 +21,11 @@ class CreateTest extends AbstractTestCase
     {
         $tz = new CarbonTimeZone(6);
 
-        $this->assertSame('Asia/Yekaterinburg', $tz->getName());
+        $this->assertSame('+06:00', $tz->getName());
 
         $tz = CarbonTimeZone::create(6);
 
-        $this->assertSame('Asia/Yekaterinburg', $tz->getName());
+        $this->assertSame('+06:00', $tz->getName());
     }
 
     public function testInstance()
@@ -40,5 +40,14 @@ class CreateTest extends AbstractTestCase
         $tz = new UnknownZone();
 
         $this->assertSame('unknown', $tz->getAbbreviatedName());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Absolute timezone offset cannot be greater than 100.
+     */
+    public function testSafeCreateDateTimeZoneWithoutStrictMode()
+    {
+        new CarbonTimeZone(-15e15);
     }
 }


### PR DESCRIPTION
- Provide methods to get offset/region name from a timezone and convert it from one to the other
- Allow numeric (hour/minute offset) timezone as names
- Fix #1564