### PR TITLE
Add createFromFormat static method to CarbonInterval

### DIFF
--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -484,13 +484,13 @@ class CarbonInterval extends DateInterval
 
         if (preg_match('/s([,.])([uv])$/', $format, $match)) {
             $interval = explode($match[1], $interval);
-            $i = count($interval) - 1;
-            $interval[$i] = str_pad($interval[$i], $match[2] === 'v' ? 3 : 6, '0');
+            $index = count($interval) - 1;
+            $interval[$index] = str_pad($interval[$index], $match[2] === 'v' ? 3 : 6, '0');
             $interval = implode($match[1], $interval);
         }
 
-        for ($i = 0; $i < $length; $i++) {
-            $expected = mb_substr($format, $i, 1);
+        for ($index = 0; $index < $length; $index++) {
+            $expected = mb_substr($format, $index, 1);
             $nextCharacter = mb_substr($interval, 0, 1);
             $unit = static::$formats[$expected] ?? null;
 

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -11,6 +11,7 @@
 namespace Carbon;
 
 use BadMethodCallException;
+use Carbon\Exceptions\ParseErrorException;
 use Carbon\Traits\Mixin;
 use Carbon\Traits\Options;
 use Closure;
@@ -194,6 +195,29 @@ class CarbonInterval extends DateInterval
     protected static $cascadeFactors;
 
     /**
+     * @var array
+     */
+    protected static $formats = [
+        'y' => 'y',
+        'Y' => 'y',
+        'o' => 'y',
+        'm' => 'm',
+        'n' => 'm',
+        'W' => 'weeks',
+        'd' => 'd',
+        'j' => 'd',
+        'z' => 'd',
+        'h' => 'h',
+        'g' => 'h',
+        'H' => 'h',
+        'G' => 'h',
+        'i' => 'i',
+        's' => 's',
+        'u' => 'micro',
+        'v' => 'milli',
+    ];
+
+    /**
      * @var array|null
      */
     private static $flipCascadeFactors;
@@ -293,7 +317,7 @@ class CarbonInterval extends DateInterval
      * @param int|null $seconds
      * @param int|null $microseconds
      *
-     * @throws Exception
+     * @throws Exception when the interval_spec (passed as $years) cannot be parsed as an interval.
      */
     public function __construct($years = 1, $months = null, $weeks = null, $days = null, $hours = null, $minutes = null, $seconds = null, $microseconds = null)
     {
@@ -429,6 +453,8 @@ class CarbonInterval extends DateInterval
      * @param int $seconds
      * @param int $microseconds
      *
+     * @throws Exception when the interval_spec (passed as $years) cannot be parsed as an interval.
+     *
      * @return static
      */
     public static function create($years = 1, $months = null, $weeks = null, $days = null, $hours = null, $minutes = null, $seconds = null, $microseconds = null)
@@ -447,13 +473,58 @@ class CarbonInterval extends DateInterval
      * @param string $format   Format of the $interval input string
      * @param string $interval Input string to convert into an interval
      *
+     * @throws Exception when the $interval cannot be parsed as an interval.
+     *
      * @return static
      */
     public static function createFromFormat(string $format, ?string $interval)
     {
-        return Carbon::createFromFormat('!'.ltrim($format, '!'), $interval, 'UTC')->diffAsCarbonInterval(
-            Carbon::parse('1970-01-01 00:00:00', 'UTC')
-        );
+        $instance = new static(0);
+        $length = mb_strlen($format);
+
+        if (preg_match('/s([,.])([uv])$/', $format, $match)) {
+            $interval = explode($match[1], $interval);
+            $i = count($interval) - 1;
+            $interval[$i] = str_pad($interval[$i], $match[2] === 'v' ? 3 : 6, '0');
+            $interval = implode($match[1], $interval);
+        }
+
+        for ($i = 0; $i < $length; $i++) {
+            $expected = mb_substr($format, $i, 1);
+            $nextCharacter = mb_substr($interval, 0, 1);
+            $unit = static::$formats[$expected] ?? null;
+
+            if ($unit) {
+                if (!preg_match('/^-?\d+/', $interval, $match)) {
+                    throw new ParseErrorException('number', $nextCharacter);
+                }
+
+                $interval = mb_substr($interval, mb_strlen($match[0]));
+                $instance->$unit += intval($match[0]);
+
+                continue;
+            }
+
+            if ($nextCharacter !== $expected) {
+                throw new ParseErrorException(
+                    "'$expected'",
+                    $nextCharacter,
+                    'Allowed substitutes for interval formats are '.implode(', ', array_keys(static::$formats))."\n".
+                    'See https://www.php.net/manual/en/function.date.php for their meaning'
+                );
+            }
+
+            $interval = mb_substr($interval, 1);
+        }
+
+        if ($interval !== '') {
+            throw new ParseErrorException(
+                'end of string',
+                $interval
+            );
+        }
+
+        return $instance;
     }
 
     /**

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -444,8 +444,8 @@ class CarbonInterval extends DateInterval
      * echo Carboninterval::createFromFormat('H:i', '1:30');
      * ```
      *
-     * @param string $format
-     * @param string $interval
+     * @param string $format   Format of the $interval input string
+     * @param string $interval Input string to convert into an interval
      *
      * @return static
      */

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -439,12 +439,17 @@ class CarbonInterval extends DateInterval
     /**
      * Parse a string into a new CarbonInterval object according to the specified format.
      *
+     * @example
+     * ```
+     * echo Carboninterval::createFromFormat('H:i', '1:30');
+     * ```
+     *
      * @param string $format
      * @param string $interval
      *
-     * @return void
+     * @return static
      */
-    public static function createFromFormat(string $format, string $interval)
+    public static function createFromFormat(string $format, ?string $interval)
     {
         return Carbon::createFromFormat('!'.ltrim($format, '!'), $interval, 'UTC')->diffAsCarbonInterval(
             Carbon::parse('1970-01-01 00:00:00', 'UTC')

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -437,6 +437,21 @@ class CarbonInterval extends DateInterval
     }
 
     /**
+     * Parse a string into a new CarbonInterval object according to the specified format.
+     *
+     * @param string $format
+     * @param string $interval
+     *
+     * @return void
+     */
+    public static function createFromFormat(string $format, string $interval)
+    {
+        return Carbon::createFromFormat('!'.ltrim($format, '!'), $interval, 'UTC')->diffAsCarbonInterval(
+            Carbon::parse('1970-01-01 00:00:00', 'UTC')
+        );
+    }
+
+    /**
      * Get a copy of the instance.
      *
      * @return static

--- a/src/Carbon/Exceptions/ParseErrorException.php
+++ b/src/Carbon/Exceptions/ParseErrorException.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Exceptions;
+
+use Exception;
+use InvalidArgumentException;
+
+class ParseErrorException extends InvalidArgumentException
+{
+    /**
+     * Constructor.
+     *
+     * @param string          $expected
+     * @param string          $actual
+     * @param int             $code
+     * @param \Exception|null $previous
+     */
+    public function __construct($expected, $actual, $help = '', $code = 0, Exception $previous = null)
+    {
+        $actual = $actual === '' ? 'data is missing' : "get '$actual'";
+
+        parent::__construct(trim("Format expected $expected but $actual\n$help"), $code, $previous);
+    }
+}

--- a/tests/CarbonInterval/CreateFromFormatTest.php
+++ b/tests/CarbonInterval/CreateFromFormatTest.php
@@ -1,0 +1,124 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\CarbonInterval;
+
+use Carbon\CarbonInterval;
+use Tests\AbstractTestCase;
+
+class CreateFromFormatTest extends AbstractTestCase
+{
+
+    public function testDefaults()
+    {
+        $ci = CarbonInterval::createFromFormat('H:i:s', '');
+        $this->assertInstanceOfCarbonInterval($ci);
+        $this->assertCarbonInterval($ci, 1, 0, 0, 0, 0, 0);
+    }
+
+    public function testNulls()
+    {
+        $ci = CarbonInterval::createFromFormat('H:i:s', null);
+        $this->assertCarbonInterval($ci, 0, 0, 0, 0, 0, 0);
+    }
+
+    public function testYears()
+    {
+        $ci = CarbonInterval::createFromFormat('Y', '1');
+        $this->assertInstanceOfCarbonInterval($ci);
+        $this->assertCarbonInterval($ci, 1, 0, 0, 0, 0, 0);
+
+        $ci = CarbonInterval::createFromFormat('Y', '2');
+        $this->assertInstanceOfCarbonInterval($ci);
+        $this->assertCarbonInterval($ci, 2, 0, 0, 0, 0, 0);
+    }
+
+    public function testMonths()
+    {
+        $ci = CarbonInterval::createFromFormat('m', '1');
+        $this->assertInstanceOfCarbonInterval($ci);
+        $this->assertCarbonInterval($ci, 0, 1, 0, 0, 0, 0);
+
+        $ci = CarbonInterval::createFromFormat('m', '2');
+        $this->assertInstanceOfCarbonInterval($ci);
+        $this->assertCarbonInterval($ci, 0, 2, 0, 0, 0, 0);
+    }
+
+    public function testDays()
+    {
+        $ci = CarbonInterval::createFromFormat('d', '1');
+        $this->assertInstanceOfCarbonInterval($ci);
+        $this->assertCarbonInterval($ci, 0, 0, 1, 0, 0, 0);
+
+        $ci = CarbonInterval::createFromFormat('d', '2');
+        $this->assertInstanceOfCarbonInterval($ci);
+        $this->assertCarbonInterval($ci, 0, 0, 2, 0, 0, 0);
+    }
+
+    public function testHours()
+    {
+        $ci = CarbonInterval::createFromFormat('H', '1');
+        $this->assertInstanceOfCarbonInterval($ci);
+        $this->assertCarbonInterval($ci, 0, 0, 0, 1, 0, 0);
+
+        $ci = CarbonInterval::createFromFormat('H', '2');
+        $this->assertInstanceOfCarbonInterval($ci);
+        $this->assertCarbonInterval($ci, 0, 0, 0, 2, 0, 0);
+    }
+
+    public function testMinutes()
+    {
+        $ci = CarbonInterval::createFromFormat('i', '1');
+        $this->assertInstanceOfCarbonInterval($ci);
+        $this->assertCarbonInterval($ci, 0, 0, 0, 0, 1, 0);
+
+        $ci = CarbonInterval::createFromFormat('i', '2');
+        $this->assertInstanceOfCarbonInterval($ci);
+        $this->assertCarbonInterval($ci, 0, 0, 0, 0, 2, 0);
+    }
+
+    public function testSeconds()
+    {
+        $ci = CarbonInterval::createFromFormat('s', '1');
+        $this->assertInstanceOfCarbonInterval($ci);
+        $this->assertCarbonInterval($ci, 0, 0, 0, 0, 0, 1);
+
+        $ci = CarbonInterval::createFromFormat('s', '2');
+        $this->assertCarbonInterval($ci, 0, 0, 0, 0, 0, 2);
+    }
+
+    public function testMicroseconds()
+    {
+        $ci = CarbonInterval::createFromFormat('u', '1');
+        $this->assertInstanceOfCarbonInterval($ci);
+        $this->assertCarbonInterval($ci, 0, 0, 0, 0, 0, 0, 100000);
+        $this->assertSame(2, $ci->microseconds);
+
+        $ci = CarbonInterval::createFromFormat('u', '2');
+        $this->assertInstanceOfCarbonInterval($ci);
+        $this->assertCarbonInterval($ci, 0, 0, 0, 0, 0, 0, 200000);
+    }
+
+    public function testAll()
+    {
+        $ci = CarbonInterval::createFromFormat('Y-m-d H:i:s.u', '2000-01-02 3:04:05.5');
+        $this->assertInstanceOfCarbonInterval($ci);
+        $this->assertCarbonInterval($ci, 2000, 1, 2, 3, 4, 5, 500000);
+    }
+
+    public function testCopy()
+    {
+        $one = CarbonInterval::createFromFormat('H:i:s', '10:10:10');
+        $two = $one->copy()->hours(3)->minutes(3)->seconds(3);
+        $this->assertCarbonInterval($one, 0, 0, 0, 10, 10, 10);
+        $this->assertCarbonInterval($two, 0, 0, 0,  3,  3,  3);
+    }
+}

--- a/tests/CarbonInterval/CreateFromFormatTest.php
+++ b/tests/CarbonInterval/CreateFromFormatTest.php
@@ -19,15 +19,16 @@ class CreateFromFormatTest extends AbstractTestCase
 
     public function testDefaults()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Data missing');
         $ci = CarbonInterval::createFromFormat('H:i:s', '');
-        $this->assertInstanceOfCarbonInterval($ci);
-        $this->assertCarbonInterval($ci, 1, 0, 0, 0, 0, 0);
     }
 
     public function testNulls()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Data missing');
         $ci = CarbonInterval::createFromFormat('H:i:s', null);
-        $this->assertCarbonInterval($ci, 0, 0, 0, 0, 0, 0);
     }
 
     public function testYears()

--- a/tests/CarbonInterval/CreateFromFormatTest.php
+++ b/tests/CarbonInterval/CreateFromFormatTest.php
@@ -16,19 +16,18 @@ use Tests\AbstractTestCase;
 
 class CreateFromFormatTest extends AbstractTestCase
 {
-
     public function testDefaults()
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Data missing');
-        $ci = CarbonInterval::createFromFormat('H:i:s', '');
+        CarbonInterval::createFromFormat('H:i:s', '');
     }
 
     public function testNulls()
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Data missing');
-        $ci = CarbonInterval::createFromFormat('H:i:s', null);
+        CarbonInterval::createFromFormat('H:i:s', null);
     }
 
     public function testYears()
