### PR TITLE
Implement contains() and JsonSerializable in CarbonPeriod

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -46,6 +46,6 @@ $rules = array(
 );
 
 return Config::create()->setRules($rules)
-             ->setFinder(Finder::create()->in(__DIR__))
+             ->setFinder(Finder::create()->in(__DIR__.'/src'))
              ->setUsingCache(true)
              ->setRiskyAllowed(true);

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -23,6 +23,7 @@ use DateTime;
 use DateTimeInterface;
 use InvalidArgumentException;
 use Iterator;
+use JsonSerializable;
 use RuntimeException;
 
 /**
@@ -176,7 +177,7 @@ use RuntimeException;
  * @method $this ceilMicrosecond(float $precision = 1) Ceil the current instance microsecond with given precision.
  * @method $this ceilMicroseconds(float $precision = 1) Ceil the current instance microsecond with given precision.
  */
-class CarbonPeriod implements Iterator, Countable
+class CarbonPeriod implements Iterator, Countable, JsonSerializable
 {
     use Options, Cast, Mixin {
         Mixin::mixin as baseMixin;
@@ -921,6 +922,26 @@ class CarbonPeriod implements Iterator, Countable
     }
 
     /**
+     * Returns true if the start date should be included.
+     *
+     * @return bool
+     */
+    public function isStartIncluded()
+    {
+        return !$this->isStartExcluded();
+    }
+
+    /**
+     * Returns true if the end date should be included.
+     *
+     * @return bool
+     */
+    public function isEndIncluded()
+    {
+        return !$this->isEndExcluded();
+    }
+
+    /**
      * Add a filter to the stack.
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
@@ -1516,7 +1537,7 @@ class CarbonPeriod implements Iterator, Countable
     /**
      * Convert the date period into an array without changing current iteration state.
      *
-     * @return array
+     * @return CarbonInterface[]
      */
     public function toArray()
     {
@@ -1814,6 +1835,7 @@ class CarbonPeriod implements Iterator, Countable
 
     /**
      * Determines if the instance is equal to another.
+     * Warning: if options differ, instances wil never be equal.
      *
      * @param mixed $period
      *
@@ -1828,6 +1850,7 @@ class CarbonPeriod implements Iterator, Countable
 
     /**
      * Determines if the instance is equal to another.
+     * Warning: if options differ, instances wil never be equal.
      *
      * @param mixed $period
      *
@@ -1848,6 +1871,7 @@ class CarbonPeriod implements Iterator, Countable
 
     /**
      * Determines if the instance is not equal to another.
+     * Warning: if options differ, instances wil never be equal.
      *
      * @param mixed $period
      *
@@ -1862,6 +1886,7 @@ class CarbonPeriod implements Iterator, Countable
 
     /**
      * Determines if the instance is not equal to another.
+     * Warning: if options differ, instances wil never be equal.
      *
      * @param mixed $period
      *
@@ -1874,6 +1899,7 @@ class CarbonPeriod implements Iterator, Countable
 
     /**
      * Determines if the start date is before an other given date.
+     * (Rather start/end are included by options is ignored.)
      *
      * @param mixed $date
      *
@@ -1886,6 +1912,7 @@ class CarbonPeriod implements Iterator, Countable
 
     /**
      * Determines if the start date is before or the same as a given date.
+     * (Rather start/end are included by options is ignored.)
      *
      * @param mixed $date
      *
@@ -1898,6 +1925,7 @@ class CarbonPeriod implements Iterator, Countable
 
     /**
      * Determines if the start date is after an other given date.
+     * (Rather start/end are included by options is ignored.)
      *
      * @param mixed $date
      *
@@ -1910,6 +1938,7 @@ class CarbonPeriod implements Iterator, Countable
 
     /**
      * Determines if the start date is after or the same as a given date.
+     * (Rather start/end are included by options is ignored.)
      *
      * @param mixed $date
      *
@@ -1922,6 +1951,7 @@ class CarbonPeriod implements Iterator, Countable
 
     /**
      * Determines if the start date is the same as a given date.
+     * (Rather start/end are included by options is ignored.)
      *
      * @param mixed $date
      *
@@ -1934,6 +1964,7 @@ class CarbonPeriod implements Iterator, Countable
 
     /**
      * Determines if the end date is before an other given date.
+     * (Rather start/end are included by options is ignored.)
      *
      * @param mixed $date
      *
@@ -1946,6 +1977,7 @@ class CarbonPeriod implements Iterator, Countable
 
     /**
      * Determines if the end date is before or the same as a given date.
+     * (Rather start/end are included by options is ignored.)
      *
      * @param mixed $date
      *
@@ -1958,6 +1990,7 @@ class CarbonPeriod implements Iterator, Countable
 
     /**
      * Determines if the end date is after an other given date.
+     * (Rather start/end are included by options is ignored.)
      *
      * @param mixed $date
      *
@@ -1970,6 +2003,7 @@ class CarbonPeriod implements Iterator, Countable
 
     /**
      * Determines if the end date is after or the same as a given date.
+     * (Rather start/end are included by options is ignored.)
      *
      * @param mixed $date
      *
@@ -1982,6 +2016,7 @@ class CarbonPeriod implements Iterator, Countable
 
     /**
      * Determines if the end date is the same as a given date.
+     * (Rather start/end are included by options is ignored.)
      *
      * @param mixed $date
      *
@@ -1994,30 +2029,33 @@ class CarbonPeriod implements Iterator, Countable
 
     /**
      * Return true if start date is now or later.
+     * (Rather start/end are included by options is ignored.)
      *
      * @return bool
      */
-    public function isStarted()
+    public function isStarted(): bool
     {
         return $this->startsBeforeOrAt();
     }
 
     /**
      * Return true if end date is now or later.
+     * (Rather start/end are included by options is ignored.)
      *
      * @return bool
      */
-    public function isEnded()
+    public function isEnded(): bool
     {
         return $this->endsBeforeOrAt();
     }
 
     /**
      * Return true if now is between start date (included) and end date (excluded).
+     * (Rather start/end are included by options is ignored.)
      *
      * @return bool
      */
-    public function isInProgress()
+    public function isInProgress(): bool
     {
         return $this->isStarted() && !$this->isEnded();
     }
@@ -2133,5 +2171,32 @@ class CarbonPeriod implements Iterator, Countable
     protected function resolveCarbon($date = null)
     {
         return $this->getStartDate()->nowWithSameTz()->carbonize($date);
+    }
+
+    /**
+     * Specify data which should be serialized to JSON.
+     *
+     * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
+     *
+     * @return CarbonInterface[]
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Return true if the given date is between start and end.
+     *
+     * @param \Carbon\Carbon|\Carbon\CarbonPeriod|\Carbon\CarbonInterval|\DateInterval|\DatePeriod|\DateTimeInterface|string|null $date
+     *
+     * @return bool
+     */
+    public function contains($date = null): bool
+    {
+        $startMethod = 'startsBefore'.($this->isStartIncluded() ? 'OrAt' : '');
+        $endMethod = 'endsAfter'.($this->isEndIncluded() ? 'OrAt' : '');
+
+        return $this->$startMethod($date) && $this->$endMethod($date);
     }
 }

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -2209,7 +2209,7 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
     /**
      * Resolve passed arguments or DatePeriod to a CarbonPeriod object.
      *
-     * @param mixin $period
+     * @param mixed $period
      * @param mixed ...$arguments
      *
      * @return static

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -1899,7 +1899,7 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
             && $this->getDateInterval()->eq($period->getDateInterval())
             && $this->getStartDate()->eq($period->getStartDate())
             && $this->getEndDate()->eq($period->getEndDate())
-            && $this->getOptions() === $period->getOptions();
+            && ($this->getOptions() & (~static::IMMUTABLE)) === ($period->getOptions() & (~static::IMMUTABLE));
     }
 
     /**

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -2207,6 +2207,25 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
     }
 
     /**
+     * Resolve passed arguments or DatePeriod to a CarbonPeriod object.
+     *
+     * @param mixin $period
+     * @param mixed ...$arguments
+     *
+     * @return static
+     */
+    protected function resolveCarbonPeriod($period, ...$arguments)
+    {
+        if ($period instanceof self) {
+            return $period;
+        }
+
+        return $period instanceof DatePeriod
+            ? static::instance($period)
+            : static::create($period, ...$arguments);
+    }
+
+    /**
      * Specify data which should be serialized to JSON.
      *
      * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
@@ -2244,11 +2263,7 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
      */
     public function follows($period, ...$arguments): bool
     {
-        if (!($period instanceof self)) {
-            $period = $period instanceof DatePeriod
-                ? static::instance($period)
-                : static::create($period, ...$arguments);
-        }
+        $period = $this->resolveCarbonPeriod($period, ...$arguments);
 
         return $this->getIncludedStartDate()->equalTo($period->getIncludedEndDate()->add($period->getDateInterval()));
     }
@@ -2264,11 +2279,7 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
      */
     public function isFollowedBy($period, ...$arguments): bool
     {
-        if (!($period instanceof self)) {
-            $period = $period instanceof DatePeriod
-                ? static::instance($period)
-                : static::create($period, ...$arguments);
-        }
+        $period = $this->resolveCarbonPeriod($period, ...$arguments);
 
         return $period->follows($this);
     }

--- a/tests/CarbonPeriod/ComparisonTest.php
+++ b/tests/CarbonPeriod/ComparisonTest.php
@@ -142,4 +142,23 @@ class ComparisonTest extends AbstractTestCase
         $this->assertTrue(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsAt('2020-02-01'));
         $this->assertFalse(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsAt('2020-01-05'));
     }
