### PR TITLE
Fix createFromFormat() to match native implementation when using test now

### DIFF
--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -443,7 +443,7 @@ trait Creator
     }
 
     /**
-     * @param string                          $format Datetime format
+     * @param string                          $format     Datetime format
      * @param string                          $time
      * @param \DateTimeZone|string|false|null $originalTz
      *

--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -442,6 +442,13 @@ trait Creator
         return static::today($tz)->setTimeFromTimeString($time);
     }
 
+    /**
+     * @param string                          $format Datetime format
+     * @param string                          $time
+     * @param \DateTimeZone|string|false|null $originalTz
+     *
+     * @return \DateTimeInterface|false
+     */
     private static function createFromFormatAndTimezone($format, $time, $originalTz)
     {
         // Work-around for https://bugs.php.net/bug.php?id=75577
@@ -504,6 +511,10 @@ trait Creator
             if ($tz === null && !preg_match("/{$nonEscaped}[eOPT]/", $nonIgnored)) {
                 $tz = $mock->getTimezone();
             }
+
+            // Set microseconds to zero to match behavior of DateTime::createFromFormat()
+            // See https://bugs.php.net/bug.php?id=74332
+            $mock = $mock->copy()->microsecond(0);
 
             // Prepend mock datetime only if the format does not contain non escaped unix epoch reset flag.
             if (!preg_match("/{$nonEscaped}[!|]/", $format)) {

--- a/tests/Carbon/CreateFromFormatTest.php
+++ b/tests/Carbon/CreateFromFormatTest.php
@@ -92,6 +92,18 @@ class CreateFromFormatTest extends AbstractTestCase
         $this->assertSame(254687, $d->micro);
     }
 
+    public function testCreateFromFormatWithTestNow()
+    {
+        Carbon::setTestNow();
+        $d = Carbon::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11');
+        Carbon::setTestNow($this->now->microsecond($d->microsecond ?: 254687));
+        $now = $this->now->copy();
+        $d_testnow = Carbon::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11');
+
+        $this->assertEquals($d, $d_testnow);
+        $this->assertEquals($now, $this->now);
+    }
+
     public function testCreateLastErrorsCanBeAccessedByExtendingClass()
     {
         $this->assertSame([

--- a/tests/Carbon/CreateFromFormatTest.php
+++ b/tests/Carbon/CreateFromFormatTest.php
@@ -95,13 +95,11 @@ class CreateFromFormatTest extends AbstractTestCase
     public function testCreateFromFormatWithTestNow()
     {
         Carbon::setTestNow();
-        $d = Carbon::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11');
-        Carbon::setTestNow($this->now->microsecond($d->microsecond ?: 254687));
-        $now = $this->now->copy();
-        $d_testnow = Carbon::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11');
+        $nativeDate = Carbon::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11');
+        Carbon::setTestNow(Carbon::now());
+        $mockedDate = Carbon::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11');
 
-        $this->assertEquals($d, $d_testnow);
-        $this->assertEquals($now, $this->now);
+        $this->assertSame($mockedDate->micro === 0, $nativeDate->micro === 0);
     }
 
     public function testCreateLastErrorsCanBeAccessedByExtendingClass()

--- a/tests/Carbon/TestingAidsTest.php
+++ b/tests/Carbon/TestingAidsTest.php
@@ -193,7 +193,9 @@ class TestingAidsTest extends AbstractTestCase
     {
         Carbon::setTestNow($now = Carbon::parse('2013-09-01 05:10:15.123456', 'America/Vancouver'));
 
-        $this->assertSame('2018-05-06 05:10:15.123456', Carbon::createFromFormat('Y-m-d', '2018-05-06')->format('Y-m-d H:i:s.u'));
+        // Set microseconds to zero to match behavior of DateTime::createFromFormat()
+        // See https://bugs.php.net/bug.php?id=74332
+        $this->assertSame('2018-05-06 05:10:15.000000', Carbon::createFromFormat('Y-m-d', '2018-05-06')->format('Y-m-d H:i:s.u'));
         $this->assertSame('2013-09-01 10:20:30.654321', Carbon::createFromFormat('H:i:s.u', '10:20:30.654321')->format('Y-m-d H:i:s.u'));
     }
 }

--- a/tests/CarbonImmutable/CreateFromFormatTest.php
+++ b/tests/CarbonImmutable/CreateFromFormatTest.php
@@ -77,13 +77,11 @@ class CreateFromFormatTest extends AbstractTestCase
     public function testCreateFromFormatWithTestNow()
     {
         Carbon::setTestNow();
-        $d = Carbon::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11');
-        Carbon::setTestNow($this->now->microsecond($d->microsecond ?: 254687));
-        $now = $this->now->copy();
-        $d_testnow = Carbon::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11');
+        $nativeDate = Carbon::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11');
+        Carbon::setTestNow(Carbon::now());
+        $mockedDate = Carbon::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11');
 
-        $this->assertEquals($d, $d_testnow);
-        $this->assertEquals($now, $this->now);
+        $this->assertSame($mockedDate->micro === 0, $nativeDate->micro === 0);
     }
 
     public function testCreateLastErrorsCanBeAccessedByExtendingClass()

--- a/tests/CarbonImmutable/CreateFromFormatTest.php
+++ b/tests/CarbonImmutable/CreateFromFormatTest.php
@@ -74,6 +74,18 @@ class CreateFromFormatTest extends AbstractTestCase
         $this->assertSame(254687, $d->micro);
     }
 
+    public function testCreateFromFormatWithTestNow()
+    {
+        Carbon::setTestNow();
+        $d = Carbon::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11');
+        Carbon::setTestNow($this->now->microsecond($d->microsecond ?: 254687));
+        $now = $this->now->copy();
+        $d_testnow = Carbon::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11');
+
+        $this->assertEquals($d, $d_testnow);
+        $this->assertEquals($now, $this->now);
+    }
+
     public function testCreateLastErrorsCanBeAccessedByExtendingClass()
     {
         $this->assertSame([

--- a/tests/CarbonImmutable/TestingAidsTest.php
+++ b/tests/CarbonImmutable/TestingAidsTest.php
@@ -202,7 +202,9 @@ class TestingAidsTest extends AbstractTestCase
     {
         Carbon::setTestNow($now = Carbon::parse('2013-09-01 05:10:15.123456', 'America/Vancouver'));
 
-        $this->assertSame('2018-05-06 05:10:15.123456', Carbon::createFromFormat('Y-m-d', '2018-05-06')->format('Y-m-d H:i:s.u'));
+        // Set microseconds to zero to match behavior of DateTime::createFromFormat()
+        // See https://bugs.php.net/bug.php?id=74332
+        $this->assertSame('2018-05-06 05:10:15.000000', Carbon::createFromFormat('Y-m-d', '2018-05-06')->format('Y-m-d H:i:s.u'));
         $this->assertSame('2013-09-01 10:20:30.654321', Carbon::createFromFormat('H:i:s.u', '10:20:30.654321')->format('Y-m-d H:i:s.u'));
     }
 }


### PR DESCRIPTION
The [documentation](http://php.net/manual/en/datetime.createfromformat.php) for `DateTime::createFromFormat()` states that "portions of the generated time which are not specified in format will be set to the current system time." However, this is has never been true for the microsecond portion, which is set to zero if not specified in the format.

There is an open ticket about this (https://bugs.php.net/bug.php?id=74332) but it doesn't appear that it will be fixed anytime soon. It seems reasonable to proceed as if the current behavior is the expected behavior for now.

Currently, the result of `Carbon::createFromFormat()` matches `DateTime::createFromFormat()` except when using test now, in which case `Carbon::createFromFormat()` returns a microsecond portion from the test now. This PR sets the microsecond to zero when it is not specified in the format while using test now so that the two will be aligned.

The tests are written so that they will fail if `DateTime::createFromFormat()` does begin setting the microsecond portion, at which point backwards compatibility should be addressed.