### PR TITLE
Fix #1740 Czech translation

### DIFF
--- a/src/Carbon/Lang/cs.php
+++ b/src/Carbon/Lang/cs.php
@@ -40,15 +40,16 @@ $za = function ($time) {
 };
 
 $pred = function ($time) {
-    $time = preg_replace('/hodiny?(?!\w)/', 'hodinami', $time);
-    $time = preg_replace('/minuty?(?!\w)/', 'minutami', $time);
-    $time = preg_replace('/sekundy?(?!\w)/', 'sekundami', $time);
-
-    return 'před '.strtr($time, [
+    $time = strtr($time, [
         'hodina' => 'hodinou',
         'minuta' => 'minutou',
         'sekunda' => 'sekundou',
     ]);
+    $time = preg_replace('/hodiny?(?!\w)/', 'hodinami', $time);
+    $time = preg_replace('/minuty?(?!\w)/', 'minutami', $time);
+    $time = preg_replace('/sekundy?(?!\w)/', 'sekundami', $time);
+
+    return "před $time";
 };
 
 return [

--- a/src/Carbon/Lang/cs.php
+++ b/src/Carbon/Lang/cs.php
@@ -29,29 +29,52 @@
  * - newman101
  * - Petr Kadlec
  */
+$transformTime = function ($time) {
+    return strtr($time, [
+        'hodina' => 'hodinu',
+        'minuta' => 'minutu',
+        'sekunda' => 'sekundu',
+    ]);
+};
+
 return [
     'year' => ':count rok|:count roky|:count let',
     'y' => ':count rok|:count roky|:count let',
+    'a_year' => 'rok|:count roky|:count let',
     'month' => ':count měsíc|:count měsíce|:count měsíců',
     'm' => ':count měs.',
+    'a_month' => 'měsíc|:count měsíce|:count měsíců',
     'week' => ':count týden|:count týdny|:count týdnů',
     'w' => ':count týd.',
+    'a_week' => 'týden|:count týdny|:count týdnů',
     'day' => ':count den|:count dny|:count dní',
     'd' => ':count den|:count dny|:count dní',
-    'hour' => ':count hodinu|:count hodiny|:count hodin',
+    'a_day' => 'den|:count dny|:count dní',
+    'hour' => ':count hodina|:count hodiny|:count hodin',
     'h' => ':count hod.',
-    'minute' => ':count minutu|:count minuty|:count minut',
+    'a_hour' => 'hodina|:count hodiny|:count hodin',
+    'minute' => ':count minuta|:count minuty|:count minut',
     'min' => ':count min.',
-    'second' => ':count sekundu|:count sekundy|:count sekund',
+    'a_minute' => 'minuta|:count minuty|:count minut',
+    'second' => ':count sekunda|:count sekundy|:count sekund',
     's' => ':count sek.',
-    'ago' => ':time nazpět',
-    'from_now' => 'za :time',
-    'after' => 'o :time později',
-    'before' => ':time předtím',
+    'a_second' => 'pár sekund|:count sekundy|:count sekund',
+    'ago' => function ($time) use ($transformTime) {
+        return $transformTime($time).' nazpět';
+    },
+    'from_now' => function ($time) use ($transformTime) {
+        return 'za '.$transformTime($time);
+    },
+    'after' => function ($time) use ($transformTime) {
+        return 'o '.$transformTime($time).' později';
+    },
+    'before' => function ($time) use ($transformTime) {
+        return $transformTime($time).' předtím';
+    },
     'first_day_of_week' => 1,
     'day_of_first_week_of_year' => 4,
     'months' => ['leden', 'únor', 'březen', 'duben', 'květen', 'červen', 'červenec', 'srpen', 'září', 'říjen', 'listopad', 'prosinec'],
-    'months_short' => ['led', 'úno', 'bře', 'dub', 'kvě', 'čer', 'čer', 'srp', 'zář', 'říj', 'lis', 'pro'],
+    'months_short' => ['led', 'úno', 'bře', 'dub', 'kvě', 'čvn', 'čvc', 'srp', 'zář', 'říj', 'lis', 'pro'],
     'weekdays' => ['neděle', 'pondělí', 'úterý', 'středa', 'čtvrtek', 'pátek', 'sobota'],
     'weekdays_short' => ['ned', 'pon', 'úte', 'stř', 'čtv', 'pát', 'sob'],
     'weekdays_min' => ['ne', 'po', 'út', 'st', 'čt', 'pá', 'so'],

--- a/src/Carbon/Lang/cs.php
+++ b/src/Carbon/Lang/cs.php
@@ -28,12 +28,26 @@
  * - Tlapi
  * - newman101
  * - Petr Kadlec
+ * - tommaskraus
+ * - Karel Sommer (calvera)
  */
-$transformTime = function ($time) {
-    return strtr($time, [
+$za = function ($time) {
+    return 'za '.strtr($time, [
         'hodina' => 'hodinu',
         'minuta' => 'minutu',
         'sekunda' => 'sekundu',
+    ]);
+};
+
+$pred = function ($time) {
+    $time = preg_replace('/hodiny?(?!\w)/', 'hodinami', $time);
+    $time = preg_replace('/minuty?(?!\w)/', 'minutami', $time);
+    $time = preg_replace('/sekundy?(?!\w)/', 'sekundami', $time);
+
+    return 'před '.strtr($time, [
+        'hodina' => 'hodinou',
+        'minuta' => 'minutou',
+        'sekunda' => 'sekundou',
     ]);
 };
 
@@ -59,18 +73,10 @@ return [
     'second' => ':count sekunda|:count sekundy|:count sekund',
     's' => ':count sek.',
     'a_second' => 'pár sekund|:count sekundy|:count sekund',
-    'ago' => function ($time) use ($transformTime) {
-        return $transformTime($time).' nazpět';
-    },
-    'from_now' => function ($time) use ($transformTime) {
-        return 'za '.$transformTime($time);
-    },
-    'after' => function ($time) use ($transformTime) {
-        return 'o '.$transformTime($time).' později';
-    },
-    'before' => function ($time) use ($transformTime) {
-        return $transformTime($time).' předtím';
-    },
+    'ago' => $pred,
+    'from_now' => $za,
+    'before' => $pred,
+    'after' => $za,
     'first_day_of_week' => 1,
     'day_of_first_week_of_year' => 4,
     'months' => ['leden', 'únor', 'březen', 'duben', 'květen', 'červen', 'červenec', 'srpen', 'září', 'říjen', 'listopad', 'prosinec'],

--- a/tests/Localization/CsCzTest.php
+++ b/tests/Localization/CsCzTest.php
@@ -123,7 +123,7 @@ class CsCzTest extends LocalizationTestCase
         // Carbon::now()->subSeconds(1)->diffForHumans(null, false, true)
         'před 1 sek.',
         // Carbon::now()->subSeconds(2)->diffForHumans()
-        'před 2 sekundoumi',
+        'před 2 sekundami',
         // Carbon::now()->subSeconds(2)->diffForHumans(null, false, true)
         'před 2 sek.',
         // Carbon::now()->subMinutes(1)->diffForHumans()
@@ -131,7 +131,7 @@ class CsCzTest extends LocalizationTestCase
         // Carbon::now()->subMinutes(1)->diffForHumans(null, false, true)
         'před 1 min.',
         // Carbon::now()->subMinutes(2)->diffForHumans()
-        'před 2 minutoumi',
+        'před 2 minutami',
         // Carbon::now()->subMinutes(2)->diffForHumans(null, false, true)
         'před 2 min.',
         // Carbon::now()->subHours(1)->diffForHumans()
@@ -139,7 +139,7 @@ class CsCzTest extends LocalizationTestCase
         // Carbon::now()->subHours(1)->diffForHumans(null, false, true)
         'před 1 hod.',
         // Carbon::now()->subHours(2)->diffForHumans()
-        'před 2 hodinoumi',
+        'před 2 hodinami',
         // Carbon::now()->subHours(2)->diffForHumans(null, false, true)
         'před 2 hod.',
         // Carbon::now()->subDays(1)->diffForHumans()

--- a/tests/Localization/CsCzTest.php
+++ b/tests/Localization/CsCzTest.php
@@ -187,7 +187,7 @@ class CsCzTest extends LocalizationTestCase
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond(), false, true)
         '1 sek. předtím',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now(), true)
-        '1 sekundu',
+        '1 sekunda',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now(), true, true)
         '1 sek.',
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond()->addSecond(), true)
@@ -197,7 +197,7 @@ class CsCzTest extends LocalizationTestCase
         // Carbon::now()->addSecond()->diffForHumans(null, false, true, 1)
         'za 1 sek.',
         // Carbon::now()->addMinute()->addSecond()->diffForHumans(null, true, false, 2)
-        '1 minutu 1 sekundu',
+        '1 minuta 1 sekunda',
         // Carbon::now()->addYears(2)->addMonths(3)->addDay()->addSecond()->diffForHumans(null, true, true, 4)
         '2 roky 3 měs. 1 den 1 sek.',
         // Carbon::now()->addYears(3)->diffForHumans(null, null, false, 4)
@@ -215,9 +215,9 @@ class CsCzTest extends LocalizationTestCase
         // Carbon::now()->addWeek()->addDays(6)->diffForHumans(["join" => true, "parts" => 2])
         'za 1 týden a 6 dní',
         // Carbon::now()->addWeeks(2)->addHour()->diffForHumans(null, true, false, 2)
-        '2 týdny 1 hodinu',
+        '2 týdny 1 hodina',
         // Carbon::now()->addHour()->diffForHumans(["aUnit" => true])
-        'za 1 hodinu',
+        'za hodinu',
         // CarbonInterval::days(2)->forHumans()
         '2 dny',
         // CarbonInterval::create('P1DT3H')->forHumans(true)

--- a/tests/Localization/CsCzTest.php
+++ b/tests/Localization/CsCzTest.php
@@ -119,73 +119,73 @@ class CsCzTest extends LocalizationTestCase
         // Carbon::parse('2018-01-01 00:00:00')->ordinal('hour')
         '0',
         // Carbon::now()->subSeconds(1)->diffForHumans()
-        '1 sekundu nazpět',
+        'před 1 sekundou',
         // Carbon::now()->subSeconds(1)->diffForHumans(null, false, true)
-        '1 sek. nazpět',
+        'před 1 sek.',
         // Carbon::now()->subSeconds(2)->diffForHumans()
-        '2 sekundy nazpět',
+        'před 2 sekundoumi',
         // Carbon::now()->subSeconds(2)->diffForHumans(null, false, true)
-        '2 sek. nazpět',
+        'před 2 sek.',
         // Carbon::now()->subMinutes(1)->diffForHumans()
-        '1 minutu nazpět',
+        'před 1 minutou',
         // Carbon::now()->subMinutes(1)->diffForHumans(null, false, true)
-        '1 min. nazpět',
+        'před 1 min.',
         // Carbon::now()->subMinutes(2)->diffForHumans()
-        '2 minuty nazpět',
+        'před 2 minutoumi',
         // Carbon::now()->subMinutes(2)->diffForHumans(null, false, true)
-        '2 min. nazpět',
+        'před 2 min.',
         // Carbon::now()->subHours(1)->diffForHumans()
-        '1 hodinu nazpět',
+        'před 1 hodinou',
         // Carbon::now()->subHours(1)->diffForHumans(null, false, true)
-        '1 hod. nazpět',
+        'před 1 hod.',
         // Carbon::now()->subHours(2)->diffForHumans()
-        '2 hodiny nazpět',
+        'před 2 hodinoumi',
         // Carbon::now()->subHours(2)->diffForHumans(null, false, true)
-        '2 hod. nazpět',
+        'před 2 hod.',
         // Carbon::now()->subDays(1)->diffForHumans()
-        '1 den nazpět',
+        'před 1 den',
         // Carbon::now()->subDays(1)->diffForHumans(null, false, true)
-        '1 den nazpět',
+        'před 1 den',
         // Carbon::now()->subDays(2)->diffForHumans()
-        '2 dny nazpět',
+        'před 2 dny',
         // Carbon::now()->subDays(2)->diffForHumans(null, false, true)
-        '2 dny nazpět',
+        'před 2 dny',
         // Carbon::now()->subWeeks(1)->diffForHumans()
-        '1 týden nazpět',
+        'před 1 týden',
         // Carbon::now()->subWeeks(1)->diffForHumans(null, false, true)
-        '1 týd. nazpět',
+        'před 1 týd.',
         // Carbon::now()->subWeeks(2)->diffForHumans()
-        '2 týdny nazpět',
+        'před 2 týdny',
         // Carbon::now()->subWeeks(2)->diffForHumans(null, false, true)
-        '2 týd. nazpět',
+        'před 2 týd.',
         // Carbon::now()->subMonths(1)->diffForHumans()
-        '1 měsíc nazpět',
+        'před 1 měsíc',
         // Carbon::now()->subMonths(1)->diffForHumans(null, false, true)
-        '1 měs. nazpět',
+        'před 1 měs.',
         // Carbon::now()->subMonths(2)->diffForHumans()
-        '2 měsíce nazpět',
+        'před 2 měsíce',
         // Carbon::now()->subMonths(2)->diffForHumans(null, false, true)
-        '2 měs. nazpět',
+        'před 2 měs.',
         // Carbon::now()->subYears(1)->diffForHumans()
-        '1 rok nazpět',
+        'před 1 rok',
         // Carbon::now()->subYears(1)->diffForHumans(null, false, true)
-        '1 rok nazpět',
+        'před 1 rok',
         // Carbon::now()->subYears(2)->diffForHumans()
-        '2 roky nazpět',
+        'před 2 roky',
         // Carbon::now()->subYears(2)->diffForHumans(null, false, true)
-        '2 roky nazpět',
+        'před 2 roky',
         // Carbon::now()->addSecond()->diffForHumans()
         'za 1 sekundu',
         // Carbon::now()->addSecond()->diffForHumans(null, false, true)
         'za 1 sek.',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now())
-        'o 1 sekundu později',
+        'za 1 sekundu',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now(), false, true)
-        'o 1 sek. později',
+        'za 1 sek.',
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond())
-        '1 sekundu předtím',
+        'před 1 sekundou',
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond(), false, true)
-        '1 sek. předtím',
+        'před 1 sek.',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now(), true)
         '1 sekunda',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now(), true, true)