+
+    public function testContains()
+    {
+        $period = CarbonPeriod::create('2019-08-01', '2019-08-10');
+
+        $this->assertFalse($period->contains('2019-07-31 23:59:59'));
+        $this->assertTrue($period->contains('2019-08-01'));
+        $this->assertTrue($period->contains('2019-08-02'));
+        $this->assertTrue($period->contains('2019-08-10'));
+        $this->assertFalse($period->contains('2019-08-10 00:00:01'));
+
+        $period = CarbonPeriod::create('2019-08-01', '2019-08-10', CarbonPeriod::EXCLUDE_START_DATE | CarbonPeriod::EXCLUDE_END_DATE);
+
+        $this->assertFalse($period->contains('2019-08-01'));
+        $this->assertTrue($period->contains('2019-08-01 00:00:01'));
+        $this->assertTrue($period->contains('2019-08-02'));
+        $this->assertTrue($period->contains('2019-08-09 23:59:59'));
+        $this->assertFalse($period->contains('2019-08-10'));
+    }
 }

--- a/tests/CarbonPeriod/ComparisonTest.php
+++ b/tests/CarbonPeriod/ComparisonTest.php
@@ -14,7 +14,9 @@ namespace Tests\CarbonPeriod;
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
 use Carbon\CarbonPeriod;
