### PR TITLE
Fix Return Type Annotation

### DIFF
--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -1003,7 +1003,7 @@ class CarbonPeriod implements Iterator, Countable
      * Returns true when current date is valid, false if it is not, or static::END_ITERATION
      * when iteration should be stopped.
      *
-     * @return bool|static::END_ITERATION
+     * @return bool|string
      */
     protected function validateCurrentDate()
     {


### PR DESCRIPTION
There seems to be a bug in the return type annotation for `validateCurrentDate`.

This bug crashes `Psalm`. 