@@ -120,6 +119,6 @@ class CreateFromFormatTest extends AbstractTestCase
         $one = CarbonInterval::createFromFormat('H:i:s', '10:10:10');
         $two = $one->copy()->hours(3)->minutes(3)->seconds(3);
         $this->assertCarbonInterval($one, 0, 0, 0, 10, 10, 10);
-        $this->assertCarbonInterval($two, 0, 0, 0,  3,  3,  3);
+        $this->assertCarbonInterval($two, 0, 0, 0, 3, 3, 3);
     }
 }

--- a/tests/CarbonInterval/CreateFromFormatTest.php
+++ b/tests/CarbonInterval/CreateFromFormatTest.php
@@ -76,40 +76,40 @@ class CreateFromFormatTest extends AbstractTestCase
 
     public function testMinutes()
     {
-        $ci = CarbonInterval::createFromFormat('i', '1');
+        $ci = CarbonInterval::createFromFormat('i', '01');
         $this->assertInstanceOfCarbonInterval($ci);
         $this->assertCarbonInterval($ci, 0, 0, 0, 0, 1, 0);
 
-        $ci = CarbonInterval::createFromFormat('i', '2');
+        $ci = CarbonInterval::createFromFormat('i', '02');
         $this->assertInstanceOfCarbonInterval($ci);
         $this->assertCarbonInterval($ci, 0, 0, 0, 0, 2, 0);
     }
 
     public function testSeconds()
     {
-        $ci = CarbonInterval::createFromFormat('s', '1');
+        $ci = CarbonInterval::createFromFormat('s', '01');
         $this->assertInstanceOfCarbonInterval($ci);
         $this->assertCarbonInterval($ci, 0, 0, 0, 0, 0, 1);
 
-        $ci = CarbonInterval::createFromFormat('s', '2');
+        $ci = CarbonInterval::createFromFormat('s', '02');
         $this->assertCarbonInterval($ci, 0, 0, 0, 0, 0, 2);
     }
 
     public function testMicroseconds()
     {
-        $ci = CarbonInterval::createFromFormat('u', '1');
+        $ci = CarbonInterval::createFromFormat('u', '100000');
         $this->assertInstanceOfCarbonInterval($ci);
         $this->assertCarbonInterval($ci, 0, 0, 0, 0, 0, 0, 100000);
         $this->assertSame(2, $ci->microseconds);
 
-        $ci = CarbonInterval::createFromFormat('u', '2');
+        $ci = CarbonInterval::createFromFormat('u', '200000');
         $this->assertInstanceOfCarbonInterval($ci);
         $this->assertCarbonInterval($ci, 0, 0, 0, 0, 0, 0, 200000);
     }
 
     public function testAll()
     {
-        $ci = CarbonInterval::createFromFormat('Y-m-d H:i:s.u', '2000-01-02 3:04:05.5');
+        $ci = CarbonInterval::createFromFormat('Y-m-d H:i:s.u', '2000-01-02 3:04:05.500000');
         $this->assertInstanceOfCarbonInterval($ci);
         $this->assertCarbonInterval($ci, 2000, 1, 2, 3, 4, 5, 500000);
     }


### PR DESCRIPTION
Added `createFromFormat` method to `CarbonInterval`'s core for #1918 .

Useful to handle time interval strings like MySQL `time` field (e.g.: '10:20:00'):
E.g.:
```php
CarbonInterval::createFromFormat('H:i:s', '10:20:00')
```

is equivalent to:
```php
list($hours, $minutes, $seconds) = explode(':', '10:20:00');
new CarbonInterval(0, 0, 0, 0, $hours, $minutes, $seconds);
```
or
```php
CarbonInterval::hours($hours)->minutes($minutes)->seconds($seconds);
```