### PR TITLE
#2002 Fix CarbonInterval not honoring toStringFormat setting.

### DIFF
--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -1654,7 +1654,7 @@ class CarbonInterval extends DateInterval
      */
     public function __toString()
     {
-        return $this->forHumans();
+        return $this->localToStringFormat ? $this->format($this->localToStringFormat) : $this->forHumans();
     }
 
     /**

--- a/tests/CarbonInterval/ToStringTest.php
+++ b/tests/CarbonInterval/ToStringTest.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\CarbonInterval;
+
+use Carbon\CarbonInterval;
+use Tests\AbstractTestCase;
+
+class ToStringTest extends AbstractTestCase
+{
+    public function testDefault()
+    {
+        CarbonInterval::setLocale('en');
+        $ci = CarbonInterval::create(11, 1, 2, 5, 22, 33, 55);
+        $this->assertSame('11 years 1 month 2 weeks 5 days 22 hours 33 minutes 55 seconds:abc', $ci.':abc');
+    }
+
+    public function testDefaultWithMicroseconds()
+    {
+        CarbonInterval::setLocale('en');
+        $ci = CarbonInterval::create(11, 1, 2, 5, 22, 33, 55, 12345);
+        $this->assertSame('11 years 1 month 2 weeks 5 days 22 hours 33 minutes 55 seconds:abc', $ci.':abc');
+    }
+
+    public function testOverrideSimple()
+    {
+        $ci = CarbonInterval::create(0, 0, 0, 0, 22, 33, 55);
+        $ci->settings(['toStringFormat' => '%H:%I:%S']);
+        $this->assertSame('22:33:55:abc', $ci.':abc');
+    }
+
+    public function testOverrideWithMicroseconds()
+    {
+        $ci = CarbonInterval::create(11, 1, 2, 5, 22, 33, 55, 12345);
+        $ci->settings(['toStringFormat' => '%R%Y-%M-%D %H:%I:%S.%F']);
+        $this->assertSame('+11-01-19 22:33:55.012345:abc', $ci.':abc');
+    }
+
+    public function testOverrideWithInvert()
+    {
+        $ci = CarbonInterval::create(11, 1, 2, 5, 22, 33, 55)->invert();
+        $ci->settings(['toStringFormat' => '%R%Y-%M-%D %H:%I:%S']);
+        $this->assertSame('-11-01-19 22:33:55:abc', $ci.':abc');
+    }
+}


### PR DESCRIPTION
Complete with tests (second attempt).