+use DateInterval;
 use DatePeriod;
+use DateTimeImmutable;
 use Tests\AbstractTestCase;
 
 class ComparisonTest extends AbstractTestCase
@@ -160,5 +162,73 @@ class ComparisonTest extends AbstractTestCase
         $this->assertTrue($period->contains('2019-08-02'));
         $this->assertTrue($period->contains('2019-08-09 23:59:59'));
         $this->assertFalse($period->contains('2019-08-10'));
+    }
+
+    public function testConsecutivePeriods()
+    {
+        $july = CarbonPeriod::create('2019-07-29', '2019-07-31');
+        $august = CarbonPeriod::create('2019-08-01', '2019-08-12');
+
+        $this->assertFalse($july->follows($august));
+        $this->assertTrue($august->follows($july));
+
+        $this->assertTrue($july->isFollowedBy($august));
+        $this->assertFalse($august->isFollowedBy($july));
+
+        $this->assertTrue($july->isConsecutiveWith($august));
+        $this->assertTrue($august->isConsecutiveWith($july));
+
+        $this->assertFalse($july->follows('2019-08-01', '2019-08-12'));
+        $this->assertTrue($august->follows('2019-07-29', '2019-07-31'));
+
+        $this->assertTrue($july->isFollowedBy('2019-08-01', '2019-08-12'));
+        $this->assertFalse($august->isFollowedBy('2019-07-29', '2019-07-31'));
+
+        $this->assertTrue($july->isConsecutiveWith('2019-08-01', '2019-08-12'));
+        $this->assertTrue($august->isConsecutiveWith('2019-07-29', '2019-07-31'));
+
+        $july2 = new DatePeriod(
+            new DateTimeImmutable('2019-07-29'),
+            new DateInterval('P1D'),
+            new DateTimeImmutable('2019-07-31')
+        );
+        $august2 = new DatePeriod(
+            new DateTimeImmutable('2019-08-01'),
+            new DateInterval('P1D'),
+            new DateTimeImmutable('2019-08-12')
+        );
+
+        $this->assertFalse($july->follows($august2));
+        $this->assertTrue($august->follows($july2));
+
+        $this->assertTrue($july->isFollowedBy($august2));
+        $this->assertFalse($august->isFollowedBy($july2));
+
+        $this->assertTrue($july->isConsecutiveWith($august2));
+        $this->assertTrue($august->isConsecutiveWith($july2));
+
+        $july = CarbonPeriod::create('2019-07-29', '2019-08-01');
+        $august = CarbonPeriod::create('2019-08-01', '2019-08-12');
+
+        $this->assertFalse($july->follows($august));
+        $this->assertFalse($august->follows($july));
+
+        $this->assertFalse($july->isFollowedBy($august));
+        $this->assertFalse($august->isFollowedBy($july));
+
+        $this->assertFalse($july->isConsecutiveWith($august));
+        $this->assertFalse($august->isConsecutiveWith($july));
+
+        $july = CarbonPeriod::create('2019-07-29', '2019-07-31', CarbonPeriod::EXCLUDE_END_DATE);
+        $august = CarbonPeriod::create('2019-08-01', '2019-08-12', CarbonPeriod::EXCLUDE_START_DATE);
+
+        $this->assertFalse($july->follows($august));
+        $this->assertFalse($august->follows($july));
+
+        $this->assertFalse($july->isFollowedBy($august));
+        $this->assertFalse($august->isFollowedBy($july));
+
+        $this->assertFalse($july->isConsecutiveWith($august));
+        $this->assertFalse($august->isConsecutiveWith($july));
     }
 }


### PR DESCRIPTION
Add CarbonPeriod methods:
- Fix #1829 Improve CarbonPeriod JSON serialization
- Implement contains()
- Implement getIncludedStartDate()
- Implement getIncludedEndDate()
- Implement follows()
- Implement isFollowedBy()
- Implement isConsecutiveWith()