### PR TITLE
Add NL period language definitions

### DIFF
--- a/src/Carbon/Lang/nl.php
+++ b/src/Carbon/Lang/nl.php
@@ -33,6 +33,10 @@ return [
     'diff_tomorrow' => 'morgen',
     'diff_after_tomorrow' => 'overmorgen',
     'diff_before_yesterday' => 'eergisteren',
+    'period_recurrences' => ':count keer',
+    'period_interval' => 'elke :interval',
+    'period_start_date' => 'van :date',
+    'period_end_date' => 'tot :date',
     'formats' => [
         'LT' => 'HH:mm',
         'LTS' => 'HH:mm:ss',


### PR DESCRIPTION
The missing Dutch language lines.

A note about the `period_interval` definition though. In Dutch we have an inflective keyword for singular intervals, depending on the gender of the word it refers to (notice there's no trailing `-e`). Unfortunately there's currently no clear way to get this right. An edge case, but I can imagine other languages might need this as well. Perhaps a similar approach as `ordinal` might come to the rescue?

|        | **one**  | **multiple** |
|--------|------|----------|
| **second** | elke | elke     |
| **minute** | elke | elke     |
| **hour**   | ⚠️ elk   | elke     |
| **day**    | elke | elke     |
| **week**   | elke | elke     |
| **month**  | elke | elke     |
| **year**   | ⚠️ elk  | elke     |