@@ -203,9 +203,9 @@ class CsCzTest extends LocalizationTestCase
         // Carbon::now()->addYears(3)->diffForHumans(null, null, false, 4)
         'za 3 roky',
         // Carbon::now()->subMonths(5)->diffForHumans(null, null, true, 4)
-        '5 měs. nazpět',
+        'před 5 měs.',
         // Carbon::now()->subYears(2)->subMonths(3)->subDay()->subSecond()->diffForHumans(null, null, true, 4)
-        '2 roky 3 měs. 1 den 1 sek. nazpět',
+        'před 2 roky 3 měs. 1 den 1 sek.',
         // Carbon::now()->addWeek()->addHours(10)->diffForHumans(null, true, false, 2)
         '1 týden 10 hodin',
         // Carbon::now()->addWeek()->addDays(6)->diffForHumans(null, true, false, 2)

--- a/tests/Localization/CsTest.php
+++ b/tests/Localization/CsTest.php
@@ -119,73 +119,73 @@ class CsTest extends LocalizationTestCase
         // Carbon::parse('2018-01-01 00:00:00')->ordinal('hour')
         '0',
         // Carbon::now()->subSeconds(1)->diffForHumans()
-        '1 sekundu nazpět',
+        'před 1 sekundou',
         // Carbon::now()->subSeconds(1)->diffForHumans(null, false, true)
