### PR TITLE
Type exceptions to catch them more easily

### DIFF
--- a/phpmd.xml
+++ b/phpmd.xml
@@ -33,7 +33,7 @@
     </rule>
     <rule ref="rulesets/design.xml/CouplingBetweenObjects">
         <properties>
-            <property name="maximum" value="20" />
+            <property name="maximum" value="25" />
         </properties>
     </rule>
     <rule ref="rulesets/naming.xml/ShortVariable">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -39,6 +39,9 @@
         <testsuite name="laravel">
             <directory>tests/Laravel</directory>
         </testsuite>
+        <testsuite name="doctrine">
+            <directory>tests/Doctrine</directory>
+        </testsuite>
         <testsuite name="factory">
             <directory>tests/Factory</directory>
         </testsuite>

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -12,7 +12,13 @@ namespace Carbon;
 
 use Carbon\Exceptions\BadFluentConstructorException;
 use Carbon\Exceptions\BadFluentSetterException;
+use Carbon\Exceptions\InvalidCastException;
+use Carbon\Exceptions\InvalidIntervalException;
 use Carbon\Exceptions\ParseErrorException;
+use Carbon\Exceptions\UnitNotConfiguredException;
+use Carbon\Exceptions\UnknownGetterException;
+use Carbon\Exceptions\UnknownSetterException;
+use Carbon\Exceptions\UnknownUnitException;
 use Carbon\Traits\IntervalRounding;
 use Carbon\Traits\Mixin;
 use Carbon\Traits\Options;
@@ -20,6 +26,7 @@ use Closure;
 use DateInterval;
 use Exception;
 use InvalidArgumentException;
+use ReflectionException;
 use Throwable;
 
 /**
@@ -825,7 +832,7 @@ class CarbonInterval extends DateInterval
         $mainClass = DateInterval::class;
 
         if (!is_a($className, $mainClass, true)) {
-            throw new InvalidArgumentException("$className is not a sub-class of $mainClass.");
+            throw new InvalidCastException("$className is not a sub-class of $mainClass.");
         }
 
         $microseconds = $interval->f;
@@ -964,7 +971,7 @@ class CarbonInterval extends DateInterval
      *
      * @param string $name
      *
-     * @throws InvalidArgumentException
+     * @throws UnknownGetterException
      *
      * @return int|float|string
      */
@@ -1012,7 +1019,7 @@ class CarbonInterval extends DateInterval
                 return $this->getTranslatorLocale();
 
             default:
-                throw new InvalidArgumentException(sprintf("Unknown getter '%s'", $name));
+                throw new UnknownGetterException($name);
         }
     }
 
@@ -1022,7 +1029,7 @@ class CarbonInterval extends DateInterval
      * @param string $name
      * @param int    $value
      *
