### PR TITLE
#2041 Provide Doctrine ORM Carbon types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "symfony/translation": "^3.4 || ^4.0 || ^5.0"
     },
     "require-dev": {
+        "doctrine/orm": "^2.7",
         "friendsofphp/php-cs-fixer": "^2.14 || ^3.0",
         "kylekatarnls/multi-tester": "^1.1",
         "phpmd/phpmd": "^2.8",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,6 +13,7 @@
     <filter>
         <whitelist>
             <directory>src/Carbon</directory>
+            <directory suffix=".php">src/Carbon/Doctrine</directory>
         </whitelist>
     </filter>
 

--- a/src/Carbon/Doctrine/CarbonType.php
+++ b/src/Carbon/Doctrine/CarbonType.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Thanks to https://github.com/flaushi for his suggestion:
+ * https://github.com/doctrine/dbal/issues/2873#issuecomment-534956358
+ */
+namespace Carbon\Doctrine;
+
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
+use DateTimeInterface;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\VarDateTimeImmutableType;
+
+trait CarbonType
+{
+    protected function getCarbonClassName(): string
+    {
+        return Carbon::class;
+    }
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        if ($fieldDeclaration['version'] ?? false) {
+            return 'TIMESTAMP';
+        }
+
+        return $platform instanceof PostgreSqlPlatform
+            ? 'TIMESTAMP(6) WITHOUT TIME ZONE'
+            : 'DATETIME(6)';
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        if ($value === null || $value instanceof CarbonInterface) {
+            return $value;
+        }
+
+        $class = $this->getCarbonClassName();
+
+        if ($value instanceof DateTimeInterface) {
+            return $class::instance($value);
+        }
+
+        $date = $class::createFromFormat('Y-m-d H:i:s.u', $value)
+            ?: $class::instance(date_create($value));
+
+        if (!$date) {
+            throw ConversionException::conversionFailedFormat(
+                $value,
+                $this->getName(),
+                'Y-m-d H:i:s.u'
+            );
+        }
+
+        return $date;
+    }
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        if ($value === null) {
+            return $value;
+        }
+
+        if ($value instanceof DateTimeInterface) {
+            return $value->format('Y-m-d H:i:s.u');
+        }
+
+        throw ConversionException::conversionFailedInvalidType(
+            $value,
+            $this->getName(),
+            ['null', 'DateTime']
+        );
+    }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
+}

--- a/src/Carbon/Doctrine/CarbonType.php
+++ b/src/Carbon/Doctrine/CarbonType.php
@@ -37,6 +37,9 @@ trait CarbonType
         return trim("$before($precision) $after");
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
         if ($value === null || $value instanceof CarbonInterface) {
@@ -63,6 +66,9 @@ trait CarbonType
         return $date;
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
         if ($value === null) {
@@ -80,6 +86,9 @@ trait CarbonType
         );
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {
         return true;

--- a/src/Carbon/Doctrine/DateTimeDefaultPrecision.php
+++ b/src/Carbon/Doctrine/DateTimeDefaultPrecision.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Thanks to https://github.com/flaushi for his suggestion:
+ * https://github.com/doctrine/dbal/issues/2873#issuecomment-534956358
+ */
+namespace Carbon\Doctrine;
+
+class DateTimeDefaultPrecision
+{
+    private static $precision = 6;
+
+    /**
+     * Change the default Doctrine datetime and datetime_immutable precision.
+     *
+     * @param int $precision
+     */
+    public static function set(int $precision): void
+    {
+        self::$precision = $precision;
+    }
+
+    /**
+     * Get the default Doctrine datetime and datetime_immutable precision.
+     *
+     * @return int
+     */
+    public static function get(): int
+    {
+        return self::$precision;
+    }
+}

--- a/src/Carbon/Doctrine/DateTimeImmutableType.php
+++ b/src/Carbon/Doctrine/DateTimeImmutableType.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Thanks to https://github.com/flaushi for his suggestion:
+ * https://github.com/doctrine/dbal/issues/2873#issuecomment-534956358
+ */
+namespace Carbon\Doctrine;
+
+use Carbon\CarbonImmutable;
+use Doctrine\DBAL\Types\VarDateTimeType;
+
+class DateTimeImmutableType extends VarDateTimeType
+{
+    use CarbonType;
+
+    protected function getCarbonClassName(): string
+    {
+        return CarbonImmutable::class;
+    }
+}

--- a/src/Carbon/Doctrine/DateTimeType.php
+++ b/src/Carbon/Doctrine/DateTimeType.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Thanks to https://github.com/flaushi for his suggestion:
+ * https://github.com/doctrine/dbal/issues/2873#issuecomment-534956358
+ */
+namespace Carbon\Doctrine;
+
+use Doctrine\DBAL\Types\VarDateTimeImmutableType;
+
+class DateTimeType extends VarDateTimeImmutableType
+{
+    use CarbonType;
+}

--- a/tests/Carbon/SettersTest.php
+++ b/tests/Carbon/SettersTest.php
@@ -632,7 +632,7 @@ class SettersTest extends AbstractTestCase
         ];
 
         for ($i = 0; $i < static::SET_UNIT_NO_OVERFLOW_SAMPLE; $i++) {
-            $year = mt_rand(2000, 3000);
+            $year = mt_rand(2000, 2500);
             $month = mt_rand(1, 12);
             $day = mt_rand(1, 28);
             $hour = mt_rand(0, 23);


### PR DESCRIPTION
Doctrine ORM (and so Symfony) provides `datetime` and `datetime_immutable` types for `DateTime` and `DateTimeImmutable`.

This PR provides Doctrine types to get dates properties automatically mapped to `Carbon` and `CarbonImmutable` so Symfony users could choose to get every entities dates enhanced with `Carbon` methods (or use a custom type name to enable it on demand).

Usage: add types to **config/packages/doctrine.yaml**:
```yaml
doctrine:
    dbal:
        types:
            datetime_immutable: \Carbon\Doctrine\DateTimeImmutableType
            datetime: \Carbon\Doctrine\DateTimeType
```

Credits: https://github.com/doctrine/dbal/issues/2873#issuecomment-534956358

To be noted:
- This implementation will also allow to set a custom precision for a given property using annotation: `ORM\Column(type="datetime", precision=3)` although we recommend to rather apply the precision globally for consistency.
- Those types will use microsecond-precision as the default because the current default precision of Doctrine date types (second) is not enough in many cases, default precision can be changed using `\Carbon\Doctrine\DateTimeDefaultPrecision::set($newPrecision)` where `$newPrecision` is the number of digits of the second decimal part.
- Due to a limitation in Doctrine, it won't be possible to set the precision of a particular property to 0 (unless the default precision itself is set to 0)

Fix #2041