### PR TITLE
Add php tag for syntax highlighting in README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,8 @@
 An international PHP extension for DateTime. [http://carbon.nesbot.com](http://carbon.nesbot.com)
 
 ```php
+<?php
+
 use Carbon\Carbon;
 
 printf("Right now is %s", Carbon::now()->toDateTimeString());


### PR DESCRIPTION
This PR adds an opening php tag in order to have the syntax highlighting in the README.md

**Before:**
![before](https://user-images.githubusercontent.com/2642302/82088509-31348900-96f2-11ea-8d63-373dd2f5b1b0.png)

**After:**
![after](https://user-images.githubusercontent.com/2642302/82088515-342f7980-96f2-11ea-9faf-3bad35172e15.png)
