### PR TITLE
Fix #2036 Short month January translation in de_AT

### DIFF
--- a/src/Carbon/Lang/de_AT.php
+++ b/src/Carbon/Lang/de_AT.php
@@ -21,4 +21,7 @@ return array_replace_recursive(require __DIR__.'/de.php', [
     'months' => [
         0 => 'Jänner',
     ],
+    'months_short' => [
+        0 => 'Jän',
+    ],
 ]);


### PR DESCRIPTION
Jan > Jän for German Austria