### PR TITLE
CarbonPeriod and CarbonImmutable not behaving similarly

### DIFF
--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -1446,10 +1446,11 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
         $this->key = 0;
         $this->current = call_user_func([$this->dateClass, 'make'], $this->startDate);
         $settings = $this->getSettings();
-        $locale = $this->getTranslatorLocale();
-        if ($locale) {
-            $settings['locale'] = $locale;
+
+        if ($this->hasLocalTranslator()) {
+            $settings['locale'] = $this->getTranslatorLocale();
         }
+
         $this->current->settings($settings);
         $this->timezone = static::intervalHasTime($this->dateInterval) ? $this->current->getTimezone() : null;
 

--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -99,7 +99,13 @@ trait Creator
         $instance = new static($date->format('Y-m-d H:i:s.u'), $date->getTimezone());
 
         if ($date instanceof CarbonInterface || $date instanceof Options) {
-            $instance->settings($date->getSettings());
+            $settings = $date->getSettings();
+
+            if (!$date->hasLocalTranslator()) {
+                unset($settings['locale']);
+            }
+
+            $instance->settings($settings);
         }
 
         return $instance;

--- a/src/Carbon/Traits/Localization.php
+++ b/src/Carbon/Traits/Localization.php
@@ -138,6 +138,16 @@ trait Localization
     }
 
     /**
+     * Return true if the current instance has its own translator.
+     *
+     * @return bool
+     */
+    public function hasLocalTranslator()
+    {
+        return isset($this->localTranslator);
+    }
+
+    /**
      * Get the translator of the current instance or the default if none set.
      *
      * @return \Symfony\Component\Translation\TranslatorInterface

--- a/tests/CarbonPeriod/ToStringTest.php
+++ b/tests/CarbonPeriod/ToStringTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Tests\CarbonPeriod;
 
 use Carbon\Carbon;
+use Carbon\CarbonImmutable;
 use Carbon\CarbonInterval;
 use Carbon\CarbonPeriod;
 use Tests\AbstractTestCase;
@@ -146,6 +147,25 @@ class ToStringTest extends AbstractTestCase
         $this->assertSame(
             '2015-09-30T00:00:00-04:00/P3DT5H/2015-10-03T00:00:00-04:00',
             $period->spec()
+        );
+    }
+
+    public function testStartOfWeekForPeriod()
+    {
+        $sunday = CarbonImmutable::parse('2019-12-01');
+
+        $period = CarbonPeriod::create($sunday->startOfWeek(), '1 week', $sunday->endOfWeek())->toArray();
+
+        $formattedSunday = $sunday->startOfWeek()->format('Y-m-d H:i:s');
+
+        $this->assertSame(
+            '2019-11-25 00:00:00',
+            $formattedSunday
+        );
+
+        $this->assertSame(
+            $formattedSunday,
+            $period[0]->toImmutable()->startOfWeek()->format('Y-m-d H:i:s')
         );
     }
 }


### PR DESCRIPTION
This Pull Request is in the form of Help Wanted / Possible Bug report.

I recently noticed that when using `CarbonPeriod` and Carbon, they differ in configuration of when the week start (Monday vs Sunday) causing inconsistency. I'm looking for help on validating whether there's something I can do to fix this issue or if it's actually a bug that would need to be addressed in Carbon itself.

The use case:

Parsing the date **2019-12-01** and asking for the first day of the Week, by default, returns **2019-11-25**, which is the Monday of said Week. Using CarbonPeriod to make an array of weeks will give an array of Carbon instances that are differently configured and will consider **Sunday** as the first day of the week. When asking for the first day of the week from **2019-11-25**, it further reduces 1 day to 24th of November (Sunday).

- Is there a way to instruct CarbonPeriod to be consistent with default Carbon settings?
- Is this something I can do while looping through each row of Carbon Period?
- Is this something worth investigating inside Carbon itself?

Thanks!