-     * @throws InvalidArgumentException
+     * @throws UnknownSetterException
      */
     public function __set($name, $value)
     {
@@ -1076,7 +1083,7 @@ class CarbonInterval extends DateInterval
 
             default:
                 if ($this->localStrictModeEnabled ?? Carbon::isStrictModeEnabled()) {
-                    throw new InvalidArgumentException(sprintf("Unknown setter '%s'", $name));
+                    throw new UnknownSetterException($name);
                 }
 
                 $this->$name = $value;
@@ -1165,7 +1172,7 @@ class CarbonInterval extends DateInterval
      *
      * @param object|string $mixin
      *
-     * @throws \ReflectionException
+     * @throws ReflectionException
      *
      * @return void
      */
@@ -2061,7 +2068,7 @@ class CarbonInterval extends DateInterval
      *
      * @param string $unit
      *
-     * @throws InvalidArgumentException
+     * @throws UnknownUnitException|UnitNotConfiguredException
      *
      * @return float
      */
@@ -2072,7 +2079,7 @@ class CarbonInterval extends DateInterval
         if (in_array($unit, ['days', 'weeks'])) {
             $realUnit = 'dayz';
         } elseif (!in_array($unit, ['microseconds', 'milliseconds', 'seconds', 'minutes', 'hours', 'dayz', 'months', 'years'])) {
-            throw new InvalidArgumentException("Unknown unit '$unit'.");
+            throw new UnknownUnitException($unit);
         }
 
         $result = 0;
@@ -2138,7 +2145,7 @@ class CarbonInterval extends DateInterval
         }
 
         if (!$unitFound) {
-            throw new InvalidArgumentException("Unit $unit have no configuration to get total from other units.");
+            throw new UnitNotConfiguredException($unit);
         }
 
         if ($unit === 'weeks') {

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -25,7 +25,6 @@ use Carbon\Traits\Options;
 use Closure;
 use DateInterval;
 use Exception;
-use InvalidArgumentException;
 use ReflectionException;
 use Throwable;
 
@@ -805,7 +804,7 @@ class CarbonInterval extends DateInterval
                     break;
 
                 default:
-                    throw new InvalidArgumentException(
+                    throw new InvalidIntervalException(
                         sprintf('Invalid part %s in definition %s', $part, $intervalDefinition)
                     );
             }
@@ -1795,7 +1794,7 @@ class CarbonInterval extends DateInterval
         $interval = static::make($unit);
 
         if (!$interval) {
-            throw new InvalidArgumentException('This type of data cannot be added/subtracted.');
+            throw new InvalidIntervalException('This type of data cannot be added/subtracted.');
         }
 
         if ($value !== 1) {
@@ -2472,22 +2471,7 @@ class CarbonInterval extends DateInterval
      */
     public function round($precision = 1, $function = 'round')
     {
-        $unit = 'second';
-
-        if ($precision instanceof DateInterval) {
-            $precision = (string) self::instance($precision);
-        }
-
-        if (is_string($precision) && preg_match('/^\s*(?<precision>\d+)?\s*(?<unit>\w+)(?<other>\W.*)?$/', $precision, $match)) {
-            if (trim($match['other'] ?? '') !== '') {
-                throw new InvalidArgumentException('Rounding is only possible with single unit intervals.');
-            }
-
-            $precision = (int) ($match['precision'] ?: 1);
-            $unit = $match['unit'];
-        }
-
-        return $this->roundUnit($unit, $precision, $function);
+        return $this->roundWith($precision, $function);
     }
 
     /**

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -12,6 +12,8 @@ namespace Carbon;
 
 use Carbon\Exceptions\InvalidCastException;
 use Carbon\Exceptions\InvalidIntervalException;
+use Carbon\Exceptions\InvalidPeriodDateException;
+use Carbon\Exceptions\InvalidPeriodParameterException;
 use Carbon\Exceptions\NotACarbonClassException;
 use Carbon\Exceptions\NotAPeriodException;
 use Carbon\Exceptions\UnknownMethodException;
@@ -504,7 +506,7 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
             } elseif ($end === null && $parsed = Carbon::make(static::addMissingParts($start, $part))) {
                 $end = $part;
             } else {
-                throw new InvalidArgumentException("Invalid ISO 8601 specification: $iso.");
+                throw new InvalidPeriodParameterException("Invalid ISO 8601 specification: $iso.");
             }
 
             $result[] = $parsed;
@@ -669,7 +671,7 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
             } elseif ($this->options === null && (is_int($argument) || $argument === null)) {
                 $this->setOptions($argument);
             } else {
-                throw new InvalidArgumentException('Invalid constructor parameters.');
+                throw new InvalidPeriodParameterException('Invalid constructor parameters.');
             }
         }
 
@@ -803,7 +805,7 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
     public function setOptions($options)
     {
         if (!is_int($options) && !is_null($options)) {
-            throw new InvalidArgumentException('Invalid options.');
+            throw new InvalidPeriodParameterException('Invalid options.');
         }
 
         $this->options = $options ?: 0;
@@ -1186,7 +1188,7 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
     public function setRecurrences($recurrences)
     {
         if (!is_numeric($recurrences) && !is_null($recurrences) || $recurrences < 0) {
-            throw new InvalidArgumentException('Invalid number of recurrences.');
+            throw new InvalidPeriodParameterException('Invalid number of recurrences.');
         }
 
         if ($recurrences === null) {
@@ -1229,14 +1231,14 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
      * @param DateTime|DateTimeInterface|string $date
      * @param bool|null                         $inclusive
      *
-     * @throws \InvalidArgumentException
-     *
      * @return $this
+     * @throws InvalidPeriodDateException
+     *
      */
     public function setStartDate($date, $inclusive = null)
     {
         if (!$date = call_user_func([$this->dateClass, 'make'], $date)) {
-            throw new InvalidArgumentException('Invalid start date.');
+            throw new InvalidPeriodDateException('Invalid start date.');
         }
 
         $this->startDate = $date;
@@ -1261,7 +1263,7 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
     public function setEndDate($date, $inclusive = null)
     {
         if (!is_null($date) && !$date = call_user_func([$this->dateClass, 'make'], $date)) {
-            throw new InvalidArgumentException('Invalid end date.');
+            throw new InvalidPeriodDateException('Invalid end date.');
         }
 
         if (!$date) {

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -1231,9 +1231,9 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
      * @param DateTime|DateTimeInterface|string $date
      * @param bool|null                         $inclusive
      *
-     * @return $this
      * @throws InvalidPeriodDateException
      *
+     * @return $this
      */
     public function setStartDate($date, $inclusive = null)
     {

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -2219,22 +2219,7 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
      */
     public function round($precision = null, $function = 'round')
     {
-        $unit = 'second';
-
-        if ($precision === null || $precision instanceof DateInterval) {
-            $precision = (string) ($precision === null ? $this->getDateInterval() : CarbonInterval::instance($precision));
-        }
-
-        if (is_string($precision) && preg_match('/^\s*(?<precision>\d+)?\s*(?<unit>\w+)(?<other>\W.*)?$/', $precision, $match)) {
-            if (trim($match['other'] ?? '') !== '') {
-                throw new InvalidArgumentException('Rounding is only possible with single unit intervals.');
-            }
-
-            $precision = (int) ($match['precision'] ?: 1);
-            $unit = $match['unit'];
-        }
-
-        return $this->roundUnit($unit, $precision, $function);
+        return $this->roundWith($precision ?? (string) $this->getDateInterval(), $function);
     }
 
     /**

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -12,6 +12,7 @@ namespace Carbon;
 
 use BadMethodCallException;
 use Carbon\Exceptions\NotAPeriodException;
+use Carbon\Traits\IntervalRounding;
 use Carbon\Traits\Mixin;
 use Carbon\Traits\Options;
 use Closure;
@@ -178,9 +179,11 @@ use RuntimeException;
  */
 class CarbonPeriod implements Iterator, Countable, JsonSerializable
 {
-    use Options, Mixin {
+    use IntervalRounding;
+    use Mixin {
         Mixin::mixin as baseMixin;
     }
+    use Options;
 
     /**
      * Built-in filters.
@@ -1743,14 +1746,10 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
             });
         }
 
-        $action = substr($method, 0, 4);
+        $roundedValue = $this->callRoundMethod($method, $parameters);
 
-        if ($action !== 'ceil') {
-            $action = substr($method, 0, 5);
-        }
-
-        if (in_array($action, ['round', 'floor', 'ceil'])) {
-            return $this->{$action.'Unit'}(substr($method, strlen($action)), ...$parameters);
+        if ($roundedValue !== null) {
+            return $roundedValue;
         }
 
         $first = count($parameters) >= 1 ? $parameters[0] : null;

--- a/src/Carbon/CarbonTimeZone.php
+++ b/src/Carbon/CarbonTimeZone.php
@@ -10,9 +10,10 @@
  */
 namespace Carbon;
 
+use Carbon\Exceptions\InvalidCastException;
+use Carbon\Exceptions\InvalidTimeZoneException;
 use DateTimeInterface;
 use DateTimeZone;
-use InvalidArgumentException;
 
 class CarbonTimeZone extends DateTimeZone
 {
@@ -24,7 +25,7 @@ class CarbonTimeZone extends DateTimeZone
     protected static function parseNumericTimezone($timezone)
     {
         if ($timezone <= -100 || $timezone >= 100) {
-            throw new InvalidArgumentException('Absolute timezone offset cannot be greater than 100.');
+            throw new InvalidTimeZoneException('Absolute timezone offset cannot be greater than 100.');
         }
 
         return ($timezone >= 0 ? '+' : '').$timezone.':00';
@@ -66,7 +67,7 @@ class CarbonTimeZone extends DateTimeZone
                 return new $className($this->getName());
             }
 
-            throw new InvalidArgumentException("$className has not the instance() method needed to cast the date.");
+            throw new InvalidCastException("$className has not the instance() method needed to cast the date.");
         }
 
         return $className::instance($this);
@@ -98,7 +99,7 @@ class CarbonTimeZone extends DateTimeZone
 
         if ($tz === false) {
             if (Carbon::isStrictModeEnabled()) {
-                throw new InvalidArgumentException('Unknown or bad timezone ('.($objectDump ?: $object).')');
+                throw new InvalidTimeZoneException('Unknown or bad timezone ('.($objectDump ?: $object).')');
             }
 
             return false;
@@ -213,7 +214,7 @@ class CarbonTimeZone extends DateTimeZone
 
         if ($tz === false) {
             if (Carbon::isStrictModeEnabled()) {
-                throw new InvalidArgumentException('Unknown timezone for offset '.$this->getOffset($date ?: Carbon::now($this)).' seconds.');
+                throw new InvalidTimeZoneException('Unknown timezone for offset '.$this->getOffset($date ?: Carbon::now($this)).' seconds.');
             }
 
             return false;

--- a/src/Carbon/CarbonTimeZone.php
+++ b/src/Carbon/CarbonTimeZone.php
@@ -79,6 +79,8 @@ class CarbonTimeZone extends DateTimeZone
      * @param DateTimeZone|string|int|null $object     original value to get CarbonTimeZone from it.
      * @param DateTimeZone|string|int|null $objectDump dump of the object for error messages.
      *
+     * @throws InvalidTimeZoneException
+     *
      * @return false|static
      */
     public static function instance($object = null, $objectDump = null)

--- a/src/Carbon/Exceptions/BadComparisonUnitException.php
+++ b/src/Carbon/Exceptions/BadComparisonUnitException.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Exceptions;
+
+use Exception;
+
+class BadComparisonUnitException extends UnitException
+{
+    /**
+     * Constructor.
+     *
+     * @param string         $unit
+     * @param int            $code
+     * @param Exception|null $previous
+     */
+    public function __construct($unit, $code = 0, Exception $previous = null)
+    {
+        parent::__construct("Bad comparison unit: '$unit'", $code, $previous);
+    }
+}

--- a/src/Carbon/Exceptions/BadFluentConstructorException.php
+++ b/src/Carbon/Exceptions/BadFluentConstructorException.php
@@ -11,19 +11,19 @@
 namespace Carbon\Exceptions;
 
 use Exception;
-use InvalidArgumentException as BaseInvalidArgumentException;
+use BadMethodCallException as BaseBadMethodCallException;
 
-class BadUnitException extends BaseInvalidArgumentException implements InvalidArgumentException
+class BadFluentConstructorException extends BaseBadMethodCallException implements BadMethodCallException
 {
     /**
      * Constructor.
      *
-     * @param string         $unit
+     * @param string         $method
      * @param int            $code
      * @param Exception|null $previous
      */
-    public function __construct($unit, $code = 0, Exception $previous = null)
+    public function __construct($method, $code = 0, Exception $previous = null)
     {
-        parent::__construct("Bad comparison unit: '$unit'", $code, $previous);
+        parent::__construct(sprintf("Unknown fluent constructor '%s'.", $method), $code, $previous);
     }
 }

--- a/src/Carbon/Exceptions/BadFluentConstructorException.php
+++ b/src/Carbon/Exceptions/BadFluentConstructorException.php
@@ -10,8 +10,8 @@
  */
 namespace Carbon\Exceptions;
 
-use Exception;
 use BadMethodCallException as BaseBadMethodCallException;
+use Exception;
 
 class BadFluentConstructorException extends BaseBadMethodCallException implements BadMethodCallException
 {

--- a/src/Carbon/Exceptions/BadFluentSetterException.php
+++ b/src/Carbon/Exceptions/BadFluentSetterException.php
@@ -11,19 +11,19 @@
 namespace Carbon\Exceptions;
 
 use Exception;
-use InvalidArgumentException as BaseInvalidArgumentException;
+use BadMethodCallException as BaseBadMethodCallException;
 
-class BadUnitException extends BaseInvalidArgumentException implements InvalidArgumentException
+class BadFluentSetterException extends BaseBadMethodCallException implements BadMethodCallException
 {
     /**
      * Constructor.
      *
-     * @param string         $unit
+     * @param string         $method
      * @param int            $code
      * @param Exception|null $previous
      */
-    public function __construct($unit, $code = 0, Exception $previous = null)
+    public function __construct($method, $code = 0, Exception $previous = null)
     {
-        parent::__construct("Bad comparison unit: '$unit'", $code, $previous);
+        parent::__construct(sprintf("Unknown fluent setter '%s'", $method), $code, $previous);
     }
 }

--- a/src/Carbon/Exceptions/BadFluentSetterException.php
+++ b/src/Carbon/Exceptions/BadFluentSetterException.php
@@ -10,8 +10,8 @@
  */
 namespace Carbon\Exceptions;
 
-use Exception;
 use BadMethodCallException as BaseBadMethodCallException;
+use Exception;
 
 class BadFluentSetterException extends BaseBadMethodCallException implements BadMethodCallException
 {

--- a/src/Carbon/Exceptions/BadMethodCallException.php
+++ b/src/Carbon/Exceptions/BadMethodCallException.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Exceptions;
+
+interface BadMethodCallException extends Exception
+{
+}

--- a/src/Carbon/Exceptions/Exception.php
+++ b/src/Carbon/Exceptions/Exception.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Exceptions;
+
+interface Exception
+{
+}

--- a/src/Carbon/Exceptions/ImmutableException.php
+++ b/src/Carbon/Exceptions/ImmutableException.php
@@ -18,7 +18,7 @@ class ImmutableException extends BaseRuntimeException implements RuntimeExceptio
     /**
      * Constructor.
      *
-     * @param string         $value the immutable type/value
+     * @param string         $value    the immutable type/value
      * @param int            $code
      * @param Exception|null $previous
      */

--- a/src/Carbon/Exceptions/ImmutableException.php
+++ b/src/Carbon/Exceptions/ImmutableException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Exceptions;
+
+use Exception;
+use RuntimeException as BaseRuntimeException;
+
+class ImmutableException extends BaseRuntimeException implements RuntimeException
+{
+    /**
+     * Constructor.
+     *
+     * @param string         $value the immutable type/value
+     * @param int            $code
+     * @param Exception|null $previous
+     */
+    public function __construct($value, $code = 0, Exception $previous = null)
+    {
+        parent::__construct("$value is immutable.", $code, $previous);
+    }
+}

--- a/src/Carbon/Exceptions/InvalidArgumentException.php
+++ b/src/Carbon/Exceptions/InvalidArgumentException.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Exceptions;
+
+interface InvalidArgumentException extends Exception
+{
+}

--- a/src/Carbon/Exceptions/InvalidCastException.php
+++ b/src/Carbon/Exceptions/InvalidCastException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Exceptions;
+
+use Exception;
+use InvalidArgumentException as BaseInvalidArgumentException;
+
+class InvalidCastException extends BaseInvalidArgumentException implements InvalidArgumentException
+{
+    /**
+     * Constructor.
+     *
+     * @param string         $message
+     * @param int            $code
+     * @param Exception|null $previous
+     */
+    public function __construct($message, $code = 0, Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Carbon/Exceptions/InvalidDateException.php
+++ b/src/Carbon/Exceptions/InvalidDateException.php
@@ -11,9 +11,9 @@
 namespace Carbon\Exceptions;
 
 use Exception;
-use InvalidArgumentException;
+use InvalidArgumentException as BaseInvalidArgumentException;
 
-class InvalidDateException extends InvalidArgumentException
+class InvalidDateException extends BaseInvalidArgumentException implements InvalidArgumentException
 {
     /**
      * The invalid field.
@@ -32,10 +32,10 @@ class InvalidDateException extends InvalidArgumentException
     /**
      * Constructor.
      *
-     * @param string          $field
-     * @param mixed           $value
-     * @param int             $code
-     * @param \Exception|null $previous
+     * @param string         $field
+     * @param mixed          $value
+     * @param int            $code
+     * @param Exception|null $previous
      */
     public function __construct($field, $value, $code = 0, Exception $previous = null)
     {

--- a/src/Carbon/Exceptions/InvalidFormatException.php
+++ b/src/Carbon/Exceptions/InvalidFormatException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Exceptions;
+
+use Exception;
+use InvalidArgumentException as BaseInvalidArgumentException;
+
+class InvalidFormatException extends BaseInvalidArgumentException implements InvalidArgumentException
+{
+    /**
+     * Constructor.
+     *
+     * @param string         $message
+     * @param int            $code
+     * @param Exception|null $previous
+     */
+    public function __construct($message, $code = 0, Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Carbon/Exceptions/InvalidIntervalException.php
+++ b/src/Carbon/Exceptions/InvalidIntervalException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Exceptions;
+
+use Exception;
+use InvalidArgumentException as BaseInvalidArgumentException;
+
+class InvalidIntervalException extends BaseInvalidArgumentException implements InvalidArgumentException
+{
+    /**
+     * Constructor.
+     *
+     * @param string         $message
+     * @param int            $code
+     * @param Exception|null $previous
+     */
+    public function __construct($message, $code = 0, Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Carbon/Exceptions/InvalidPeriodDateException.php
+++ b/src/Carbon/Exceptions/InvalidPeriodDateException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Exceptions;
+
+use Exception;
+use InvalidArgumentException as BaseInvalidArgumentException;
+
+class InvalidPeriodDateException extends BaseInvalidArgumentException implements InvalidArgumentException
+{
+    /**
+     * Constructor.
+     *
+     * @param string         $message
+     * @param int            $code
+     * @param Exception|null $previous
+     */
+    public function __construct($message, $code = 0, Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Carbon/Exceptions/InvalidPeriodParameterException.php
+++ b/src/Carbon/Exceptions/InvalidPeriodParameterException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Exceptions;
+
+use Exception;
+use InvalidArgumentException as BaseInvalidArgumentException;
+
+class InvalidPeriodParameterException extends BaseInvalidArgumentException implements InvalidArgumentException
+{
+    /**
+     * Constructor.
+     *
+     * @param string         $message
+     * @param int            $code
+     * @param Exception|null $previous
+     */
+    public function __construct($message, $code = 0, Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Carbon/Exceptions/InvalidTimeZoneException.php
+++ b/src/Carbon/Exceptions/InvalidTimeZoneException.php
@@ -13,17 +13,17 @@ namespace Carbon\Exceptions;
 use Exception;
 use InvalidArgumentException as BaseInvalidArgumentException;
 
-class BadUnitException extends BaseInvalidArgumentException implements InvalidArgumentException
+class InvalidTimeZoneException extends BaseInvalidArgumentException implements InvalidArgumentException
 {
     /**
      * Constructor.
      *
-     * @param string         $unit
+     * @param string         $message
      * @param int            $code
      * @param Exception|null $previous
      */
-    public function __construct($unit, $code = 0, Exception $previous = null)
+    public function __construct($message, $code = 0, Exception $previous = null)
     {
-        parent::__construct("Bad comparison unit: '$unit'", $code, $previous);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Carbon/Exceptions/InvalidTypeException.php
+++ b/src/Carbon/Exceptions/InvalidTypeException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Exceptions;
+
+use Exception;
+use InvalidArgumentException as BaseInvalidArgumentException;
+
+class InvalidTypeException extends BaseInvalidArgumentException implements InvalidArgumentException
+{
+    /**
+     * Constructor.
+     *
+     * @param string         $message
+     * @param int            $code
+     * @param Exception|null $previous
+     */
+    public function __construct($message, $code = 0, Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Carbon/Exceptions/NotACarbonClassException.php
+++ b/src/Carbon/Exceptions/NotACarbonClassException.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Exceptions;
+
+use Carbon\CarbonInterface;
+use Exception;
+use InvalidArgumentException as BaseInvalidArgumentException;
+
+class NotACarbonClassException extends BaseInvalidArgumentException implements InvalidArgumentException
+{
+    /**
+     * Constructor.
+     *
+     * @param string         $className
+     * @param int            $code
+     * @param Exception|null $previous
+     */
+    public function __construct($className, $code = 0, Exception $previous = null)
+    {
+        parent::__construct(sprintf(
+            'Given class does not implement %s: %s',
+            CarbonInterface::class,
+            $className
+        ), $code, $previous);
+    }
+}

--- a/src/Carbon/Exceptions/NotAPeriodException.php
+++ b/src/Carbon/Exceptions/NotAPeriodException.php
@@ -11,16 +11,16 @@
 namespace Carbon\Exceptions;
 
 use Exception;
-use InvalidArgumentException;
+use InvalidArgumentException as BaseInvalidArgumentException;
 
-class NotAPeriodException extends InvalidArgumentException
+class NotAPeriodException extends BaseInvalidArgumentException implements InvalidArgumentException
 {
     /**
      * Constructor.
      *
-     * @param string          $message
-     * @param int             $code
-     * @param \Exception|null $previous
+     * @param string         $message
+     * @param int            $code
+     * @param Exception|null $previous
      */
     public function __construct($message, $code = 0, Exception $previous = null)
     {

--- a/src/Carbon/Exceptions/NotLocaleAwareException.php
+++ b/src/Carbon/Exceptions/NotLocaleAwareException.php
@@ -11,16 +11,16 @@
 namespace Carbon\Exceptions;
 
 use Exception;
-use InvalidArgumentException;
+use InvalidArgumentException as BaseInvalidArgumentException;
 
-class NotLocaleAwareException extends InvalidArgumentException
+class NotLocaleAwareException extends BaseInvalidArgumentException implements InvalidArgumentException
 {
     /**
      * Constructor.
      *
-     * @param mixed           $object
-     * @param int             $code
-     * @param \Exception|null $previous
+     * @param mixed          $object
+     * @param int            $code
+     * @param Exception|null $previous
      */
     public function __construct($object, $code = 0, Exception $previous = null)
     {

--- a/src/Carbon/Exceptions/OutOfRangeException.php
+++ b/src/Carbon/Exceptions/OutOfRangeException.php
@@ -49,7 +49,9 @@ class OutOfRangeException extends BaseInvalidArgumentException implements Invali
     /**
      * Constructor.
      *
-     * @param string         $field
+     * @param string         $unit
+     * @param mixed          $min
+     * @param mixed          $max
      * @param mixed          $value
      * @param int            $code
      * @param Exception|null $previous

--- a/src/Carbon/Exceptions/OutOfRangeException.php
+++ b/src/Carbon/Exceptions/OutOfRangeException.php
@@ -11,9 +11,12 @@
 namespace Carbon\Exceptions;
 
 use Exception;
-use OutOfRangeException as BaseOutOfRangeException;
+use InvalidArgumentException as BaseInvalidArgumentException;
 
-class OutOfRangeException extends BaseOutOfRangeException implements InvalidArgumentException
+// This will extends OutOfRangeException instead of InvalidArgumentException since 3.0.0
+// use OutOfRangeException as BaseOutOfRangeException;
+
+class OutOfRangeException extends BaseInvalidArgumentException implements InvalidArgumentException
 {
     /**
      * The unit or name of the value.

--- a/src/Carbon/Exceptions/OutOfRangeException.php
+++ b/src/Carbon/Exceptions/OutOfRangeException.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Exceptions;
+
+use Exception;
+use OutOfRangeException as BaseOutOfRangeException;
+
+class OutOfRangeException extends BaseOutOfRangeException implements InvalidArgumentException
+{
+    /**
+     * The unit or name of the value.
+     *
+     * @var string
+     */
+    private $unit;
+
+    /**
+     * The range minimum.
+     *
+     * @var mixed
+     */
+    private $min;
+
+    /**
+     * The range maximum.
+     *
+     * @var mixed
+     */
+    private $max;
+
+    /**
+     * The invalid value.
+     *
+     * @var mixed
+     */
+    private $value;
+
+    /**
+     * Constructor.
+     *
+     * @param string         $field
+     * @param mixed          $value
+     * @param int            $code
+     * @param Exception|null $previous
+     */
+    public function __construct($unit, $min, $max, $value, $code = 0, Exception $previous = null)
+    {
+        $this->unit = $unit;
+        $this->min = $min;
+        $this->max = $max;
+        $this->value = $value;
+
+        parent::__construct("$unit must be between $min and $max, $value given", $code, $previous);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getMax()
+    {
+        return $this->max;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getMin()
+    {
+        return $this->min;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getUnit()
+    {
+        return $this->unit;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/Carbon/Exceptions/ParseErrorException.php
+++ b/src/Carbon/Exceptions/ParseErrorException.php
@@ -11,17 +11,17 @@
 namespace Carbon\Exceptions;
 
 use Exception;
-use InvalidArgumentException;
+use InvalidArgumentException as BaseInvalidArgumentException;
 
-class ParseErrorException extends InvalidArgumentException
+class ParseErrorException extends BaseInvalidArgumentException implements InvalidArgumentException
 {
     /**
      * Constructor.
      *
-     * @param string          $expected
-     * @param string          $actual
-     * @param int             $code
-     * @param \Exception|null $previous
+     * @param string         $expected
+     * @param string         $actual
+     * @param int            $code
+     * @param Exception|null $previous
      */
     public function __construct($expected, $actual, $help = '', $code = 0, Exception $previous = null)
     {

--- a/src/Carbon/Exceptions/RuntimeException.php
+++ b/src/Carbon/Exceptions/RuntimeException.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Exceptions;
+
+interface RuntimeException extends Exception
+{
+}

--- a/src/Carbon/Exceptions/UnitException.php
+++ b/src/Carbon/Exceptions/UnitException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Exceptions;
+
+use Exception;
+use InvalidArgumentException as BaseInvalidArgumentException;
+
+class UnitException extends BaseInvalidArgumentException implements InvalidArgumentException
+{
+    /**
+     * Constructor.
+     *
+     * @param string         $message
+     * @param int            $code
+     * @param Exception|null $previous
+     */
+    public function __construct($message, $code = 0, Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Carbon/Exceptions/UnitNotConfiguredException.php
+++ b/src/Carbon/Exceptions/UnitNotConfiguredException.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Exceptions;
+
+use Exception;
+
+class UnitNotConfiguredException extends UnitException
+{
+    /**
+     * Constructor.
+     *
+     * @param string         $unit
+     * @param int            $code
+     * @param Exception|null $previous
+     */
+    public function __construct($unit, $code = 0, Exception $previous = null)
+    {
+        parent::__construct("Unit $unit have no configuration to get total from other units.", $code, $previous);
+    }
+}

--- a/src/Carbon/Exceptions/UnknownGetterException.php
+++ b/src/Carbon/Exceptions/UnknownGetterException.php
@@ -10,15 +10,15 @@
  */
 namespace Carbon\Exceptions;
 
-use BadMethodCallException as BaseBadMethodCallException;
 use Exception;
+use InvalidArgumentException as BaseInvalidArgumentException;
 
-class UnknownGetterException extends BaseBadMethodCallException implements BadMethodCallException
+class UnknownGetterException extends BaseInvalidArgumentException implements InvalidArgumentException
 {
     /**
      * Constructor.
      *
-     * @param string         $name getter name
+     * @param string         $name     getter name
      * @param int            $code
      * @param Exception|null $previous
      */

--- a/src/Carbon/Exceptions/UnknownGetterException.php
+++ b/src/Carbon/Exceptions/UnknownGetterException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Exceptions;
+
+use BadMethodCallException as BaseBadMethodCallException;
+use Exception;
+
+class UnknownGetterException extends BaseBadMethodCallException implements BadMethodCallException
+{
+    /**
+     * Constructor.
+     *
+     * @param string         $name getter name
+     * @param int            $code
+     * @param Exception|null $previous
+     */
+    public function __construct($name, $code = 0, Exception $previous = null)
+    {
+        parent::__construct("Unknown getter '$name'", $code, $previous);
+    }
+}

--- a/src/Carbon/Exceptions/UnknownMethodException.php
+++ b/src/Carbon/Exceptions/UnknownMethodException.php
@@ -11,19 +11,19 @@
 namespace Carbon\Exceptions;
 
 use Exception;
-use InvalidArgumentException as BaseInvalidArgumentException;
+use BadMethodCallException as BaseBadMethodCallException;
 
-class BadUnitException extends BaseInvalidArgumentException implements InvalidArgumentException
+class UnknownMethodException extends BaseBadMethodCallException implements BadMethodCallException
 {
     /**
      * Constructor.
      *
-     * @param string         $unit
+     * @param string         $method
      * @param int            $code
      * @param Exception|null $previous
      */
-    public function __construct($unit, $code = 0, Exception $previous = null)
+    public function __construct($method, $code = 0, Exception $previous = null)
     {
-        parent::__construct("Bad comparison unit: '$unit'", $code, $previous);
+        parent::__construct("Method $method does not exist.", $code, $previous);
     }
 }

--- a/src/Carbon/Exceptions/UnknownMethodException.php
+++ b/src/Carbon/Exceptions/UnknownMethodException.php
@@ -10,8 +10,8 @@
  */
 namespace Carbon\Exceptions;
 
-use Exception;
 use BadMethodCallException as BaseBadMethodCallException;
+use Exception;
 
 class UnknownMethodException extends BaseBadMethodCallException implements BadMethodCallException
 {

--- a/src/Carbon/Exceptions/UnknownSetterException.php
+++ b/src/Carbon/Exceptions/UnknownSetterException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Exceptions;
+
+use BadMethodCallException as BaseBadMethodCallException;
+use Exception;
+
+class UnknownSetterException extends BaseBadMethodCallException implements BadMethodCallException
+{
+    /**
+     * Constructor.
+     *
+     * @param string         $name setter name
+     * @param int            $code
+     * @param Exception|null $previous
+     */
+    public function __construct($name, $code = 0, Exception $previous = null)
+    {
+        parent::__construct("Unknown setter '$name'", $code, $previous);
+    }
+}

--- a/src/Carbon/Exceptions/UnknownSetterException.php
+++ b/src/Carbon/Exceptions/UnknownSetterException.php
@@ -10,15 +10,15 @@
  */
 namespace Carbon\Exceptions;
 
-use BadMethodCallException as BaseBadMethodCallException;
 use Exception;
+use InvalidArgumentException as BaseInvalidArgumentException;
 
-class UnknownSetterException extends BaseBadMethodCallException implements BadMethodCallException
+class UnknownSetterException extends BaseInvalidArgumentException implements BadMethodCallException
 {
     /**
      * Constructor.
      *
-     * @param string         $name setter name
+     * @param string         $name     setter name
      * @param int            $code
      * @param Exception|null $previous
      */

--- a/src/Carbon/Exceptions/UnknownUnitException.php
+++ b/src/Carbon/Exceptions/UnknownUnitException.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Exceptions;
+
+use Exception;
+
+class UnknownUnitException extends UnitException
+{
+    /**
+     * Constructor.
+     *
+     * @param string         $unit
+     * @param int            $code
+     * @param Exception|null $previous
+     */
+    public function __construct($unit, $code = 0, Exception $previous = null)
+    {
+        parent::__construct("Unknown unit '$unit'.", $code, $previous);
+    }
+}

--- a/src/Carbon/Exceptions/UnreachableException.php
+++ b/src/Carbon/Exceptions/UnreachableException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Exceptions;
+
+use Exception;
+use RuntimeException as BaseRuntimeException;
+
+class UnreachableException extends BaseRuntimeException implements RuntimeException
+{
+    /**
+     * Constructor.
+     *
+     * @param string         $message
+     * @param int            $code
+     * @param Exception|null $previous
+     */
+    public function __construct($message, $code = 0, Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Carbon/Traits/Boundaries.php
+++ b/src/Carbon/Traits/Boundaries.php
@@ -10,7 +10,7 @@
  */
 namespace Carbon\Traits;
 
-use InvalidArgumentException;
+use Carbon\Exceptions\UnknownUnitException;
 
 /**
  * Trait Boundaries.
@@ -418,7 +418,7 @@ trait Boundaries
         $ucfUnit = ucfirst(static::singularUnit($unit));
         $method = "startOf$ucfUnit";
         if (!method_exists($this, $method)) {
-            throw new InvalidArgumentException("Unknown unit '$unit'");
+            throw new UnknownUnitException($unit);
         }
 
         return $this->$method(...$params);
@@ -444,7 +444,7 @@ trait Boundaries
         $ucfUnit = ucfirst(static::singularUnit($unit));
         $method = "endOf$ucfUnit";
         if (!method_exists($this, $method)) {
-            throw new InvalidArgumentException("Unknown unit '$unit'");
+            throw new UnknownUnitException($unit);
         }
 
         return $this->$method(...$params);

--- a/src/Carbon/Traits/Cast.php
+++ b/src/Carbon/Traits/Cast.php
@@ -2,8 +2,8 @@
 
 namespace Carbon\Traits;
 
+use Carbon\Exceptions\InvalidCastException;
 use DateTimeInterface;
-use InvalidArgumentException;
 
 /**
  * Trait Cast.
@@ -26,7 +26,7 @@ trait Cast
                 return new $className($this->rawFormat('Y-m-d H:i:s.u'), $this->getTimezone());
             }
 
-            throw new InvalidArgumentException("$className has not the instance() method needed to cast the date.");
+            throw new InvalidCastException("$className has not the instance() method needed to cast the date.");
         }
 
         return $className::instance($this);

--- a/src/Carbon/Traits/Comparison.php
+++ b/src/Carbon/Traits/Comparison.php
@@ -11,7 +11,7 @@
 namespace Carbon\Traits;
 
 use Carbon\CarbonInterface;
-use Carbon\Exceptions\BadUnitException;
+use Carbon\Exceptions\BadComparisonUnitException;
 use InvalidArgumentException;
 
 /**
@@ -621,7 +621,7 @@ trait Comparison
             }
 
             if ($this->localStrictModeEnabled ?? static::isStrictModeEnabled()) {
-                throw new BadUnitException($unit);
+                throw new BadComparisonUnitException($unit);
             }
 
             return false;

--- a/src/Carbon/Traits/Converter.php
+++ b/src/Carbon/Traits/Converter.php
@@ -15,10 +15,10 @@ use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 use Carbon\CarbonInterval;
 use Carbon\CarbonPeriod;
+use Carbon\Exceptions\UnitException;
 use Closure;
 use DateTime;
 use DateTimeImmutable;
-use InvalidArgumentException;
 
 /**
  * Trait Converter.
@@ -211,7 +211,7 @@ trait Converter
                 return 'H:i:s.u';
         }
 
-        throw new InvalidArgumentException('Precision unit expected among: minute, second, millisecond and microsecond.');
+        throw new UnitException('Precision unit expected among: minute, second, millisecond and microsecond.');
     }
 
     /**

--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -14,6 +14,7 @@ use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 use Carbon\Exceptions\InvalidDateException;
+use Carbon\Exceptions\OutOfRangeException;
 use Carbon\Translator;
 use Closure;
 use DateTimeInterface;
@@ -313,7 +314,7 @@ trait Creator
     private static function assertBetween($unit, $value, $min, $max)
     {
         if (static::isStrictModeEnabled() && ($value < $min || $value > $max)) {
-            throw new InvalidArgumentException("$unit must be between $min and $max, $value given");
+            throw new OutOfRangeException($unit, $min, $max, $value);
         }
     }
 

--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -14,13 +14,13 @@ use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 use Carbon\Exceptions\InvalidDateException;
+use Carbon\Exceptions\InvalidFormatException;
 use Carbon\Exceptions\OutOfRangeException;
 use Carbon\Translator;
 use Closure;
 use DateTimeInterface;
 use DateTimeZone;
 use Exception;
-use InvalidArgumentException;
 
 /**
  * Trait Creator.
@@ -50,6 +50,8 @@ trait Creator
      *
      * @param string|null              $time
      * @param DateTimeZone|string|null $tz
+     *
+     * @throws InvalidFormatException
      */
     public function __construct($time = null, $tz = null)
     {
@@ -79,7 +81,11 @@ trait Creator
             setlocale(LC_NUMERIC, 'C');
         }
 
-        parent::__construct($time ?: 'now', static::safeCreateDateTimeZone($tz) ?: null);
+        try {
+            parent::__construct($time ?: 'now', static::safeCreateDateTimeZone($tz) ?: null);
+        } catch (Exception $exception) {
+            throw new InvalidFormatException($exception->getMessage(), 0, $exception);
+        }
 
         $this->constructedObjectId = spl_object_hash($this);
 
@@ -163,7 +169,7 @@ trait Creator
      * @param string|null              $time
      * @param DateTimeZone|string|null $tz
      *
-     * @throws Exception
+     * @throws InvalidFormatException
      *
      * @return static
      */
@@ -179,7 +185,7 @@ trait Creator
             $date = @static::now($tz)->change($time);
 
             if (!$date) {
-                throw $exception;
+                throw new InvalidFormatException("Could not parse '$time': ".$exception->getMessage(), 0, $exception);
             }
 
             return $date;
@@ -196,7 +202,7 @@ trait Creator
      * @param string|null              $time
      * @param DateTimeZone|string|null $tz
      *
-     * @throws Exception
+     * @throws InvalidFormatException
      *
      * @return static
      */
@@ -222,7 +228,7 @@ trait Creator
      * @param string                   $locale
      * @param DateTimeZone|string|null $tz
      *
-     * @throws Exception
+     * @throws InvalidFormatException
      *
      * @return static
      */
@@ -353,7 +359,7 @@ trait Creator
      * @param int|null                 $second
      * @param DateTimeZone|string|null $tz
      *
-     * @throws Exception|InvalidArgumentException
+     * @throws InvalidFormatException
      *
      * @return static
      */
@@ -427,7 +433,7 @@ trait Creator
      * If $hour is not null then the default values for $minute and $second
      * will be 0.
      *
-     * If one of the set values is not valid, an \InvalidArgumentException
+     * If one of the set values is not valid, an InvalidDateException
      * will be thrown.
      *
      * @param int|null                 $year
@@ -438,7 +444,7 @@ trait Creator
      * @param int|null                 $second
      * @param DateTimeZone|string|null $tz
      *
-     * @throws Exception
+     * @throws InvalidDateException
      *
      * @return static|false
      */
@@ -479,7 +485,7 @@ trait Creator
      * @param int|null                 $day
      * @param DateTimeZone|string|null $tz
      *
-     * @throws Exception|InvalidArgumentException
+     * @throws InvalidFormatException
      *
      * @return static
      */
@@ -496,7 +502,7 @@ trait Creator
      * @param int|null                 $day
      * @param DateTimeZone|string|null $tz
      *
-     * @throws Exception
+     * @throws InvalidFormatException
      *
      * @return static
      */
@@ -513,7 +519,7 @@ trait Creator
      * @param int|null                 $second
      * @param DateTimeZone|string|null $tz
      *
-     * @throws Exception|InvalidArgumentException
+     * @throws InvalidFormatException
      *
      * @return static
      */
@@ -528,7 +534,7 @@ trait Creator
      * @param string                   $time
      * @param DateTimeZone|string|null $tz
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidFormatException
      *
      * @return static
      */
@@ -577,7 +583,7 @@ trait Creator
      * @param string                         $time
      * @param DateTimeZone|string|false|null $tz
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidFormatException
      *
      * @return static|false
      */
@@ -631,7 +637,7 @@ trait Creator
         }
 
         if (static::isStrictModeEnabled()) {
-            throw new InvalidArgumentException(implode(PHP_EOL, $lastErrors['errors']));
+            throw new InvalidFormatException(implode(PHP_EOL, $lastErrors['errors']));
         }
 
         return false;
@@ -644,7 +650,7 @@ trait Creator
      * @param string                         $time
      * @param DateTimeZone|string|false|null $tz
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidFormatException
      *
      * @return static|false
      */
@@ -672,7 +678,7 @@ trait Creator
      * @param string|null                                        $locale     locale to be used for LTS, LT, LL, LLL, etc. macro-formats (en by fault, unneeded if no such macro-format in use)
      * @param \Symfony\Component\Translation\TranslatorInterface $translator optional custom translator to use for macro-formats
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidFormatException
      *
      * @return static|false
      */
@@ -796,7 +802,7 @@ trait Creator
             $format = $replacements[$code] ?? '?';
 
             if ($format === '!') {
-                throw new InvalidArgumentException("Format $code not supported for creation.");
+                throw new InvalidFormatException("Format $code not supported for creation.");
             }
 
             return $format;
@@ -813,7 +819,7 @@ trait Creator
      * @param string                         $time
      * @param DateTimeZone|string|false|null $tz
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidFormatException
      *
      * @return static|false
      */
@@ -830,7 +836,7 @@ trait Creator
      * @param string                         $time
      * @param DateTimeZone|string|false|null $tz
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidFormatException
      *
      * @return static|false
      */
@@ -849,7 +855,7 @@ trait Creator
      *
      * @param mixed $var
      *
-     * @throws Exception
+     * @throws InvalidFormatException
      *
      * @return static|null
      */

--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -11,11 +11,14 @@
 namespace Carbon\Traits;
 
 use BadMethodCallException;
+use Carbon\Carbon;
 use Carbon\CarbonInterface;
 use Carbon\CarbonPeriod;
 use Carbon\CarbonTimeZone;
 use Carbon\Exceptions\BadComparisonUnitException;
 use Carbon\Exceptions\ImmutableException;
+use Carbon\Exceptions\InvalidTimeZoneException;
+use Carbon\Exceptions\InvalidTypeException;
 use Carbon\Exceptions\UnknownGetterException;
 use Carbon\Exceptions\UnknownMethodException;
 use Carbon\Exceptions\UnknownSetterException;
@@ -112,35 +115,35 @@ use Throwable;
  * @method        bool            isThursday()                                                                        Checks if the instance day is thursday.
  * @method        bool            isFriday()                                                                          Checks if the instance day is friday.
  * @method        bool            isSaturday()                                                                        Checks if the instance day is saturday.
- * @method        bool            isSameYear(\Carbon\Carbon|\DateTimeInterface|string|null $date = null)              Checks if the given date is in the same year as the instance. If null passed, compare to now (with the same timezone).
+ * @method        bool            isSameYear(Carbon|DateTimeInterface|string|null $date = null)              Checks if the given date is in the same year as the instance. If null passed, compare to now (with the same timezone).
  * @method        bool            isCurrentYear()                                                                     Checks if the instance is in the same year as the current moment.
  * @method        bool            isNextYear()                                                                        Checks if the instance is in the same year as the current moment next year.
  * @method        bool            isLastYear()                                                                        Checks if the instance is in the same year as the current moment last year.
- * @method        bool            isSameWeek(\Carbon\Carbon|\DateTimeInterface|string|null $date = null)              Checks if the given date is in the same week as the instance. If null passed, compare to now (with the same timezone).
+ * @method        bool            isSameWeek(Carbon|DateTimeInterface|string|null $date = null)              Checks if the given date is in the same week as the instance. If null passed, compare to now (with the same timezone).
  * @method        bool            isCurrentWeek()                                                                     Checks if the instance is in the same week as the current moment.
  * @method        bool            isNextWeek()                                                                        Checks if the instance is in the same week as the current moment next week.
  * @method        bool            isLastWeek()                                                                        Checks if the instance is in the same week as the current moment last week.
- * @method        bool            isSameDay(\Carbon\Carbon|\DateTimeInterface|string|null $date = null)               Checks if the given date is in the same day as the instance. If null passed, compare to now (with the same timezone).
+ * @method        bool            isSameDay(Carbon|DateTimeInterface|string|null $date = null)               Checks if the given date is in the same day as the instance. If null passed, compare to now (with the same timezone).
  * @method        bool            isCurrentDay()                                                                      Checks if the instance is in the same day as the current moment.
  * @method        bool            isNextDay()                                                                         Checks if the instance is in the same day as the current moment next day.
  * @method        bool            isLastDay()                                                                         Checks if the instance is in the same day as the current moment last day.
- * @method        bool            isSameHour(\Carbon\Carbon|\DateTimeInterface|string|null $date = null)              Checks if the given date is in the same hour as the instance. If null passed, compare to now (with the same timezone).
+ * @method        bool            isSameHour(Carbon|DateTimeInterface|string|null $date = null)              Checks if the given date is in the same hour as the instance. If null passed, compare to now (with the same timezone).
  * @method        bool            isCurrentHour()                                                                     Checks if the instance is in the same hour as the current moment.
  * @method        bool            isNextHour()                                                                        Checks if the instance is in the same hour as the current moment next hour.
  * @method        bool            isLastHour()                                                                        Checks if the instance is in the same hour as the current moment last hour.
- * @method        bool            isSameMinute(\Carbon\Carbon|\DateTimeInterface|string|null $date = null)            Checks if the given date is in the same minute as the instance. If null passed, compare to now (with the same timezone).
+ * @method        bool            isSameMinute(Carbon|DateTimeInterface|string|null $date = null)            Checks if the given date is in the same minute as the instance. If null passed, compare to now (with the same timezone).
  * @method        bool            isCurrentMinute()                                                                   Checks if the instance is in the same minute as the current moment.
  * @method        bool            isNextMinute()                                                                      Checks if the instance is in the same minute as the current moment next minute.
  * @method        bool            isLastMinute()                                                                      Checks if the instance is in the same minute as the current moment last minute.
- * @method        bool            isSameSecond(\Carbon\Carbon|\DateTimeInterface|string|null $date = null)            Checks if the given date is in the same second as the instance. If null passed, compare to now (with the same timezone).
+ * @method        bool            isSameSecond(Carbon|DateTimeInterface|string|null $date = null)            Checks if the given date is in the same second as the instance. If null passed, compare to now (with the same timezone).
  * @method        bool            isCurrentSecond()                                                                   Checks if the instance is in the same second as the current moment.
  * @method        bool            isNextSecond()                                                                      Checks if the instance is in the same second as the current moment next second.
  * @method        bool            isLastSecond()                                                                      Checks if the instance is in the same second as the current moment last second.
- * @method        bool            isSameMicro(\Carbon\Carbon|\DateTimeInterface|string|null $date = null)             Checks if the given date is in the same microsecond as the instance. If null passed, compare to now (with the same timezone).
+ * @method        bool            isSameMicro(Carbon|DateTimeInterface|string|null $date = null)             Checks if the given date is in the same microsecond as the instance. If null passed, compare to now (with the same timezone).
  * @method        bool            isCurrentMicro()                                                                    Checks if the instance is in the same microsecond as the current moment.
  * @method        bool            isNextMicro()                                                                       Checks if the instance is in the same microsecond as the current moment next microsecond.
  * @method        bool            isLastMicro()                                                                       Checks if the instance is in the same microsecond as the current moment last microsecond.
- * @method        bool            isSameMicrosecond(\Carbon\Carbon|\DateTimeInterface|string|null $date = null)       Checks if the given date is in the same microsecond as the instance. If null passed, compare to now (with the same timezone).
+ * @method        bool            isSameMicrosecond(Carbon|DateTimeInterface|string|null $date = null)       Checks if the given date is in the same microsecond as the instance. If null passed, compare to now (with the same timezone).
  * @method        bool            isCurrentMicrosecond()                                                              Checks if the instance is in the same microsecond as the current moment.
  * @method        bool            isNextMicrosecond()                                                                 Checks if the instance is in the same microsecond as the current moment next microsecond.
  * @method        bool            isLastMicrosecond()                                                                 Checks if the instance is in the same microsecond as the current moment last microsecond.
@@ -150,15 +153,15 @@ use Throwable;
  * @method        bool            isCurrentQuarter()                                                                  Checks if the instance is in the same quarter as the current moment.
  * @method        bool            isNextQuarter()                                                                     Checks if the instance is in the same quarter as the current moment next quarter.
  * @method        bool            isLastQuarter()                                                                     Checks if the instance is in the same quarter as the current moment last quarter.
- * @method        bool            isSameDecade(\Carbon\Carbon|\DateTimeInterface|string|null $date = null)            Checks if the given date is in the same decade as the instance. If null passed, compare to now (with the same timezone).
+ * @method        bool            isSameDecade(Carbon|DateTimeInterface|string|null $date = null)            Checks if the given date is in the same decade as the instance. If null passed, compare to now (with the same timezone).
  * @method        bool            isCurrentDecade()                                                                   Checks if the instance is in the same decade as the current moment.
  * @method        bool            isNextDecade()                                                                      Checks if the instance is in the same decade as the current moment next decade.
  * @method        bool            isLastDecade()                                                                      Checks if the instance is in the same decade as the current moment last decade.
- * @method        bool            isSameCentury(\Carbon\Carbon|\DateTimeInterface|string|null $date = null)           Checks if the given date is in the same century as the instance. If null passed, compare to now (with the same timezone).
+ * @method        bool            isSameCentury(Carbon|DateTimeInterface|string|null $date = null)           Checks if the given date is in the same century as the instance. If null passed, compare to now (with the same timezone).
  * @method        bool            isCurrentCentury()                                                                  Checks if the instance is in the same century as the current moment.
  * @method        bool            isNextCentury()                                                                     Checks if the instance is in the same century as the current moment next century.
  * @method        bool            isLastCentury()                                                                     Checks if the instance is in the same century as the current moment last century.
- * @method        bool            isSameMillennium(\Carbon\Carbon|\DateTimeInterface|string|null $date = null)        Checks if the given date is in the same millennium as the instance. If null passed, compare to now (with the same timezone).
+ * @method        bool            isSameMillennium(Carbon|DateTimeInterface|string|null $date = null)        Checks if the given date is in the same millennium as the instance. If null passed, compare to now (with the same timezone).
  * @method        bool            isCurrentMillennium()                                                               Checks if the instance is in the same millennium as the current moment.
  * @method        bool            isNextMillennium()                                                                  Checks if the instance is in the same millennium as the current moment next millennium.
  * @method        bool            isLastMillennium()                                                                  Checks if the instance is in the same millennium as the current moment last millennium.
@@ -509,14 +512,14 @@ use Throwable;
  * @method        CarbonInterface floorMicroseconds(float $precision = 1)                                             Truncate the current instance microsecond with given precision.
  * @method        CarbonInterface ceilMicrosecond(float $precision = 1)                                               Ceil the current instance microsecond with given precision.
  * @method        CarbonInterface ceilMicroseconds(float $precision = 1)                                              Ceil the current instance microsecond with given precision.
- * @method        string          shortAbsoluteDiffForHumans(\DateTimeInterface $other = null, int $parts = 1)        Get the difference (short format, 'Absolute' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
- * @method        string          longAbsoluteDiffForHumans(\DateTimeInterface $other = null, int $parts = 1)         Get the difference (long format, 'Absolute' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
- * @method        string          shortRelativeDiffForHumans(\DateTimeInterface $other = null, int $parts = 1)        Get the difference (short format, 'Relative' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
- * @method        string          longRelativeDiffForHumans(\DateTimeInterface $other = null, int $parts = 1)         Get the difference (long format, 'Relative' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
- * @method        string          shortRelativeToNowDiffForHumans(\DateTimeInterface $other = null, int $parts = 1)   Get the difference (short format, 'RelativeToNow' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
- * @method        string          longRelativeToNowDiffForHumans(\DateTimeInterface $other = null, int $parts = 1)    Get the difference (long format, 'RelativeToNow' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
- * @method        string          shortRelativeToOtherDiffForHumans(\DateTimeInterface $other = null, int $parts = 1) Get the difference (short format, 'RelativeToOther' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
- * @method        string          longRelativeToOtherDiffForHumans(\DateTimeInterface $other = null, int $parts = 1)  Get the difference (long format, 'RelativeToOther' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
+ * @method        string          shortAbsoluteDiffForHumans(DateTimeInterface $other = null, int $parts = 1)        Get the difference (short format, 'Absolute' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
+ * @method        string          longAbsoluteDiffForHumans(DateTimeInterface $other = null, int $parts = 1)         Get the difference (long format, 'Absolute' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
+ * @method        string          shortRelativeDiffForHumans(DateTimeInterface $other = null, int $parts = 1)        Get the difference (short format, 'Relative' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
+ * @method        string          longRelativeDiffForHumans(DateTimeInterface $other = null, int $parts = 1)         Get the difference (long format, 'Relative' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
+ * @method        string          shortRelativeToNowDiffForHumans(DateTimeInterface $other = null, int $parts = 1)   Get the difference (short format, 'RelativeToNow' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
+ * @method        string          longRelativeToNowDiffForHumans(DateTimeInterface $other = null, int $parts = 1)    Get the difference (long format, 'RelativeToNow' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
+ * @method        string          shortRelativeToOtherDiffForHumans(DateTimeInterface $other = null, int $parts = 1) Get the difference (short format, 'RelativeToOther' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
+ * @method        string          longRelativeToOtherDiffForHumans(DateTimeInterface $other = null, int $parts = 1)  Get the difference (long format, 'RelativeToOther' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
  *
  * </autodoc>
  */
@@ -612,7 +615,7 @@ trait Date
      * @param DateTimeZone|string|int|null $object     original value to get CarbonTimeZone from it.
      * @param DateTimeZone|string|int|null $objectDump dump of the object for error messages.
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidTimeZoneException
      *
      * @return CarbonTimeZone|false
      */
@@ -694,7 +697,7 @@ trait Date
      * @param mixed        $date
      * @param string|array $other
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidTypeException
      */
     protected static function expectDateTime($date, $other = [])
     {
@@ -704,7 +707,7 @@ trait Date
         }
 
         if (!$date instanceof DateTime && !$date instanceof DateTimeInterface) {
-            throw new InvalidArgumentException(
+            throw new InvalidTypeException(
                 $message.'DateTime or DateTimeInterface, '.
                 (is_object($date) ? get_class($date) : gettype($date)).' given'
             );
@@ -715,7 +718,7 @@ trait Date
      * Return the Carbon instance passed through, a now instance in the same timezone
      * if null given or parse the input if string given.
      *
-     * @param \Carbon\Carbon|\DateTimeInterface|string|null $date
+     * @param Carbon|DateTimeInterface|string|null $date
      *
      * @return static
      */
@@ -738,7 +741,7 @@ trait Date
      * Return the Carbon instance passed through, a now instance in the same timezone
      * if null given or parse the input if string given.
      *
-     * @param \Carbon\Carbon|\Carbon\CarbonPeriod|\Carbon\CarbonInterval|\DateInterval|\DatePeriod|\DateTimeInterface|string|null $date
+     * @param Carbon|\Carbon\CarbonPeriod|\Carbon\CarbonInterval|\DateInterval|\DatePeriod|DateTimeInterface|string|null $date
      *
      * @return static
      */
@@ -764,7 +767,7 @@ trait Date
      *
      * @param string $name
      *
-     * @throws InvalidArgumentException|ReflectionException
+     * @throws UnknownGetterException
      *
      * @return string|int|bool|DateTimeZone|null
      */
@@ -778,7 +781,7 @@ trait Date
      *
      * @param string $name
      *
-     * @throws InvalidArgumentException|ReflectionException
+     * @throws UnknownGetterException
      *
      * @return string|int|bool|DateTimeZone|null
      */
@@ -1026,7 +1029,7 @@ trait Date
     {
         try {
             $this->__get($name);
-        } catch (InvalidArgumentException | ReflectionException $e) {
+        } catch (UnknownGetterException | ReflectionException $e) {
             return false;
         }
 
@@ -1039,7 +1042,7 @@ trait Date
      * @param string                  $name
      * @param string|int|DateTimeZone $value
      *
-     * @throws InvalidArgumentException|ReflectionException
+     * @throws UnknownSetterException|ReflectionException
      *
      * @return void
      */
@@ -1060,7 +1063,7 @@ trait Date
      * @param string|array            $name
      * @param string|int|DateTimeZone $value
      *
-     * @throws InvalidArgumentException|ReflectionException
+     * @throws ImmutableException|UnknownSetterException
      *
      * @return $this
      */
@@ -1549,7 +1552,7 @@ trait Date
     /**
      * Set the year, month, and date for this instance to that of the passed instance.
      *
-     * @param \Carbon\Carbon|\DateTimeInterface $date now if null
+     * @param Carbon|DateTimeInterface $date now if null
      *
      * @return static
      */
@@ -1563,7 +1566,7 @@ trait Date
     /**
      * Set the hour, minute, second and microseconds for this instance to that of the passed instance.
      *
-     * @param \Carbon\Carbon|\DateTimeInterface $date now if null
+     * @param Carbon|DateTimeInterface $date now if null
      *
      * @return static
      */
@@ -1577,7 +1580,7 @@ trait Date
     /**
      * Set the date and time for this instance to that of the passed instance.
      *
-     * @param \Carbon\Carbon|\DateTimeInterface $date
+     * @param Carbon|DateTimeInterface $date
      *
      * @return static
      */

--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -2287,9 +2287,9 @@ trait Date
      * @param string $method     magic method name called
      * @param array  $parameters parameters list
      *
-     * @return mixed
      * @throws BadMethodCallException
      *
+     * @return mixed
      */
     public static function __callStatic($method, $parameters)
     {
@@ -2420,8 +2420,8 @@ trait Date
     /**
      * Dynamically handle calls to the class.
      *
-     * @param string $method magic method name called
-     * @param array $parameters parameters list
+     * @param string $method     magic method name called
+     * @param array  $parameters parameters list
      *
      * @throws UnknownMethodException|BadMethodCallException|ReflectionException|Throwable
      *

--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -527,7 +527,6 @@ trait Date
     use Converter;
     use Creator;
     use Difference;
-    use IntervalRounding;
     use Macro;
     use Modifiers;
     use Mutability;

--- a/src/Carbon/Traits/IntervalRounding.php
+++ b/src/Carbon/Traits/IntervalRounding.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Traits;
+
+/**
+ * Trait to call rounding methods to interval or the interval of a period.
+ */
+trait IntervalRounding
+{
+    protected function callRoundMethod(string $method, array $parameters)
+    {
+        $action = substr($method, 0, 4);
+
+        if ($action !== 'ceil') {
+            $action = substr($method, 0, 5);
+        }
+
+        if (in_array($action, ['round', 'floor', 'ceil'])) {
+            return $this->{$action.'Unit'}(substr($method, strlen($action)), ...$parameters);
+        }
+
+        return null;
+    }
+}

--- a/src/Carbon/Traits/IntervalRounding.php
+++ b/src/Carbon/Traits/IntervalRounding.php
@@ -10,6 +10,10 @@
  */
 namespace Carbon\Traits;
 
+use Carbon\CarbonInterval;
+use Carbon\Exceptions\InvalidIntervalException;
+use DateInterval;
+
 /**
  * Trait to call rounding methods to interval or the interval of a period.
  */
@@ -28,5 +32,25 @@ trait IntervalRounding
         }
 
         return null;
+    }
+
+    protected function roundWith($precision, $function)
+    {
+        $unit = 'second';
+
+        if ($precision instanceof DateInterval) {
+            $precision = (string) CarbonInterval::instance($precision);
+        }
+
+        if (is_string($precision) && preg_match('/^\s*(?<precision>\d+)?\s*(?<unit>\w+)(?<other>\W.*)?$/', $precision, $match)) {
+            if (trim($match['other'] ?? '') !== '') {
+                throw new InvalidIntervalException('Rounding is only possible with single unit intervals.');
+            }
+
+            $precision = (int) ($match['precision'] ?: 1);
+            $unit = $match['unit'];
+        }
+
+        return $this->roundUnit($unit, $precision, $function);
     }
 }

--- a/src/Carbon/Traits/Localization.php
+++ b/src/Carbon/Traits/Localization.php
@@ -11,11 +11,11 @@
 namespace Carbon\Traits;
 
 use Carbon\CarbonInterface;
+use Carbon\Exceptions\InvalidTypeException;
 use Carbon\Exceptions\NotLocaleAwareException;
 use Carbon\Language;
 use Carbon\Translator;
 use Closure;
-use InvalidArgumentException;
 use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
@@ -185,7 +185,7 @@ trait Localization
     public static function getTranslationMessageWith($translator, string $key, string $locale = null, string $default = null)
     {
         if (!($translator instanceof TranslatorBagInterface && $translator instanceof TranslatorInterface)) {
-            throw new InvalidArgumentException(
+            throw new InvalidTypeException(
                 'Translator does not implement '.TranslatorInterface::class.' and '.TranslatorBagInterface::class.'.'
             );
         }

--- a/src/Carbon/Traits/Rounding.php
+++ b/src/Carbon/Traits/Rounding.php
@@ -11,10 +11,7 @@
 namespace Carbon\Traits;
 
 use Carbon\CarbonInterface;
-use Carbon\CarbonInterval;
-use Carbon\Exceptions\InvalidIntervalException;
 use Carbon\Exceptions\UnknownUnitException;
-use DateInterval;
 
 /**
  * Trait Rounding.
@@ -28,6 +25,8 @@ use DateInterval;
  */
 trait Rounding
 {
+    use IntervalRounding;
+
     /**
      * Round the current instance at the given unit with given precision if specified and the given function.
      *
@@ -151,22 +150,7 @@ trait Rounding
      */
     public function round($precision = 1, $function = 'round')
     {
-        $unit = 'second';
-
-        if ($precision instanceof DateInterval) {
-            $precision = (string) CarbonInterval::instance($precision);
-        }
-
-        if (is_string($precision) && preg_match('/^\s*(?<precision>\d+)?\s*(?<unit>\w+)(?<other>\W.*)?$/', $precision, $match)) {
-            if (trim($match['other'] ?? '') !== '') {
-                throw new InvalidIntervalException('Rounding is only possible with single unit intervals.');
-            }
-
-            $precision = (int) ($match['precision'] ?: 1);
-            $unit = $match['unit'];
-        }
-
-        return $this->roundUnit($unit, $precision, $function);
+        return $this->roundWith($precision, $function);
     }
 
     /**

--- a/src/Carbon/Traits/Rounding.php
+++ b/src/Carbon/Traits/Rounding.php
@@ -12,8 +12,9 @@ namespace Carbon\Traits;
 
 use Carbon\CarbonInterface;
 use Carbon\CarbonInterval;
+use Carbon\Exceptions\InvalidIntervalException;
+use Carbon\Exceptions\UnknownUnitException;
 use DateInterval;
-use InvalidArgumentException;
 
 /**
  * Trait Rounding.
@@ -69,7 +70,7 @@ trait Rounding
         $precision *= $factor;
 
         if (!isset($ranges[$normalizedUnit])) {
-            throw new InvalidArgumentException("Unknown unit '$unit' to floor");
+            throw new UnknownUnitException($unit);
         }
 
         $found = false;
@@ -158,7 +159,7 @@ trait Rounding
 
         if (is_string($precision) && preg_match('/^\s*(?<precision>\d+)?\s*(?<unit>\w+)(?<other>\W.*)?$/', $precision, $match)) {
             if (trim($match['other'] ?? '') !== '') {
-                throw new InvalidArgumentException('Rounding is only possible with single unit intervals.');
+                throw new InvalidIntervalException('Rounding is only possible with single unit intervals.');
             }
 
             $precision = (int) ($match['precision'] ?: 1);

--- a/src/Carbon/Traits/Serialization.php
+++ b/src/Carbon/Traits/Serialization.php
@@ -11,7 +11,6 @@
 namespace Carbon\Traits;
 
 use Carbon\Exceptions\InvalidFormatException;
-use InvalidArgumentException;
 
 /**
  * Trait Serialization.

--- a/src/Carbon/Traits/Serialization.php
+++ b/src/Carbon/Traits/Serialization.php
@@ -10,6 +10,7 @@
  */
 namespace Carbon\Traits;
 
+use Carbon\Exceptions\InvalidFormatException;
 use InvalidArgumentException;
 
 /**
@@ -69,7 +70,7 @@ trait Serialization
      *
      * @param string $value
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidFormatException
      *
      * @return static
      */
@@ -78,7 +79,7 @@ trait Serialization
         $instance = @unserialize("$value");
 
         if (!$instance instanceof static) {
-            throw new InvalidArgumentException('Invalid serialized value.');
+            throw new InvalidFormatException("Invalid serialized value: $value");
         }
 
         return $instance;

--- a/src/Carbon/Traits/Units.php
+++ b/src/Carbon/Traits/Units.php
@@ -12,8 +12,8 @@ namespace Carbon\Traits;
 
 use Carbon\CarbonInterface;
 use Carbon\CarbonInterval;
+use Carbon\Exceptions\UnitException;
 use DateInterval;
-use InvalidArgumentException;
 
 /**
  * Trait Units.
@@ -124,7 +124,7 @@ trait Units
 
             default:
                 if ($this->localStrictModeEnabled ?? static::isStrictModeEnabled()) {
-                    throw new InvalidArgumentException("Invalid unit for real timestamp add/sub: '$unit'");
+                    throw new UnitException("Invalid unit for real timestamp add/sub: '$unit'");
                 }
 
                 return $this;

--- a/tests/Carbon/CreateTest.php
+++ b/tests/Carbon/CreateTest.php
@@ -12,7 +12,9 @@ declare(strict_types=1);
 namespace Tests\Carbon;
 
 use Carbon\Carbon;
+use Carbon\Exceptions\OutOfRangeException;
 use DateTimeZone;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 class CreateTest extends AbstractTestCase
@@ -67,10 +69,27 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateWithInvalidMonth()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('month must be between 0 and 99, -5 given');
 
         Carbon::create(null, -5);
+    }
+
+    public function testOutOfRangeException()
+    {
+        $error = null;
+
+        try {
+            Carbon::create(null, -5);
+        } catch (OutOfRangeException $exception) {
+            $error = $exception;
+        }
+
+        $this->assertInstanceOf(OutOfRangeException::class, $error);
+        $this->assertSame('month', $error->getUnit());
+        $this->assertSame(-5, $error->getValue());
+        $this->assertSame(0, $error->getMin());
+        $this->assertSame(99, $error->getMax());
     }
 
     public function testCreateWithInvalidMonthNonStrictMode()
@@ -96,7 +115,7 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateWithInvalidDay()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         Carbon::create(null, null, -4);
     }
@@ -117,7 +136,7 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateWithInvalidHour()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         Carbon::create(null, null, null, -1);
     }
@@ -136,7 +155,7 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateWithInvalidMinute()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         Carbon::create(2011, 1, 1, 0, -2, 0);
     }
@@ -155,7 +174,7 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateWithInvalidSecond()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         Carbon::create(null, null, null, null, null, -2);
     }
@@ -190,7 +209,7 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateWithInvalidTimezoneOffset()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         Carbon::createFromDate(2000, 1, 1, -28236);
     }
@@ -243,7 +262,7 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateFromIsoFormatException()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Format wo not supported for creation.');
 
         Carbon::createFromIsoFormat('YY D wo', '2019 April 4');

--- a/tests/Carbon/LocalizationTest.php
+++ b/tests/Carbon/LocalizationTest.php
@@ -729,6 +729,13 @@ class LocalizationTest extends AbstractTestCase
         $this->assertSame('3 კვირაში', $diff);
     }
 
+    public function testSinhaleseSpecialAfterTranslation()
+    {
+        $diff = Carbon::now()->locale('si')->addDays(3)->diffForHumans(Carbon::now());
+
+        $this->assertSame('දින 3 න්', $diff);
+    }
+
     public function testWeekDayMultipleForms()
     {
         $date = Carbon::parse('2018-10-10')->locale('ru');

--- a/tests/Carbon/RoundTest.php
+++ b/tests/Carbon/RoundTest.php
@@ -160,7 +160,7 @@ class RoundTest extends AbstractTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'Unknown unit \'foobar\' to floor'
+            'Unknown unit \'foobar\'.'
         );
 
         Carbon::now()->roundUnit('foobar');

--- a/tests/Carbon/SerializationTest.php
+++ b/tests/Carbon/SerializationTest.php
@@ -13,6 +13,7 @@ namespace Tests\Carbon;
 
 use Carbon\Carbon;
 use DateTime;
+use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionObject;
 use ReflectionProperty;
@@ -75,9 +76,9 @@ class SerializationTest extends AbstractTestCase
      */
     public function testFromUnserializedWithInvalidValue($value)
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'Invalid serialized value.'
+            "Invalid serialized value: $value"
         );
 
         Carbon::fromSerialized($value);

--- a/tests/CarbonImmutable/RoundTest.php
+++ b/tests/CarbonImmutable/RoundTest.php
@@ -127,7 +127,7 @@ class RoundTest extends AbstractTestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'Unknown unit \'foobar\' to floor'
+            'Unknown unit \'foobar\'.'
         );
 
         Carbon::now()->roundUnit('foobar');

--- a/tests/CarbonImmutable/SerializationTest.php
+++ b/tests/CarbonImmutable/SerializationTest.php
@@ -13,6 +13,7 @@ namespace Tests\CarbonImmutable;
 
 use Carbon\CarbonImmutable as Carbon;
 use DateTime;
+use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionObject;
 use ReflectionProperty;
@@ -71,9 +72,9 @@ class SerializationTest extends AbstractTestCase
      */
     public function testFromUnserializedWithInvalidValue($value)
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'Invalid serialized value.'
+            "Invalid serialized value: $value"
         );
 
         Carbon::fromSerialized($value);

--- a/tests/CarbonInterval/ConstructTest.php
+++ b/tests/CarbonInterval/ConstructTest.php
@@ -296,6 +296,7 @@ class ConstructTest extends AbstractTestCase
 
     public function testMake()
     {
+        $this->assertCarbonInterval(CarbonInterval::make(3, 'hours'), 0, 0, 0, 3, 0, 0);
         $this->assertCarbonInterval(CarbonInterval::make('3 hours 30 m'), 0, 0, 0, 3, 30, 0);
         $this->assertCarbonInterval(CarbonInterval::make('PT5H'), 0, 0, 0, 5, 0, 0);
         $this->assertCarbonInterval(CarbonInterval::make(new DateInterval('P1D')), 0, 0, 1, 0, 0, 0);

--- a/tests/Doctrine/CarbonTypesTest.php
+++ b/tests/Doctrine/CarbonTypesTest.php
@@ -13,7 +13,6 @@ namespace Tests\Doctrine;
 
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
-use Carbon\Doctrine\CarbonDoctrineType;
 use Carbon\Doctrine\CarbonImmutableType;
 use Carbon\Doctrine\CarbonType;
 use Carbon\Doctrine\DateTimeDefaultPrecision;
@@ -31,7 +30,7 @@ class CarbonTypesTest extends AbstractTestCase
 {
     public static function setUpBeforeClass(): void
     {
-        foreach(static::getTypes() as [$name, , $typeClass]) {
+        foreach (static::getTypes() as [$name, , $typeClass]) {
             Type::hasType($name)
                 ? Type::overrideType($name, $typeClass)
                 : Type::addType($name, $typeClass);


### PR DESCRIPTION
Allow to catch Carbon exceptions without catching other exceptions using `catch (\Carbon\Exceptions\Exception $exception)` or to catch specific kind of exceptions without listing all precise exceptions with  `catch (\Carbon\Exceptions\BadMethodCallException $exception)`