### PR TITLE
[Laravel] Defer Translator + Simplify Provider

### DIFF
--- a/src/Carbon/Laravel/ServiceProvider.php
+++ b/src/Carbon/Laravel/ServiceProvider.php
@@ -13,7 +13,9 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
     public function boot()
     {
-        if (!$this->app->bound('events') || !$this->app->bound('translator')) {
+        $this->updateLocale();
+
+        if (!$this->app->bound('events')) {
             return;
         }
 
@@ -24,17 +26,12 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             $events->listen(class_exists('Illuminate\Foundation\Events\LocaleUpdated') ? 'Illuminate\Foundation\Events\LocaleUpdated' : 'locale.changed', function () use ($service) {
                 $service->updateLocale();
             });
-            $service->updateLocale();
         }
     }
 
     public function updateLocale()
     {
-        $translator = $this->app['translator'];
-
-        if ($translator instanceof Translator || $translator instanceof IlluminateTranslator) {
-            Carbon::setLocale($translator->getLocale());
-        }
+        Carbon::setDefaultLocale($this->app->getLocale());
     }
 
     public function register()

--- a/src/Carbon/Traits/Localization.php
+++ b/src/Carbon/Traits/Localization.php
@@ -26,6 +26,13 @@ use Symfony\Component\Translation\TranslatorInterface;
 trait Localization
 {
     /**
+     * Default locale.
+     *
+     * @var string
+     */
+    protected static $defaultLocale;
+
+    /**
      * Default translator.
      *
      * @var \Symfony\Component\Translation\TranslatorInterface
@@ -101,6 +108,9 @@ trait Localization
     {
         if (static::$translator === null) {
             static::$translator = Translator::get();
+            if (static::$defaultLocale) {
+                static::$translator->setLocale(static::$defaultLocale);
+            }
         }
 
         return static::$translator;
@@ -393,6 +403,19 @@ trait Localization
     public static function getLocale()
     {
         return static::translator()->getLocale();
+    }
+
+    /**
+     * Set the default translator locale.
+     * Pass 'auto' as locale to use closest language from the current LC_TIME locale.
+     *
+     * @param string $locale locale ex. en
+     *
+     * @return void
+     */
+    public static function setDefaultLocale($locale)
+    {
+        static::$defaultLocale = $locale;
     }
 
     /**

--- a/tests/Laravel/App.php
+++ b/tests/Laravel/App.php
@@ -11,6 +11,11 @@ class App implements ArrayAccess
     /**
      * @var string
      */
+    protected $locale;
+
+    /**
+     * @var string
+     */
     protected static $version;
 
     /**
@@ -26,7 +31,7 @@ class App implements ArrayAccess
     public function register()
     {
         include_once __DIR__.'/EventDispatcher.php';
-        $this->translator = new Translator('de');
+        $this->translator = new Translator($this->locale = 'de');
     }
 
     public function setEventDispatcher($dispatcher)
@@ -50,8 +55,14 @@ class App implements ArrayAccess
 
     public function setLocale($locale)
     {
+        $this->locale = $locale;
         $this->translator->setLocale($locale);
         $this->events->dispatch(static::getLocaleChangeEventName());
+    }
+
+    public function getLocale()
+    {
+        return $this->locale;
     }
 
     public function bound($service)


### PR DESCRIPTION
As suggested in #https://github.com/briannesbitt/Carbon/issues/1776 , maybe we can wait to load the actual Translator until it's used?

I'm also not sure why we need the Laravel Translator or the Event to get the current Locale. The getLocale() is available from the App container already.