### PR TITLE
Skip test when an English locale is unavailable

### DIFF
--- a/tests/Carbon/CreateFromTimestampTest.php
+++ b/tests/Carbon/CreateFromTimestampTest.php
@@ -64,7 +64,9 @@ class CreateFromTimestampTest extends AbstractTestCase
         $this->assertCarbon($d, 1975, 5, 21, 22, 32, 5, 321000);
 
         $locale = setlocale(LC_ALL, '0');
-        setlocale(LC_ALL, 'fr_FR.UTF-8');
+        if (setlocale(LC_ALL, 'fr_FR.UTF-8') === false) {
+            $this->markTestSkipped('testComaDecimalSeparatorLocale test need fr_FR.UTF-8.');
+        }
 
         $timestamp = Carbon::create(1975, 5, 21, 22, 32, 5)->timestamp * 1000 + 321;
         $d = Carbon::createFromTimestampMs($timestamp);

--- a/tests/CarbonImmutable/CreateFromTimestampTest.php
+++ b/tests/CarbonImmutable/CreateFromTimestampTest.php
@@ -64,7 +64,9 @@ class CreateFromTimestampTest extends AbstractTestCase
         $this->assertCarbon($d, 1975, 5, 21, 22, 32, 5, 321000);
 
         $locale = setlocale(LC_ALL, '0');
-        setlocale(LC_ALL, 'fr_FR.UTF-8');
+        if (setlocale(LC_ALL, 'fr_FR.UTF-8') === false) {
+            $this->markTestSkipped('testComaDecimalSeparatorLocale test need fr_FR.UTF-8.');
+        }
 
         $timestamp = Carbon::create(1975, 5, 21, 22, 32, 5)->timestamp * 1000 + 321;
         $d = Carbon::createFromTimestampMs($timestamp);

--- a/tests/Language/TranslatorTest.php
+++ b/tests/Language/TranslatorTest.php
@@ -33,8 +33,10 @@ class TranslatorTest extends AbstractTestCase
         $this->assertSame('en_ISO', $translator->getLocale());
 
         $translator = new Translator('fr');
-        setlocale(LC_ALL, 'en_US.UTF-8', 'en_US.utf8', 'en_US', 'en_GB', 'en');
-        setlocale(LC_TIME, 'en_US.UTF-8', 'en_US.utf8', 'en_US', 'en_GB', 'en');
+        if (setlocale(LC_ALL, 'en_US.UTF-8', 'en_US.utf8', 'en_US', 'en_GB', 'en') === false ||
+            setlocale(LC_TIME, 'en_US.UTF-8', 'en_US.utf8', 'en_US', 'en_GB', 'en') === false) {
+            $this->markTestSkipped('testSetLocale test need en_US.UTF-8.');
+        }
         $translator->setLocale('auto');
 
         $this->assertStringStartsWith('en', $translator->getLocale());


### PR DESCRIPTION
testSetLocale fails in environments lacking the desired English locales.

Other tests that rely on specific locales being available on the system are
skipped if those locales are unavailable.

This change will similarly skip this test if the desired locale is not found.