-        '1 sek. nazpět',
+        'před 1 sek.',
         // Carbon::now()->subSeconds(2)->diffForHumans()
-        '2 sekundy nazpět',
+        'před 2 sekundoumi',
         // Carbon::now()->subSeconds(2)->diffForHumans(null, false, true)
-        '2 sek. nazpět',
+        'před 2 sek.',
         // Carbon::now()->subMinutes(1)->diffForHumans()
-        '1 minutu nazpět',
+        'před 1 minutou',
         // Carbon::now()->subMinutes(1)->diffForHumans(null, false, true)
-        '1 min. nazpět',
+        'před 1 min.',
         // Carbon::now()->subMinutes(2)->diffForHumans()
-        '2 minuty nazpět',
+        'před 2 minutoumi',
         // Carbon::now()->subMinutes(2)->diffForHumans(null, false, true)
-        '2 min. nazpět',
+        'před 2 min.',
         // Carbon::now()->subHours(1)->diffForHumans()
-        '1 hodinu nazpět',
+        'před 1 hodinou',
         // Carbon::now()->subHours(1)->diffForHumans(null, false, true)
-        '1 hod. nazpět',
+        'před 1 hod.',
         // Carbon::now()->subHours(2)->diffForHumans()
-        '2 hodiny nazpět',
+        'před 2 hodinoumi',
         // Carbon::now()->subHours(2)->diffForHumans(null, false, true)
