### PR TITLE
Add ext-mbstring to requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "require": {
         "php": "^7.1.8 || ^8.0",
         "ext-json": "*",
+        "ext-mbstring": "*",
         "symfony/translation": "^3.4 || ^4.0 || ^5.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require": {
         "php": "^7.1.8 || ^8.0",
         "ext-json": "*",
-        "ext-mbstring": "*",
+        "symfony/polyfill-mbstring": "^1.0",
         "symfony/translation": "^3.4 || ^4.0 || ^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
Since Carbon is using mb_ functions this should be in the composer.json to make sure the mbstring extension is installed. 

(And also, for my personal sanity when browsing the code in PHPStorm)