### PR TITLE
createFromFormat may also return false (Carbon\Carbon)

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -501,7 +501,7 @@ use DateTime;
  * @method        string         shortRelativeToOtherDiffForHumans(\DateTimeInterface $other = null, int $parts = 1)   Get the difference (short format, 'RelativeToOther' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
  * @method        string         longRelativeToOtherDiffForHumans(\DateTimeInterface $other = null, int $parts = 1)    Get the difference (long format, 'RelativeToOther' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
  * @method        static Carbon  createFromImmutable(\DateTimeImmutable $dateTime)                                     Create a new Carbon object from an immutable date.
- * @method        static Carbon  createFromFormat(string $format, string $time, string|\DateTimeZone $timezone = null) Parse a string into a new Carbon object according to the specified format.
+ * @method        static Carbon|false  createFromFormat(string $format, string $time, string|\DateTimeZone $timezone = null) Parse a string into a new Carbon object according to the specified format.
  * @method        static Carbon  __set_state(array $array)                                                             https://php.net/manual/en/datetime.set-state.php
  *
  * </autodoc>


### PR DESCRIPTION
Fixes vimeo/psalm reporting  RedundantConditionGivenDocblockType on `if ($maybeCarbon instanceof Carbon)` in code that uses Carbon.