-        '2 hod. nazpět',
+        'před 2 hod.',
         // Carbon::now()->subDays(1)->diffForHumans()
-        '1 den nazpět',
+        'před 1 den',
         // Carbon::now()->subDays(1)->diffForHumans(null, false, true)
-        '1 den nazpět',
+        'před 1 den',
         // Carbon::now()->subDays(2)->diffForHumans()
-        '2 dny nazpět',
+        'před 2 dny',
         // Carbon::now()->subDays(2)->diffForHumans(null, false, true)
-        '2 dny nazpět',
+        'před 2 dny',
         // Carbon::now()->subWeeks(1)->diffForHumans()
-        '1 týden nazpět',
+        'před 1 týden',
         // Carbon::now()->subWeeks(1)->diffForHumans(null, false, true)
-        '1 týd. nazpět',
+        'před 1 týd.',
         // Carbon::now()->subWeeks(2)->diffForHumans()
-        '2 týdny nazpět',
+        'před 2 týdny',
         // Carbon::now()->subWeeks(2)->diffForHumans(null, false, true)
-        '2 týd. nazpět',
+        'před 2 týd.',
         // Carbon::now()->subMonths(1)->diffForHumans()
-        '1 měsíc nazpět',
+        'před 1 měsíc',
         // Carbon::now()->subMonths(1)->diffForHumans(null, false, true)
