### PR TITLE
Support for symfony/translation ^3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.1.8",
         "ext-json": "*",
-        "symfony/translation": "^4.0"
+        "symfony/translation": "^3.4 || ^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14 || ^3.0",


### PR DESCRIPTION
Used interfaces `\Symfony\Component\Translation\TranslatorInterface` and `\Symfony\Component\Translation\TranslatorBagInterface` are compatible from `3.4` to `4.0` so why should we lock out users of still supported Symfony 3.4 ☺