### PR TITLE
Fix isBefore documentation

### DIFF
--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -2327,7 +2327,7 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
      * @example
      * ```
      * Carbon::parse('2018-07-25 12:45:16')->isBefore('2018-07-25 12:45:16'); // false
-     * Carbon::parse('2018-07-25 12:45:16')->isBefore('2018-07-25 12:45:18'); // false
+     * Carbon::parse('2018-07-25 12:45:16')->isBefore('2018-07-25 12:45:18'); // true
      * Carbon::parse('2018-07-25 12:45:16')->isBefore('2018-07-25 12:45:17'); // true
      * ```
      *


### PR DESCRIPTION
There was an error in the documentation of the function isBefore.

2018-07-25 12:45:16 is before 2018-07-25 12:45:18.