-        '1 měs. nazpět',
+        'před 1 měs.',
         // Carbon::now()->subMonths(2)->diffForHumans()
-        '2 měsíce nazpět',
+        'před 2 měsíce',
         // Carbon::now()->subMonths(2)->diffForHumans(null, false, true)
-        '2 měs. nazpět',
+        'před 2 měs.',
         // Carbon::now()->subYears(1)->diffForHumans()
-        '1 rok nazpět',
+        'před 1 rok',
         // Carbon::now()->subYears(1)->diffForHumans(null, false, true)
-        '1 rok nazpět',
+        'před 1 rok',
         // Carbon::now()->subYears(2)->diffForHumans()
-        '2 roky nazpět',
+        'před 2 roky',
         // Carbon::now()->subYears(2)->diffForHumans(null, false, true)
-        '2 roky nazpět',
+        'před 2 roky',
         // Carbon::now()->addSecond()->diffForHumans()
         'za 1 sekundu',
         // Carbon::now()->addSecond()->diffForHumans(null, false, true)
         'za 1 sek.',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now())
-        'o 1 sekundu později',
+        'za 1 sekundu',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now(), false, true)
-        'o 1 sek. později',
+        'za 1 sek.',
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond())
-        '1 sekundu předtím',
+        'před 1 sekundou',
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond(), false, true)
-        '1 sek. předtím',
+        'před 1 sek.',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now(), true)
         '1 sekunda',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now(), true, true)
@@ -203,9 +203,9 @@ class CsTest extends LocalizationTestCase
         // Carbon::now()->addYears(3)->diffForHumans(null, null, false, 4)
         'za 3 roky',
         // Carbon::now()->subMonths(5)->diffForHumans(null, null, true, 4)
