### PR TITLE
createFromFormat may also return false (Carbon\CarbonImmutable)

### DIFF
--- a/src/Carbon/CarbonImmutable.php
+++ b/src/Carbon/CarbonImmutable.php
@@ -501,7 +501,7 @@ use DateTimeImmutable;
  * @method        string                 shortRelativeToOtherDiffForHumans(\DateTimeInterface $other = null, int $parts = 1)   Get the difference (short format, 'RelativeToOther' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
  * @method        string                 longRelativeToOtherDiffForHumans(\DateTimeInterface $other = null, int $parts = 1)    Get the difference (long format, 'RelativeToOther' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
  * @method        static CarbonImmutable createFromMutable(\DateTime $dateTime)                                                Create a new CarbonImmutable object from an immutable date.
- * @method        static CarbonImmutable createFromFormat(string $format, string $time, string|\DateTimeZone $timezone = null) Parse a string into a new CarbonImmutable object according to the specified format.
+ * @method        static CarbonImmutable|false createFromFormat(string $format, string $time, string|\DateTimeZone $timezone = null) Parse a string into a new CarbonImmutable object according to the specified format.
  * @method        static CarbonImmutable __set_state(array $array)                                                             https://php.net/manual/en/datetime.set-state.php
  *
  * </autodoc>


### PR DESCRIPTION
Fixes vimeo/psalm reporting RedundantConditionGivenDocblockType on `if ($maybeCarbon instanceof Carbon)`  in code that uses Carbon.