### PR TITLE
Add method for diffInQuarters

### DIFF
--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -1401,6 +1401,16 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
     public function diffInWeeks($date = null, $absolute = true);
 
     /**
+     * Get the difference in quarters rounded down.
+     *
+     * @param \Carbon\CarbonInterface|\DateTimeInterface|string|null $date
+     * @param bool                                                   $absolute Get the absolute of the difference
+     *
+     * @return int
+     */
+    public function diffInQuarters($date = null, $absolute = true);
+
+    /**
      * Get the difference in years
      *
      * @param \Carbon\CarbonInterface|\DateTimeInterface|string|null $date

--- a/src/Carbon/Traits/Difference.php
+++ b/src/Carbon/Traits/Difference.php
@@ -151,6 +151,19 @@ trait Difference
     }
 
     /**
+     * Get the difference in quarters rounded down.
+     *
+     * @param \Carbon\CarbonInterface|\DateTimeInterface|string|null $date
+     * @param bool                                                   $absolute Get the absolute of the difference
+     *
+     * @return int
+     */
+    public function diffInQuarters($date = null, $absolute = true)
+    {
+        return (int) ($this->diffInMonths($date, $absolute) / static::MONTHS_PER_QUARTER);
+    }
+
+    /**
      * Get the difference in months rounded down.
      *
      * @param \Carbon\CarbonInterface|\DateTimeInterface|string|null $date

--- a/tests/Carbon/DiffTest.php
+++ b/tests/Carbon/DiffTest.php
@@ -64,19 +64,19 @@ class DiffTest extends AbstractTestCase
 
     public function testDiffInQuartersPositive()
     {
-        $dt = Carbon::createFromDate(2000, 1 , 1);
+        $dt = Carbon::createFromDate(2000, 1, 1);
         $this->assertSame(1, $dt->diffInQuarters($dt->copy()->addQuarter()->addDay()));
     }
 
     public function testDiffInQuartersNegativeWithSign()
     {
-        $dt = Carbon::createFromDate(2000, 1 , 1);
+        $dt = Carbon::createFromDate(2000, 1, 1);
         $this->assertSame(-4, $dt->diffInQuarters($dt->copy()->subQuarters(4), false));
     }
 
     public function testDiffInQuartersNegativeWithNoSign()
     {
-        $dt = Carbon::createFromDate(2000, 1 , 1);
+        $dt = Carbon::createFromDate(2000, 1, 1);
         $this->assertSame(4, $dt->diffInQuarters($dt->copy()->subQuarters(4)));
     }
 

--- a/tests/Carbon/DiffTest.php
+++ b/tests/Carbon/DiffTest.php
@@ -62,6 +62,37 @@ class DiffTest extends AbstractTestCase
         $this->assertSame(1, $dt->diffInYears($dt->copy()->addYear()->addMonths(7)));
     }
 
+    public function testDiffInQuartersPositive()
+    {
+        $dt = Carbon::createFromDate(2000, 1 , 1);
+        $this->assertSame(1, $dt->diffInQuarters($dt->copy()->addQuarter()->addDay()));
+    }
+
+    public function testDiffInQuartersNegativeWithSign()
+    {
+        $dt = Carbon::createFromDate(2000, 1 , 1);
+        $this->assertSame(-4, $dt->diffInQuarters($dt->copy()->subQuarters(4), false));
+    }
+
+    public function testDiffInQuartersNegativeWithNoSign()
+    {
+        $dt = Carbon::createFromDate(2000, 1 , 1);
+        $this->assertSame(4, $dt->diffInQuarters($dt->copy()->subQuarters(4)));
+    }
+
+    public function testDiffInQuartersVsDefaultNow()
+    {
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(4, Carbon::now()->subYear()->diffInQuarters());
+        });
+    }
+
+    public function testDiffInQuartersEnsureIsTruncated()
+    {
+        $dt = Carbon::createFromDate(2000, 1, 1);
+        $this->assertSame(1, $dt->diffInQuarters($dt->copy()->addQuarter()->addDays(12)));
+    }
+
     public function testDiffInMonthsPositive()
     {
         $dt = Carbon::createFromDate(2000, 1, 1);


### PR DESCRIPTION
<!--
    🛑 DON'T REMOVE ME.
    This issue template apply to all
      - bug reports,
      - feature proposals,
      - and documentation requests

    Having all those informations will allow us to know exactly
    what you expect and answer you faster and precisely (answer
    that matches your Carbon version, PHP version and usage).
    
    Note: Comments between <!- - and - -> won't appear in the final
    issue (See [Preview] tab).
-->
There currently is no method for getting the difference in quarters of 2 carbon objects. Whereas there are methods for adding and subtracting quarters. This PR implements the "missing" method.