-        '5 měs. nazpět',
+        'před 5 měs.',
         // Carbon::now()->subYears(2)->subMonths(3)->subDay()->subSecond()->diffForHumans(null, null, true, 4)
-        '2 roky 3 měs. 1 den 1 sek. nazpět',
+        'před 2 roky 3 měs. 1 den 1 sek.',
         // Carbon::now()->addWeek()->addHours(10)->diffForHumans(null, true, false, 2)
         '1 týden 10 hodin',
         // Carbon::now()->addWeek()->addDays(6)->diffForHumans(null, true, false, 2)

--- a/tests/Localization/CsTest.php
+++ b/tests/Localization/CsTest.php
@@ -187,7 +187,7 @@ class CsTest extends LocalizationTestCase
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond(), false, true)
         '1 sek. předtím',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now(), true)
-        '1 sekundu',
+        '1 sekunda',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now(), true, true)
         '1 sek.',
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond()->addSecond(), true)
@@ -197,7 +197,7 @@ class CsTest extends LocalizationTestCase
         // Carbon::now()->addSecond()->diffForHumans(null, false, true, 1)
         'za 1 sek.',
         // Carbon::now()->addMinute()->addSecond()->diffForHumans(null, true, false, 2)
-        '1 minutu 1 sekundu',
+        '1 minuta 1 sekunda',
         // Carbon::now()->addYears(2)->addMonths(3)->addDay()->addSecond()->diffForHumans(null, true, true, 4)
         '2 roky 3 měs. 1 den 1 sek.',
         // Carbon::now()->addYears(3)->diffForHumans(null, null, false, 4)
@@ -215,9 +215,9 @@ class CsTest extends LocalizationTestCase
         // Carbon::now()->addWeek()->addDays(6)->diffForHumans(["join" => true, "parts" => 2])
         'za 1 týden a 6 dní',
         // Carbon::now()->addWeeks(2)->addHour()->diffForHumans(null, true, false, 2)
-        '2 týdny 1 hodinu',
+        '2 týdny 1 hodina',
         // Carbon::now()->addHour()->diffForHumans(["aUnit" => true])
-        'za 1 hodinu',
+        'za hodinu',
         // CarbonInterval::days(2)->forHumans()
         '2 dny',
         // CarbonInterval::create('P1DT3H')->forHumans(true)

--- a/tests/Localization/CsTest.php
+++ b/tests/Localization/CsTest.php
@@ -123,7 +123,7 @@ class CsTest extends LocalizationTestCase
         // Carbon::now()->subSeconds(1)->diffForHumans(null, false, true)
         'před 1 sek.',
         // Carbon::now()->subSeconds(2)->diffForHumans()
-        'před 2 sekundoumi',
+        'před 2 sekundami',
         // Carbon::now()->subSeconds(2)->diffForHumans(null, false, true)
         'před 2 sek.',
         // Carbon::now()->subMinutes(1)->diffForHumans()
@@ -131,7 +131,7 @@ class CsTest extends LocalizationTestCase
         // Carbon::now()->subMinutes(1)->diffForHumans(null, false, true)
         'před 1 min.',
         // Carbon::now()->subMinutes(2)->diffForHumans()
-        'před 2 minutoumi',
+        'před 2 minutami',
         // Carbon::now()->subMinutes(2)->diffForHumans(null, false, true)
         'před 2 min.',
         // Carbon::now()->subHours(1)->diffForHumans()
@@ -139,7 +139,7 @@ class CsTest extends LocalizationTestCase
         // Carbon::now()->subHours(1)->diffForHumans(null, false, true)
         'před 1 hod.',
         // Carbon::now()->subHours(2)->diffForHumans()
-        'před 2 hodinoumi',
+        'před 2 hodinami',
         // Carbon::now()->subHours(2)->diffForHumans(null, false, true)
         'před 2 hod.',
         // Carbon::now()->subDays(1)->diffForHumans()


### PR DESCRIPTION
- Implement a_unit forms
- Fix hodina/hodinu, minuta/minutu, sekunda/sekundu declensions
- Use čvn/čvc to distinguish June from July