### PR TITLE
Add SEQUENTIAL_PARTS_ONLY option for diffForHumans

### DIFF
--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -496,12 +496,13 @@ use ReflectionException;
 interface CarbonInterface extends DateTimeInterface, JsonSerializable
 {
     /**
-     * Diff wording options.
+     * Diff wording options(expressed in octal).
      */
     public const NO_ZERO_DIFF = 01;
     public const JUST_NOW = 02;
     public const ONE_DAY_WORDS = 04;
     public const TWO_DAY_WORDS = 010;
+    public const SEQUENTIAL_PARTS_ONLY = 020;
 
     /**
      * Diff syntax options.

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -1101,6 +1101,8 @@ class CarbonInterval extends DateInterval
                 $unit = $short ? $diffIntervalData['unitShort'] : $diffIntervalData['unit'];
                 $count = $diffIntervalData['value'];
                 $interval[] = $transChoice($short, $diffIntervalData);
+            } elseif ($options & CarbonInterface::SEQUENTIAL_PARTS_ONLY && count($interval) > 0) {
+                break;
             }
 
             // break the loop after we get the required number of parts in array

--- a/tests/CarbonImmutable/DiffTest.php
+++ b/tests/CarbonImmutable/DiffTest.php
@@ -1232,6 +1232,7 @@ class DiffTest extends AbstractTestCase
         $this->assertSame(2, Carbon::JUST_NOW);
         $this->assertSame(4, Carbon::ONE_DAY_WORDS);
         $this->assertSame(8, Carbon::TWO_DAY_WORDS);
+        $this->assertSame(16, Carbon::SEQUENTIAL_PARTS_ONLY);
 
         $options = Carbon::getHumanDiffOptions();
         $this->assertSame(1, $options);
@@ -1253,8 +1254,10 @@ class DiffTest extends AbstractTestCase
         $this->assertSame('0 seconds before', $date->diffForHumans($date));
         $this->assertSame('just now', Carbon::now()->diffForHumans());
 
-        Carbon::setHumanDiffOptions(Carbon::ONE_DAY_WORDS | Carbon::TWO_DAY_WORDS | Carbon::NO_ZERO_DIFF);
-        $this->assertSame(13, Carbon::getHumanDiffOptions());
+        Carbon::setHumanDiffOptions(Carbon::ONE_DAY_WORDS | Carbon::TWO_DAY_WORDS | Carbon::NO_ZERO_DIFF | Carbon::SEQUENTIAL_PARTS_ONLY);
+        $this->assertSame(29, Carbon::getHumanDiffOptions());
+
+        Carbon::disableHumanDiffOption(Carbon::SEQUENTIAL_PARTS_ONLY);
 
         $oneDayAfter = Carbon::create(2018, 3, 13, 2, 5, 6, 'UTC');
         $oneDayBefore = Carbon::create(2018, 3, 11, 2, 5, 6, 'UTC');
@@ -1285,6 +1288,80 @@ class DiffTest extends AbstractTestCase
         $this->assertSame(7, Carbon::getHumanDiffOptions());
         Carbon::enableHumanDiffOption(Carbon::JUST_NOW);
         $this->assertSame(7, Carbon::getHumanDiffOptions());
+
+        $origin = Carbon::create(2019, 1, 4, 0, 0, 0 , 'UTC');
+        $comparison = Carbon::create(2019, 2, 4, 0, 0, 0, 'UTC');
+        $this->assertSame('1 month before', $origin->diffForHumans($comparison, [
+            'parts' => 2,
+        ]));
+        $this->assertSame('1 month before', $origin->diffForHumans($comparison, [
+            'parts' => 2,
+            'options' => CarbonInterface::SEQUENTIAL_PARTS_ONLY,
+        ]));
+
+        $origin = Carbon::create(2019, 1, 4, 0, 0, 0 , 'UTC');
+        $comparison = Carbon::create(2019, 2, 11, 0, 0, 0, 'UTC');
+        $this->assertSame('1 month 1 week before', $origin->diffForHumans($comparison, [
+            'parts' => 2,
+        ]));
+        $this->assertSame('1 month 1 week before', $origin->diffForHumans($comparison, [
+            'parts' => 2,
+            'options' => CarbonInterface::SEQUENTIAL_PARTS_ONLY,
+        ]));
+
+        $origin = Carbon::create(2019, 1, 4, 0, 0, 0 , 'UTC');
+        $comparison = Carbon::create(2019, 2, 12, 0, 0, 0, 'UTC');
+        $this->assertSame('1 month 1 week before', $origin->diffForHumans($comparison, [
+            'parts' => 2,
+        ]));
+        $this->assertSame('1 month 1 week before', $origin->diffForHumans($comparison, [
+            'parts' => 2,
+            'options' => CarbonInterface::SEQUENTIAL_PARTS_ONLY,
+        ]));
+        $this->assertSame('1 month 1 week 1 day before', $origin->diffForHumans($comparison, [
+            'parts' => 3,
+        ]));
+        $this->assertSame('1 month 1 week 1 day before', $origin->diffForHumans($comparison, [
+            'parts' => 3,
+            'options' => CarbonInterface::SEQUENTIAL_PARTS_ONLY,
+        ]));
+
+        $origin = Carbon::create(2019, 1, 4, 0, 0, 0 , 'UTC');
+        $comparison = Carbon::create(2020, 1, 11, 0, 0, 0, 'UTC');
+        $this->assertSame('1 year 1 week before', $origin->diffForHumans($comparison, [
+            'parts' => 2,
+        ]));
+        $this->assertSame('1 year before', $origin->diffForHumans($comparison, [
+            'parts' => 2,
+            'options' => CarbonInterface::SEQUENTIAL_PARTS_ONLY,
+        ]));
+
+        $origin = Carbon::create(2019, 1, 4, 0, 0, 0 , 'UTC');
+        $comparison = Carbon::create(2019, 2, 5, 0, 0, 0, 'UTC');
+        $this->assertSame('1 month 1 day before', $origin->diffForHumans($comparison, [
+            'parts' => 2,
+        ]));
+        $this->assertSame('1 month before', $origin->diffForHumans($comparison, [
+            'parts' => 2,
+            'options' => CarbonInterface::SEQUENTIAL_PARTS_ONLY,
+        ]));
+
+        $origin = Carbon::create(2019, 1, 4, 0, 0, 0 , 'UTC');
+        $comparison = Carbon::create(2019, 1, 12, 0, 1, 0, 'UTC');
+        $this->assertSame('1 week 1 day before', $origin->diffForHumans($comparison, [
+            'parts' => 2,
+        ]));
+        $this->assertSame('1 week 1 day before', $origin->diffForHumans($comparison, [
+            'parts' => 2,
+            'options' => CarbonInterface::SEQUENTIAL_PARTS_ONLY,
+        ]));
+        $this->assertSame('1 week 1 day 1 minute before', $origin->diffForHumans($comparison, [
+            'parts' => 3,
+        ]));
+        $this->assertSame('1 week 1 day before', $origin->diffForHumans($comparison, [
+            'parts' => 3,
+            'options' => CarbonInterface::SEQUENTIAL_PARTS_ONLY,
+        ]));
 
         Carbon::setHumanDiffOptions($options);
     }

--- a/tests/CarbonImmutable/DiffTest.php
+++ b/tests/CarbonImmutable/DiffTest.php
@@ -1289,7 +1289,7 @@ class DiffTest extends AbstractTestCase
         Carbon::enableHumanDiffOption(Carbon::JUST_NOW);
         $this->assertSame(7, Carbon::getHumanDiffOptions());
 
-        $origin = Carbon::create(2019, 1, 4, 0, 0, 0 , 'UTC');
+        $origin = Carbon::create(2019, 1, 4, 0, 0, 0, 'UTC');
         $comparison = Carbon::create(2019, 2, 4, 0, 0, 0, 'UTC');
         $this->assertSame('1 month before', $origin->diffForHumans($comparison, [
             'parts' => 2,
@@ -1299,7 +1299,7 @@ class DiffTest extends AbstractTestCase
             'options' => CarbonInterface::SEQUENTIAL_PARTS_ONLY,
         ]));
 
-        $origin = Carbon::create(2019, 1, 4, 0, 0, 0 , 'UTC');
+        $origin = Carbon::create(2019, 1, 4, 0, 0, 0, 'UTC');
         $comparison = Carbon::create(2019, 2, 11, 0, 0, 0, 'UTC');
         $this->assertSame('1 month 1 week before', $origin->diffForHumans($comparison, [
             'parts' => 2,
@@ -1309,7 +1309,7 @@ class DiffTest extends AbstractTestCase
             'options' => CarbonInterface::SEQUENTIAL_PARTS_ONLY,
         ]));
 
-        $origin = Carbon::create(2019, 1, 4, 0, 0, 0 , 'UTC');
+        $origin = Carbon::create(2019, 1, 4, 0, 0, 0, 'UTC');
         $comparison = Carbon::create(2019, 2, 12, 0, 0, 0, 'UTC');
         $this->assertSame('1 month 1 week before', $origin->diffForHumans($comparison, [
             'parts' => 2,
@@ -1326,7 +1326,7 @@ class DiffTest extends AbstractTestCase
             'options' => CarbonInterface::SEQUENTIAL_PARTS_ONLY,
         ]));
 
-        $origin = Carbon::create(2019, 1, 4, 0, 0, 0 , 'UTC');
+        $origin = Carbon::create(2019, 1, 4, 0, 0, 0, 'UTC');
         $comparison = Carbon::create(2020, 1, 11, 0, 0, 0, 'UTC');
         $this->assertSame('1 year 1 week before', $origin->diffForHumans($comparison, [
             'parts' => 2,
@@ -1336,7 +1336,7 @@ class DiffTest extends AbstractTestCase
             'options' => CarbonInterface::SEQUENTIAL_PARTS_ONLY,
         ]));
 
-        $origin = Carbon::create(2019, 1, 4, 0, 0, 0 , 'UTC');
+        $origin = Carbon::create(2019, 1, 4, 0, 0, 0, 'UTC');
         $comparison = Carbon::create(2019, 2, 5, 0, 0, 0, 'UTC');
         $this->assertSame('1 month 1 day before', $origin->diffForHumans($comparison, [
             'parts' => 2,
@@ -1346,7 +1346,7 @@ class DiffTest extends AbstractTestCase
             'options' => CarbonInterface::SEQUENTIAL_PARTS_ONLY,
         ]));
 
-        $origin = Carbon::create(2019, 1, 4, 0, 0, 0 , 'UTC');
+        $origin = Carbon::create(2019, 1, 4, 0, 0, 0, 'UTC');
         $comparison = Carbon::create(2019, 1, 12, 0, 1, 0, 'UTC');
         $this->assertSame('1 week 1 day before', $origin->diffForHumans($comparison, [
             'parts' => 2,


### PR DESCRIPTION
This pull requests resolves #1701.

I think that the case described in the issue is not considered about the week.
This pull request is an implementation that takes the week into consideration. (although the code is actually written in the issue 👍)

We can see if we check the unit test, but here's some examples.

| diff                                      | parts | without SEQUENTIAL_PARTS_ONLY (actual result/default) | with SEQUENTIAL_PARTS_ONLY |
|-------------------------------------------|-------|-------------------------------------------------------|----------------------------|
| 2019-01-04 - 2019-02-04                   | 2     | 1 month                                               | 1 month                    |
| 2019-01-04 - 2019-02-11                   | 2     | 1 month 1 week                                        | 1 month 1 week             |
| 2019-01-04 - 2019-02-12                   | 2     | 1 month 1 week                                        | 1 month 1 week             |
| 2019-01-04 - 2019-02-12                   | 3     | 1 month 1 week 1 day                                  | 1 month 1 week 1 day       |
| 2019-01-04 - 2020-01-11                   | 2     | 1 year 1 week                                         | 1 year                     |
| 2019-01-04 - 2019-02-05                   | 2     | 1 month 1 day                                         | 1 month                    |
| 2019-01-04 00:00:00 - 2019-01-12 00:01:00 | 2     | 1 week 1 day                                          | 1 week 1 day               |
| 2019-01-04 00:00:00 - 2019-01-12 00:01:00 | 3     | 1 week 1 day 1 minute                                 | 1 week 1 day               |