### PR TITLE
Fix doctrine orm carbon type

### DIFF
--- a/src/Carbon/Doctrine/CarbonType.php
+++ b/src/Carbon/Doctrine/CarbonType.php
@@ -52,8 +52,7 @@ trait CarbonType
             return $class::instance($value);
         }
 
-        $date = $class::createFromFormat('Y-m-d H:i:s.u', $value)
-            ?: $class::instance(date_create($value));
+        $date = $class::parse($value);
 
         if (!$date) {
             throw ConversionException::conversionFailedFormat(


### PR DESCRIPTION
Hello, 

When I tried the new carbon type, I got a "Data missing".

This is due to postgres not using the 'Y-m-d H:i:s.u' format but 'Y-m-d H:i:s' when microseconds are set to zero.

The solution is based on this comment :
https://github.com/doctrine/dbal/issues/2873#issuecomment-535452749