### PR TITLE
Fix addRealMicrosecond() with low float precision

### DIFF
--- a/src/Carbon/Traits/Units.php
+++ b/src/Carbon/Traits/Units.php
@@ -41,7 +41,7 @@ trait Units
                 /* @var CarbonInterface $this */
                 $diff = $this->microsecond + $value;
                 $time = $this->getTimestamp();
-                $seconds = floor($diff / static::MICROSECONDS_PER_SECOND);
+                $seconds = (int) floor($diff / static::MICROSECONDS_PER_SECOND);
                 $time += $seconds;
                 $diff -= $seconds * static::MICROSECONDS_PER_SECOND;
                 $microtime = str_pad($diff, 6, '0', STR_PAD_LEFT);
@@ -242,7 +242,7 @@ trait Units
         // Work-around for bug https://bugs.php.net/bug.php?id=75642
         if ($unit === 'micro' || $unit === 'microsecond') {
             $microseconds = $this->micro + $value;
-            $second = floor($microseconds / static::MICROSECONDS_PER_SECOND);
+            $second = (int) floor($microseconds / static::MICROSECONDS_PER_SECOND);
             $microseconds %= static::MICROSECONDS_PER_SECOND;
             if ($microseconds < 0) {
                 $microseconds += static::MICROSECONDS_PER_SECOND;

--- a/tests/Carbon/ModifyTest.php
+++ b/tests/Carbon/ModifyTest.php
@@ -203,4 +203,15 @@ class ModifyTest extends AbstractTestCase
 
         (new Carbon('2014-03-30 00:00:00'))->addRealUnit('foobar');
     }
+
+    public function testAddRealMicrosecondWithLowFloatPrecision()
+    {
+        $precision = ini_set('precision', 9);
+
+        $a = new Carbon('2014-03-30 00:59:59.999999', 'Europe/London');
+        $a->addRealMicrosecond();
+        $this->assertSame('02:00:00.000000', $a->format('H:i:s.u'));
+
+        ini_set('precision', $precision);
+    }
 }


### PR DESCRIPTION
This PR fixes the error `DateTime::modify(): Failed to parse time string (@1.3961412E+9.000000) at position 9 (2): Unexpected character` when calling `addRealMicrosecond()` when the INI `precision` is set too low.

It fixes the issue by casting the result of `floor()` to an integer.