### PR TITLE
Fix #1706 Allow mixins to have constructor arguments

### DIFF
--- a/src/Carbon/Traits/Macro.php
+++ b/src/Carbon/Traits/Macro.php
@@ -134,6 +134,9 @@ trait Macro
         );
 
         foreach ($methods as $method) {
+            if ($method->isConstructor() || $method->isDestructor()) {
+                continue;
+            }
             $method->setAccessible(true);
 
             static::macro($method->name, $method->invoke($mixin));

--- a/tests/Carbon/Fixtures/Mixin.php
+++ b/tests/Carbon/Fixtures/Mixin.php
@@ -16,6 +16,11 @@ class Mixin
 {
     public $timezone = null;
 
+    public function __construct($timezone)
+    {
+        $this->timezone = $timezone;
+    }
+
     public function setUserTimezone()
     {
         $mixin = $this;

--- a/tests/Carbon/MacroTest.php
+++ b/tests/Carbon/MacroTest.php
@@ -86,7 +86,7 @@ class MacroTest extends AbstractTestCaseWithOldNow
     public function testCarbonIsMixinable()
     {
         include_once __DIR__.'/Fixtures/Mixin.php';
-        $mixin = new Mixin();
+        $mixin = new Mixin('America/New_York');
         Carbon::mixin($mixin);
         Carbon::setUserTimezone('America/Belize');
 


### PR DESCRIPTION
This PR fixes #1706.  Previously if your mixin had required constructor arguments it would cause a fatal error because the constructor was called with zero arguments by `Carbon::mixin`.

Similarly if you had a destructor it would also be called by `Carbon::mixin`.

I updated the `MacroTest` mixin fixture to reproduce the constructor issue.