### PR TITLE
[Laravel] Support event dispatcher's contract

### DIFF
--- a/src/Carbon/Laravel/ServiceProvider.php
+++ b/src/Carbon/Laravel/ServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Carbon\Laravel;
 
 use Carbon\Carbon;
+use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Events\EventDispatcher;
 use Illuminate\Translation\Translator as IlluminateTranslator;
@@ -19,7 +20,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $service = $this;
         $events = $this->app['events'];
 
-        if ($events instanceof EventDispatcher || $events instanceof Dispatcher) {
+        if ($this->isEventDispatcher($events)) {
             $events->listen(class_exists('Illuminate\Foundation\Events\LocaleUpdated') ? 'Illuminate\Foundation\Events\LocaleUpdated' : 'locale.changed', function () use ($service) {
                 $service->updateLocale();
             });
@@ -39,5 +40,12 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     public function register()
     {
         // Needed for Laravel < 5.3 compatibility
+    }
+
+    protected function isEventDispatcher($instance)
+    {
+        return $instance instanceof EventDispatcher
+            || $instance instanceof Dispatcher
+            || $instance instanceof DispatcherContract;
     }
 }

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -79,6 +79,7 @@ abstract class AbstractTestCase extends TestCase
     protected function tearDown(): void
     {
         date_default_timezone_set($this->saveTz);
+
         Carbon::setTestNow();
         Carbon::resetToStringFormat();
         Carbon::resetMonthsOverflow();
@@ -87,11 +88,12 @@ abstract class AbstractTestCase extends TestCase
         /** @var Translator $translator */
         $translator = Carbon::getTranslator();
         $translator->resetMessages();
+
         CarbonImmutable::setTestNow();
         CarbonImmutable::resetToStringFormat();
         CarbonImmutable::resetMonthsOverflow();
         CarbonImmutable::setTranslator(new Translator('en'));
-        Carbon::setLocale('en');
+        CarbonImmutable::setLocale('en');
         /** @var Translator $translator */
         $translator = CarbonImmutable::getTranslator();
         $translator->resetMessages();

--- a/tests/Laravel/App.php
+++ b/tests/Laravel/App.php
@@ -1,7 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use Illuminate\Events\EventDispatcher;
+namespace Tests\Laravel;
+
+use ArrayAccess;
 use Symfony\Component\Translation\Translator;
 
 class App implements ArrayAccess
@@ -17,7 +19,7 @@ class App implements ArrayAccess
     public $translator;
 
     /**
-     * @var EventDispatcher
+     * @var \Illuminate\Events\EventDispatcher
      */
     public $events;
 
@@ -25,7 +27,11 @@ class App implements ArrayAccess
     {
         include_once __DIR__.'/EventDispatcher.php';
         $this->translator = new Translator('de');
-        $this->events = new EventDispatcher();
+    }
+
+    public function setEventDispatcher($dispatcher)
+    {
+        $this->events = $dispatcher;
     }
 
     public static function version($version = null)

--- a/tests/Laravel/Dispatcher.php
+++ b/tests/Laravel/Dispatcher.php
@@ -3,6 +3,6 @@ declare(strict_types=1);
 
 namespace Illuminate\Events;
 
-class Dispatcher extends EventDispatcher
+class Dispatcher extends \Tests\Laravel\EventDispatcherBase
 {
 }

--- a/tests/Laravel/EventDispatcher.php
+++ b/tests/Laravel/EventDispatcher.php
@@ -3,28 +3,6 @@ declare(strict_types=1);
 
 namespace Illuminate\Events;
 
-class EventDispatcher
+class EventDispatcher extends \Tests\Laravel\EventDispatcherBase
 {
-    /**
-     * @var array
-     */
-    protected $listeners;
-
-    public function listen($name, $listener)
-    {
-        if (!isset($this->listeners[$name])) {
-            $this->listeners[$name] = [];
-        }
-
-        $this->listeners[$name][] = $listener;
-    }
-
-    public function dispatch($name, $event = null)
-    {
-        if (isset($this->listeners[$name])) {
-            foreach ($this->listeners[$name] as $listener) {
-                call_user_func($listener, $event);
-            }
-        }
-    }
 }

--- a/tests/Laravel/EventDispatcherBase.php
+++ b/tests/Laravel/EventDispatcherBase.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Laravel;
+
+class EventDispatcherBase
+{
+    /**
+     * @var array
+     */
+    protected $listeners;
+
+    public function listen($name, $listener)
+    {
+        if (!isset($this->listeners[$name])) {
+            $this->listeners[$name] = [];
+        }
+
+        $this->listeners[$name][] = $listener;
+    }
+
+    public function dispatch($name, $event = null)
+    {
+        if (isset($this->listeners[$name])) {
+            foreach ($this->listeners[$name] as $listener) {
+                call_user_func($listener, $event);
+            }
+        }
+    }
+}

--- a/tests/Laravel/ServiceProvider.php
+++ b/tests/Laravel/ServiceProvider.php
@@ -3,16 +3,19 @@ declare(strict_types=1);
 
 namespace Illuminate\Support;
 
+use Illuminate\Events\EventDispatcher;
+use Tests\Laravel\App;
+
 class ServiceProvider
 {
     /**
-     * @var \App
+     * @var App
      */
     public $app;
 
-    public function __construct()
+    public function __construct($dispatcher = null)
     {
-        include_once __DIR__.'/App.php';
-        $this->app = new \App();
+        $this->app = new App();
+        $this->app->setEventDispatcher($dispatcher ?: new EventDispatcher());
     }
 }

--- a/tests/Laravel/ServiceProviderTest.php
+++ b/tests/Laravel/ServiceProviderTest.php
@@ -1,18 +1,39 @@
 <?php
 declare(strict_types=1);
 
-namespace Tests\Carbon\Laravel;
+namespace Tests\Laravel;
 
 use Carbon\Carbon;
 use Carbon\Laravel\ServiceProvider;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Events\EventDispatcher;
 use PHPUnit\Framework\TestCase;
 
 class ServiceProviderTest extends TestCase
 {
-    public function testBoot()
+    public function getDispatchers()
+    {
+        if (!class_exists(Dispatcher::class)) {
+            include_once __DIR__.'/Dispatcher.php';
+        }
+
+        if (!class_exists(EventDispatcher::class)) {
+            include_once __DIR__.'/EventDispatcher.php';
+        }
+
+        return [
+            [new Dispatcher()],
+            [new EventDispatcher()],
+        ];
+    }
+
+    /**
+     * @dataProvider getDispatchers
+     */
+    public function testBoot($dispatcher)
     {
         include_once __DIR__.'/ServiceProvider.php';
-        $service = new ServiceProvider();
+        $service = new ServiceProvider($dispatcher);
 
         $this->assertSame('en', Carbon::getLocale());
         $service->boot();
@@ -23,5 +44,8 @@ class ServiceProviderTest extends TestCase
         $service->app->setLocale('fr');
         $this->assertSame('fr', Carbon::getLocale());
         $this->assertNull($service->register());
+
+        // Reset language
+        Carbon::setLocale('en');
     }
 }


### PR DESCRIPTION
This PR implements the changes discussed in issue #1747.

Namely, it allows `$app['events']` instances to be instances of `Illuminate\Contracts\Events\Dispatcher` in order to support any implementation of Laravel's event dispatcher.

Note that I've taken the liberty to extract the `if` condition into it's own protected method. Let me know if you'd like me to inline it instead.

Thanks again for allowing me to write this PR. 🙏 