### PR TITLE
Fix static analyses of Carbon

### DIFF
--- a/src/Carbon/Traits/Rounding.php
+++ b/src/Carbon/Traits/Rounding.php
@@ -23,7 +23,7 @@ use InvalidArgumentException;
  * Depends on the following methods:
  *
  * @method CarbonInterface copy()
- * @method CarbonInterface startOfWeek()
+ * @method CarbonInterface startOfWeek(int $weekStartsAt = null)
  */
 trait Rounding
 {


### PR DESCRIPTION
The current update of Larastan started emitting a new error (as reported here https://github.com/nunomaduro/larastan/issues/541). Making the method signature consistent with the Interface could fix the problem.