### PR TITLE
First day of week and first week of year for pt_BR

### DIFF
--- a/src/Carbon/Lang/pt_BR.php
+++ b/src/Carbon/Lang/pt_BR.php
@@ -34,6 +34,4 @@ return array_replace_recursive(require __DIR__.'/pt.php', [
         'LLL' => 'D [de] MMMM [de] YYYY [às] HH:mm',
         'LLLL' => 'dddd, D [de] MMMM [de] YYYY [às] HH:mm',
     ],
-    'first_day_of_week' => 0,
-    'day_of_first_week_of_year' => 1,
 ]);


### PR DESCRIPTION
In Brazil we have an organization that publishes technical norms regarding several matters. One of these norms specifies the first day of the week as Monday and the first week of a year as the first week in a year which contains a Thursday.

This organization is called ABNT (Associação Brasileira de Normas Técnicas / Brazilian Association of Technical Norms /  abnt.org.br). We could say it is a local ISO. The norm related to those values is NBR 9577 which was published in Set'1986. The norm can be found in the following address: 

https://www.abntcatalogo.com.br/norma.aspx?ID=4113 

Unfortunately ABNT does not make NBR's available for free. As this is a short norm (3 pages) you can find some parts of it using Google Images search, I won't link the image file directly, as it could infringe copyright, but the following link contains an image where one could assert both the first day of week and how the first week of year is determined:

https://www.normas.com.br/visualizar/abnt-nbr-nm/5515/abnt-nbr9577-emprego-de-numeracao-de-semanas-procedimento

It is valid to add that the related ISO norm (ISO 8601) has the same specifications regarding those week related values as the NBR 9577. One could read more about ISO 8601 in [Wikipedia](https://en.wikipedia.org/wiki/ISO_week_date).

Comparing to the **pt** locale (https://github.com/briannesbitt/Carbon/blob/master/src/Carbon/Lang/pt.php), which the **pt_BR** locale inherits almost all of its attributes from, this PR only removes the attributes related to those values as the **pt** locale already has the Moday as the first day of the week and the Thursday as the day which the first week of the year must contains.

---

I noticed that change when migrating a project to use Carbon 2. Before I used a package that extended Carbon to add localization (https://github.com/jenssegers/date) and I set the locale globally with `Carbon::setLocale`. When migrating to Carbon 2 I noticed all my week based reports started to malfunction, so I found that Carbon 2 set those values differently to the pt_BR locale. 

I couldn't find why those changes where made as they were introduced in a commit labeled [Add aUnit option for translations](https://github.com/briannesbitt/Carbon/commit/3b9d527d566cc92114bc9250720c6b3007bab841). Maybe it was a refactoring oversight. This commit changes those settings for several languages, either by adding or removing custom values. Unfortunately I cannot check all the locales to see which would be appropriate values for each of them.