### PR TITLE
Georgian typo and grammar

### DIFF
--- a/src/Carbon/Lang/ka.php
+++ b/src/Carbon/Lang/ka.php
@@ -22,6 +22,7 @@
  * - JD Isaacks
  * - LONGMAN
  * - Avtandil Kikabidze (akalongman)
+ * - Levan Velijanashvili (Stichoza)
  */
 return [
     'year' => ':count წელი',
@@ -118,7 +119,7 @@ return [
             // month
             'თვე' => 'თვის',
             // week
-            'კვირი' => 'კვირის',
+            'კვირა' => 'კვირის',
             // day
             'დღე' => 'დღის',
             // hour
@@ -131,7 +132,7 @@ return [
         $time = strtr($time, array_flip($replacements));
         $time = strtr($time, $replacements);
 
-        return "$time უკან";
+        return "$time წინ";
     },
     'diff_now' => 'ახლა',
     'diff_yesterday' => 'გუშინ',

--- a/src/Carbon/Lang/ka.php
+++ b/src/Carbon/Lang/ka.php
@@ -115,24 +115,24 @@ return [
     'before' => function ($time) {
         $replacements = [
             // year
-            'წელი' => 'წლის',
+            'წელი' => 'წლით',
             // month
-            'თვე' => 'თვის',
+            'თვე' => 'თვით',
             // week
-            'კვირა' => 'კვირის',
+            'კვირა' => 'კვირით',
             // day
-            'დღე' => 'დღის',
+            'დღე' => 'დღით',
             // hour
-            'საათი' => 'საათის',
+            'საათი' => 'საათით',
             // minute
-            'წუთი' => 'წუთის',
+            'წუთი' => 'წუთით',
             // second
-            'წამი' => 'წამის',
+            'წამი' => 'წამით',
         ];
         $time = strtr($time, array_flip($replacements));
         $time = strtr($time, $replacements);
 
-        return "$time წინ";
+        return "$time ადრე";
     },
     'diff_now' => 'ახლა',
     'diff_yesterday' => 'გუშინ',

--- a/tests/Localization/KaGeTest.php
+++ b/tests/Localization/KaGeTest.php
@@ -350,11 +350,11 @@ class KaGeTest extends LocalizationTestCase
 
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond())
         // '1 second before',
-        '1 წამის უკან',
+        '1 წამით ადრე',
 
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond(), false, true)
         // '1s before',
-        '1 წამის უკან',
+        '1 წამით ადრე',
 
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now(), true)
         // '1 second',

--- a/tests/Localization/KaTest.php
+++ b/tests/Localization/KaTest.php
@@ -350,11 +350,11 @@ class KaTest extends LocalizationTestCase
 
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond())
         // '1 second before',
-        '1 წამის უკან',
+        '1 წამით ადრე',
 
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond(), false, true)
         // '1s before',
-        '1 წამის უკან',
+        '1 წამით ადრე',
 
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now(), true)
         // '1 second',


### PR DESCRIPTION
 - Typo: replace `კვირი` with `კვირა` causing incorrect translation.
 - Grammar: both "ago" and "before" in Georgian is "წინ". The word "უკან" means *behind*, not *before* and is grammatically incorrect.