### PR TITLE
Fixed serialization issue

### DIFF
--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -32,6 +32,8 @@ use InvalidArgumentException;
  */
 trait Creator
 {
+    use ObjectInitialisation;
+
     /**
      * The errors that can occur.
      *
@@ -73,6 +75,8 @@ trait Creator
         }
 
         parent::__construct($time ?: 'now', static::safeCreateDateTimeZone($tz));
+
+        $this->isDateTimeInitialised = true;
 
         if (isset($locale)) {
             setlocale(LC_NUMERIC, $locale);

--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -76,7 +76,7 @@ trait Creator
 
         parent::__construct($time ?: 'now', static::safeCreateDateTimeZone($tz));
 
-        $this->isDateTimeInitialised = true;
+        $this->isDateTimeInitialised = spl_object_hash($this);
 
         if (isset($locale)) {
             setlocale(LC_NUMERIC, $locale);

--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -76,7 +76,7 @@ trait Creator
 
         parent::__construct($time ?: 'now', static::safeCreateDateTimeZone($tz));
 
-        $this->isDateTimeInitialised = spl_object_hash($this);
+        $this->constructedObjectId = spl_object_hash($this);
 
         if (isset($locale)) {
             setlocale(LC_NUMERIC, $locale);

--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -1042,6 +1042,7 @@ trait Date
     {
         if ($this->constructedObjectId === spl_object_hash($this)) {
             $this->set($name, $value);
+            return;
         }
 
         $this->$name = $value;

--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -1040,11 +1040,11 @@ trait Date
      */
     public function __set($name, $value)
     {
-        if (!$this->isDateTimeInitialised) {
-            $this->$name = $value;
-            return;
+        if ($this->isDateTimeInitialised === spl_object_hash($this)) {
+            $this->set($name, $value);
         }
-        $this->set($name, $value);
+
+        $this->$name = $value;
     }
 
     /**

--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -1040,7 +1040,7 @@ trait Date
      */
     public function __set($name, $value)
     {
-        if ($this->isDateTimeInitialised === spl_object_hash($this)) {
+        if ($this->constructedObjectId === spl_object_hash($this)) {
             $this->set($name, $value);
         }
 

--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -525,6 +525,7 @@ trait Date
     use Macro;
     use Modifiers;
     use Mutability;
+    use ObjectInitialisation;
     use Options;
     use Rounding;
     use Serialization;
@@ -1039,6 +1040,10 @@ trait Date
      */
     public function __set($name, $value)
     {
+        if (!$this->isDateTimeInitialised) {
+            $this->$name = $value;
+            return;
+        }
         $this->set($name, $value);
     }
 

--- a/src/Carbon/Traits/ObjectInitialisation.php
+++ b/src/Carbon/Traits/ObjectInitialisation.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Traits;
+
+
+trait ObjectInitialisation
+{
+    /**
+     * @var bool
+     */
+    protected $isDateTimeInitialised = false;
+}

--- a/src/Carbon/Traits/ObjectInitialisation.php
+++ b/src/Carbon/Traits/ObjectInitialisation.php
@@ -14,7 +14,7 @@ namespace Carbon\Traits;
 trait ObjectInitialisation
 {
     /**
-     * @var bool
+     * @var string
      */
-    protected $isDateTimeInitialised = false;
+    protected $isDateTimeInitialised = null;
 }

--- a/src/Carbon/Traits/ObjectInitialisation.php
+++ b/src/Carbon/Traits/ObjectInitialisation.php
@@ -16,5 +16,5 @@ trait ObjectInitialisation
     /**
      * @var string
      */
-    protected $isDateTimeInitialised = null;
+    protected $constructedObjectId = null;
 }

--- a/src/Carbon/Traits/Serialization.php
+++ b/src/Carbon/Traits/Serialization.php
@@ -31,6 +31,8 @@ use InvalidArgumentException;
  */
 trait Serialization
 {
+    use ObjectInitialisation;
+
     /**
      * The custom Carbon JSON serializer.
      *
@@ -120,6 +122,8 @@ trait Serialization
         if (get_parent_class() && method_exists(parent::class, '__wakeup')) {
             parent::__wakeup();
         }
+
+        $this->isDateTimeInitialised = true;
 
         if (isset($this->dumpLocale)) {
             $this->locale($this->dumpLocale);

--- a/src/Carbon/Traits/Serialization.php
+++ b/src/Carbon/Traits/Serialization.php
@@ -123,7 +123,7 @@ trait Serialization
             parent::__wakeup();
         }
 
-        $this->isDateTimeInitialised = spl_object_hash($this);
+        $this->constructedObjectId = spl_object_hash($this);
 
         if (isset($this->dumpLocale)) {
             $this->locale($this->dumpLocale);

--- a/src/Carbon/Traits/Serialization.php
+++ b/src/Carbon/Traits/Serialization.php
@@ -123,7 +123,7 @@ trait Serialization
             parent::__wakeup();
         }
 
-        $this->isDateTimeInitialised = true;
+        $this->isDateTimeInitialised = spl_object_hash($this);
 
         if (isset($this->dumpLocale)) {
             $this->locale($this->dumpLocale);

--- a/tests/Carbon/SerializationTest.php
+++ b/tests/Carbon/SerializationTest.php
@@ -78,4 +78,17 @@ class SerializationTest extends AbstractTestCase
 
         Carbon::fromSerialized($value);
     }
+
+    public function testNewInstanceWithoutConstructor()
+    {
+        $d = (new \ReflectionClass(Carbon::class))->newInstanceWithoutConstructor();
+
+        $d->date = '1990-01-17 10:28:07';
+        $d->timezone_type = 3;
+        $d->timezone = 'US/Pacific';
+
+        $x = unserialize(serialize($d));
+
+        $this->assertSame('1990-01-17 10:28:07', $x->format('Y-m-d h:i:s'));
+    }
 }


### PR DESCRIPTION
A `Carbon` object can be obtained in 3 ways:
- using the `new` keyword 
- using the `newInstanceWithoutConstructor` method
- using the `unserialize` function

I've added a new property called `isDateTimeInitialised` that will tell us if a Carbon object has been initialised or not. The only time when the object is not initialised is when the `newInstanceWithoutConstructor` is used to obtain the object. 

When setting a property, checking if the object was initialised or not is done in the `__set` method. This is simply because we need to be able to serialize imutable objects too.
