### PR TITLE
Update Sinhala translations

### DIFF
--- a/src/Carbon/Lang/si.php
+++ b/src/Carbon/Lang/si.php
@@ -20,7 +20,7 @@ return [
     'year' => '{1}වසර 1|වසර :count',
     'a_year' => '{1}වසරක්|වසර :count',
     'month' => '{1}මාස 1|මාස :count',
-    'a_month' => '{1}මාසය|මාස :count',
+    'a_month' => '{1}මාසයක්|මාස :count',
     'week' => '{1}සති 1|සති :count',
     'a_week' => '{1}සතියක්|සති :count',
     'day' => '{1}දින 1|දින :count',
@@ -30,22 +30,22 @@ return [
     'minute' => '{1}මිනිත්තු 1|මිනිත්තු :count',
     'a_minute' => '{1}මිනිත්තුවක්|මිනිත්තු :count',
     'second' => '{1}තත්පර 1|තත්පර :count',
-    'a_second' => '{1}තත්පර කිහිපයකට|තත්පර :count',
-    'ago' => ':time කට පෙර',
+    'a_second' => '{1}තත්පරයක්|තත්පර :count',
+    'ago' => ':timeකට පෙර',
     'from_now' => function ($time) {
         if (preg_match('/දින \d+/', $time)) {
             return $time.' න්';
         }
 
-        return $time.' කින්';
+        return $time.'කින්';
     },
-    'before' => ':time කට පෙර',
+    'before' => ':timeකට පෙර',
     'after' => function ($time) {
         if (preg_match('/දින \d+/', $time)) {
-            return $time.' න්';
+            return $time.'න්';
         }
 
-        return $time.' කින්';
+        return $time.'කින්';
     },
     'diff_now' => 'දැන්',
     'diff_yesterday' => 'ඊයේ',
@@ -62,12 +62,12 @@ return [
         'sameDay' => '[අද] LT[ට]',
         'nextDay' => '[හෙට] LT[ට]',
         'nextWeek' => 'dddd LT[ට]',
-        'lastDay' => '[ඊයේ] LT[ට]',
+        'lastDay' => '[ඊයේ] L T[ට]',
         'lastWeek' => '[පසුගිය] dddd LT[ට]',
         'sameElse' => 'L',
     ],
     'ordinal' => ':number වැනි',
-    'meridiem' => ['පෙර වරු', 'පස් වරු', 'පෙ.ව.', 'ප.ව.'],
+    'meridiem' => ['පෙරවරු', 'පස්වරු', 'පෙ.ව.', 'ප.ව.'],
     'months' => ['ජනවාරි', 'පෙබරවාරි', 'මාර්තු', 'අප්‍රේල්', 'මැයි', 'ජූනි', 'ජූලි', 'අගෝස්තු', 'සැප්තැම්බර්', 'ඔක්තෝබර්', 'නොවැම්බර්', 'දෙසැම්බර්'],
     'months_short' => ['ජන', 'පෙබ', 'මාර්', 'අප්', 'මැයි', 'ජූනි', 'ජූලි', 'අගෝ', 'සැප්', 'ඔක්', 'නොවැ', 'දෙසැ'],
     'weekdays' => ['ඉරිදා', 'සඳුදා', 'අඟහරුවාදා', 'බදාදා', 'බ්‍රහස්පතින්දා', 'සිකුරාදා', 'සෙනසුරාදා'],

--- a/src/Carbon/Lang/si.php
+++ b/src/Carbon/Lang/si.php
@@ -18,15 +18,15 @@
  */
 return [
     'year' => '{1}වසර 1|වසර :count',
-    'a_year' => '{1}වසරක්|වසර :count',
+    'a_year' => '{1}වසර 1|වසර :count',
     'month' => '{1}මාස 1|මාස :count',
-    'a_month' => '{1}මාසයක්|මාස :count',
+    'a_month' => '{1}මාස 1|මාස :count',
     'week' => '{1}සති 1|සති :count',
-    'a_week' => '{1}සතියක්|සති :count',
+    'a_week' => '{1}සති 1|සති :count',
     'day' => '{1}දින 1|දින :count',
     'a_day' => '{1}දිනක්|දින :count',
     'hour' => '{1}පැය 1|පැය :count',
-    'a_hour' => '{1}පැයක්|පැය :count',
+    'a_hour' => '{1}පැය 1|පැය :count',
     'minute' => '{1}මිනිත්තු 1|මිනිත්තු :count',
     'a_minute' => '{1}මිනිත්තුවක්|මිනිත්තු :count',
     'second' => '{1}තත්පර 1|තත්පර :count',
@@ -37,15 +37,15 @@ return [
             return $time.' න්';
         }
 
-        return $time.'කින්';
+        return $time.' කින්';
     },
     'before' => ':timeකට පෙර',
     'after' => function ($time) {
         if (preg_match('/දින \d+/', $time)) {
-            return $time.'න්';
+            return $time.' න්';
         }
 
-        return $time.'කින්';
+        return $time.' කින්';
     },
     'diff_now' => 'දැන්',
     'diff_yesterday' => 'ඊයේ',

--- a/src/Carbon/Lang/si.php
+++ b/src/Carbon/Lang/si.php
@@ -62,7 +62,7 @@ return [
         'sameDay' => '[අද] LT[ට]',
         'nextDay' => '[හෙට] LT[ට]',
         'nextWeek' => 'dddd LT[ට]',
-        'lastDay' => '[ඊයේ] L T[ට]',
+        'lastDay' => '[ඊයේ] LT[ට]',
         'lastWeek' => '[පසුගිය] dddd LT[ට]',
         'sameElse' => 'L',
     ],

--- a/tests/Localization/SiLkTest.php
+++ b/tests/Localization/SiLkTest.php
@@ -97,25 +97,25 @@ class SiLkTest extends LocalizationTestCase
         // Carbon::parse('2018-04-10 00:00:00')->isoFormat('DDDo')
         '100 වැනි',
         // Carbon::parse('2018-02-10 00:00:00', 'Europe/Paris')->isoFormat('h:mm a z')
-        'පෙ.ව. 12:00 CET',
+        '12:00 පෙ.ව. CET',
         // Carbon::parse('2018-02-10 00:00:00')->isoFormat('h:mm A, h:mm a')
-        'පෙරවරු 12:00, පෙ.ව. 12:00',
+        '12:00 පෙරවරු, 12:00 පෙ.ව.',
         // Carbon::parse('2018-02-10 01:30:00')->isoFormat('h:mm A, h:mm a')
-        'පෙරවරු 1:30, පෙ.ව. 1:30',
+        '1:30 පෙරවරු, 1:30 පෙ.ව.',
         // Carbon::parse('2018-02-10 02:00:00')->isoFormat('h:mm A, h:mm a')
-        'පෙරවරු 2:00, පෙ.ව. 2:00',
+        '2:00 පෙරවරු, 2:00 පෙ.ව.',
         // Carbon::parse('2018-02-10 06:00:00')->isoFormat('h:mm A, h:mm a')
-        'පෙරවරු 6:00, පෙ.ව. 6:00',
+        '6:00 පෙරවරු, 6:00 පෙ.ව.',
         // Carbon::parse('2018-02-10 10:00:00')->isoFormat('h:mm A, h:mm a')
-        'පෙරවරු 10:00, පෙ.ව. 10:00',
+        '10:00 පෙරවරු, 10:00 පෙ.ව.',
         // Carbon::parse('2018-02-10 12:00:00')->isoFormat('h:mm A, h:mm a')
-        'පස්වරු 12:00, ප.ව. 12:00',
+        '12:00 පස්වරු, 12:00 ප.ව.',
         // Carbon::parse('2018-02-10 17:00:00')->isoFormat('h:mm A, h:mm a')
-        'පස්වරු 5:00, ප.ව. 5:00',
+        '5:00 පස්වරු, 5:00 ප.ව.',
         // Carbon::parse('2018-02-10 21:30:00')->isoFormat('h:mm A, h:mm a')
-        'පස්වරු 9:30, ප.ව. 9:30',
+        '9:30 පස්වරු, 9:30 ප.ව.',
         // Carbon::parse('2018-02-10 23:00:00')->isoFormat('h:mm A, h:mm a')
-        'පස්වරු 11:00, ප.ව. 11:00',
+        '11:00 පස්වරු, 11:00 ප.ව.',
         // Carbon::parse('2018-01-01 00:00:00')->ordinal('hour')
         '0 වැනි',
         // Carbon::now()->subSeconds(1)->diffForHumans()
@@ -175,13 +175,13 @@ class SiLkTest extends LocalizationTestCase
         // Carbon::now()->subYears(2)->diffForHumans(null, false, true)
         'වසර 2කට පෙර',
         // Carbon::now()->addSecond()->diffForHumans()
-        'තත්පර 1කින්',
+        'තත්පර 1 කින්',
         // Carbon::now()->addSecond()->diffForHumans(null, false, true)
-        'තත්පර 1කින්',
+        'තත්පර 1 කින්',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now())
-        'තත්පර 1කින්',
+        'තත්පර 1 කින්',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now(), false, true)
-        'තත්පර 1කින්',
+        'තත්පර 1 කින්',
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond())
         'තත්පර 1කට පෙර',
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond(), false, true)
@@ -195,13 +195,13 @@ class SiLkTest extends LocalizationTestCase
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond()->addSecond(), true, true)
         'තත්පර 2',
         // Carbon::now()->addSecond()->diffForHumans(null, false, true, 1)
-        'තත්පර 1කින්',
+        'තත්පර 1 කින්',
         // Carbon::now()->addMinute()->addSecond()->diffForHumans(null, true, false, 2)
         'මිනිත්තු 1 තත්පර 1',
         // Carbon::now()->addYears(2)->addMonths(3)->addDay()->addSecond()->diffForHumans(null, true, true, 4)
         'වසර 2 මාස 3 දින 1 තත්පර 1',
         // Carbon::now()->addYears(3)->diffForHumans(null, null, false, 4)
-        'වසර 3කින්',
+        'වසර 3 කින්',
         // Carbon::now()->subMonths(5)->diffForHumans(null, null, true, 4)
         'මාස 5කට පෙර',
         // Carbon::now()->subYears(2)->subMonths(3)->subDay()->subSecond()->diffForHumans(null, null, true, 4)
@@ -213,11 +213,11 @@ class SiLkTest extends LocalizationTestCase
         // Carbon::now()->addWeek()->addDays(6)->diffForHumans(null, true, false, 2)
         'සති 1 දින 6',
         // Carbon::now()->addWeek()->addDays(6)->diffForHumans(["join" => true, "parts" => 2])
-        'සති 1 දින 6න්',
+        'සති 1 දින 6 න්',
         // Carbon::now()->addWeeks(2)->addHour()->diffForHumans(null, true, false, 2)
         'සති 2 පැය 1',
         // Carbon::now()->addHour()->diffForHumans(["aUnit" => true])
-        'පැයකින්',
+        'පැය 1 කින්',
         // CarbonInterval::days(2)->forHumans()
         'දින 2',
         // CarbonInterval::create('P1DT3H')->forHumans(true)

--- a/tests/Localization/SiLkTest.php
+++ b/tests/Localization/SiLkTest.php
@@ -97,95 +97,95 @@ class SiLkTest extends LocalizationTestCase
         // Carbon::parse('2018-04-10 00:00:00')->isoFormat('DDDo')
         '100 වැනි',
         // Carbon::parse('2018-02-10 00:00:00', 'Europe/Paris')->isoFormat('h:mm a z')
-        '12:00 පෙ.ව. CET',
+        'පෙ.ව. 12:00 CET',
         // Carbon::parse('2018-02-10 00:00:00')->isoFormat('h:mm A, h:mm a')
-        '12:00 පෙර වරු, 12:00 පෙ.ව.',
+        'පෙරවරු 12:00, පෙ.ව. 12:00',
         // Carbon::parse('2018-02-10 01:30:00')->isoFormat('h:mm A, h:mm a')
-        '1:30 පෙර වරු, 1:30 පෙ.ව.',
+        'පෙරවරු 1:30, පෙ.ව. 1:30',
         // Carbon::parse('2018-02-10 02:00:00')->isoFormat('h:mm A, h:mm a')
-        '2:00 පෙර වරු, 2:00 පෙ.ව.',
+        'පෙරවරු 2:00, පෙ.ව. 2:00',
         // Carbon::parse('2018-02-10 06:00:00')->isoFormat('h:mm A, h:mm a')
-        '6:00 පෙර වරු, 6:00 පෙ.ව.',
+        'පෙරවරු 6:00, පෙ.ව. 6:00',
         // Carbon::parse('2018-02-10 10:00:00')->isoFormat('h:mm A, h:mm a')
-        '10:00 පෙර වරු, 10:00 පෙ.ව.',
+        'පෙරවරු 10:00, පෙ.ව. 10:00',
         // Carbon::parse('2018-02-10 12:00:00')->isoFormat('h:mm A, h:mm a')
-        '12:00 පස් වරු, 12:00 ප.ව.',
+        'පස්වරු 12:00, ප.ව. 12:00',
         // Carbon::parse('2018-02-10 17:00:00')->isoFormat('h:mm A, h:mm a')
-        '5:00 පස් වරු, 5:00 ප.ව.',
+        'පස්වරු 5:00, ප.ව. 5:00',
         // Carbon::parse('2018-02-10 21:30:00')->isoFormat('h:mm A, h:mm a')
-        '9:30 පස් වරු, 9:30 ප.ව.',
+        'පස්වරු 9:30, ප.ව. 9:30',
         // Carbon::parse('2018-02-10 23:00:00')->isoFormat('h:mm A, h:mm a')
-        '11:00 පස් වරු, 11:00 ප.ව.',
+        'පස්වරු 11:00, ප.ව. 11:00',
         // Carbon::parse('2018-01-01 00:00:00')->ordinal('hour')
         '0 වැනි',
         // Carbon::now()->subSeconds(1)->diffForHumans()
-        'තත්පර 1 කට පෙර',
+        'තත්පර 1කට පෙර',
         // Carbon::now()->subSeconds(1)->diffForHumans(null, false, true)
-        'තත්පර 1 කට පෙර',
+        'තත්පර 1කට පෙර',
         // Carbon::now()->subSeconds(2)->diffForHumans()
-        'තත්පර 2 කට පෙර',
+        'තත්පර 2කට පෙර',
         // Carbon::now()->subSeconds(2)->diffForHumans(null, false, true)
-        'තත්පර 2 කට පෙර',
+        'තත්පර 2කට පෙර',
         // Carbon::now()->subMinutes(1)->diffForHumans()
-        'මිනිත්තු 1 කට පෙර',
+        'මිනිත්තු 1කට පෙර',
         // Carbon::now()->subMinutes(1)->diffForHumans(null, false, true)
-        'මිනිත්තු 1 කට පෙර',
+        'මිනිත්තු 1කට පෙර',
         // Carbon::now()->subMinutes(2)->diffForHumans()
-        'මිනිත්තු 2 කට පෙර',
+        'මිනිත්තු 2කට පෙර',
         // Carbon::now()->subMinutes(2)->diffForHumans(null, false, true)
-        'මිනිත්තු 2 කට පෙර',
+        'මිනිත්තු 2කට පෙර',
         // Carbon::now()->subHours(1)->diffForHumans()
-        'පැය 1 කට පෙර',
+        'පැය 1කට පෙර',
         // Carbon::now()->subHours(1)->diffForHumans(null, false, true)
-        'පැය 1 කට පෙර',
+        'පැය 1කට පෙර',
         // Carbon::now()->subHours(2)->diffForHumans()
-        'පැය 2 කට පෙර',
+        'පැය 2කට පෙර',
         // Carbon::now()->subHours(2)->diffForHumans(null, false, true)
-        'පැය 2 කට පෙර',
+        'පැය 2කට පෙර',
         // Carbon::now()->subDays(1)->diffForHumans()
-        'දින 1 කට පෙර',
+        'දින 1කට පෙර',
         // Carbon::now()->subDays(1)->diffForHumans(null, false, true)
-        'දින 1 කට පෙර',
+        'දින 1කට පෙර',
         // Carbon::now()->subDays(2)->diffForHumans()
-        'දින 2 කට පෙර',
+        'දින 2කට පෙර',
         // Carbon::now()->subDays(2)->diffForHumans(null, false, true)
-        'දින 2 කට පෙර',
+        'දින 2කට පෙර',
         // Carbon::now()->subWeeks(1)->diffForHumans()
-        'සති 1 කට පෙර',
+        'සති 1කට පෙර',
         // Carbon::now()->subWeeks(1)->diffForHumans(null, false, true)
-        'සති 1 කට පෙර',
+        'සති 1කට පෙර',
         // Carbon::now()->subWeeks(2)->diffForHumans()
-        'සති 2 කට පෙර',
+        'සති 2කට පෙර',
         // Carbon::now()->subWeeks(2)->diffForHumans(null, false, true)
-        'සති 2 කට පෙර',
+        'සති 2කට පෙර',
         // Carbon::now()->subMonths(1)->diffForHumans()
-        'මාස 1 කට පෙර',
+        'මාස 1කට පෙර',
         // Carbon::now()->subMonths(1)->diffForHumans(null, false, true)
-        'මාස 1 කට පෙර',
+        'මාස 1කට පෙර',
         // Carbon::now()->subMonths(2)->diffForHumans()
-        'මාස 2 කට පෙර',
+        'මාස 2කට පෙර',
         // Carbon::now()->subMonths(2)->diffForHumans(null, false, true)
-        'මාස 2 කට පෙර',
+        'මාස 2කට පෙර',
         // Carbon::now()->subYears(1)->diffForHumans()
-        'වසර 1 කට පෙර',
+        'වසර 1කට පෙර',
         // Carbon::now()->subYears(1)->diffForHumans(null, false, true)
-        'වසර 1 කට පෙර',
+        'වසර 1කට පෙර',
         // Carbon::now()->subYears(2)->diffForHumans()
-        'වසර 2 කට පෙර',
+        'වසර 2කට පෙර',
         // Carbon::now()->subYears(2)->diffForHumans(null, false, true)
-        'වසර 2 කට පෙර',
+        'වසර 2කට පෙර',
         // Carbon::now()->addSecond()->diffForHumans()
-        'තත්පර 1 කින්',
+        'තත්පර 1කින්',
         // Carbon::now()->addSecond()->diffForHumans(null, false, true)
-        'තත්පර 1 කින්',
+        'තත්පර 1කින්',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now())
-        'තත්පර 1 කින්',
+        'තත්පර 1කින්',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now(), false, true)
-        'තත්පර 1 කින්',
+        'තත්පර 1කින්',
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond())
-        'තත්පර 1 කට පෙර',
+        'තත්පර 1කට පෙර',
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond(), false, true)
-        'තත්පර 1 කට පෙර',
+        'තත්පර 1කට පෙර',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now(), true)
         'තත්පර 1',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now(), true, true)
@@ -195,17 +195,17 @@ class SiLkTest extends LocalizationTestCase
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond()->addSecond(), true, true)
         'තත්පර 2',
         // Carbon::now()->addSecond()->diffForHumans(null, false, true, 1)
-        'තත්පර 1 කින්',
+        'තත්පර 1කින්',
         // Carbon::now()->addMinute()->addSecond()->diffForHumans(null, true, false, 2)
         'මිනිත්තු 1 තත්පර 1',
         // Carbon::now()->addYears(2)->addMonths(3)->addDay()->addSecond()->diffForHumans(null, true, true, 4)
         'වසර 2 මාස 3 දින 1 තත්පර 1',
         // Carbon::now()->addYears(3)->diffForHumans(null, null, false, 4)
-        'වසර 3 කින්',
+        'වසර 3කින්',
         // Carbon::now()->subMonths(5)->diffForHumans(null, null, true, 4)
-        'මාස 5 කට පෙර',
+        'මාස 5කට පෙර',
         // Carbon::now()->subYears(2)->subMonths(3)->subDay()->subSecond()->diffForHumans(null, null, true, 4)
-        'වසර 2 මාස 3 දින 1 තත්පර 1 කට පෙර',
+        'වසර 2 මාස 3 දින 1 තත්පර 1කට පෙර',
         // Carbon::now()->addWeek()->addHours(10)->diffForHumans(null, true, false, 2)
         'සති 1 පැය 10',
         // Carbon::now()->addWeek()->addDays(6)->diffForHumans(null, true, false, 2)
@@ -213,11 +213,11 @@ class SiLkTest extends LocalizationTestCase
         // Carbon::now()->addWeek()->addDays(6)->diffForHumans(null, true, false, 2)
         'සති 1 දින 6',
         // Carbon::now()->addWeek()->addDays(6)->diffForHumans(["join" => true, "parts" => 2])
-        'සති 1 දින 6 න්',
+        'සති 1 දින 6න්',
         // Carbon::now()->addWeeks(2)->addHour()->diffForHumans(null, true, false, 2)
         'සති 2 පැය 1',
         // Carbon::now()->addHour()->diffForHumans(["aUnit" => true])
-        'පැයක් කින්',
+        'පැයකින්',
         // CarbonInterval::days(2)->forHumans()
         'දින 2',
         // CarbonInterval::create('P1DT3H')->forHumans(true)

--- a/tests/Localization/SiTest.php
+++ b/tests/Localization/SiTest.php
@@ -97,25 +97,25 @@ class SiTest extends LocalizationTestCase
         // Carbon::parse('2018-04-10 00:00:00')->isoFormat('DDDo')
         '100 වැනි',
         // Carbon::parse('2018-02-10 00:00:00', 'Europe/Paris')->isoFormat('h:mm a z')
-        'පෙ.ව. 12:00 CET',
+        '12:00 පෙ.ව. CET',
         // Carbon::parse('2018-02-10 00:00:00')->isoFormat('h:mm A, h:mm a')
-        'පෙරවරු 12:00, පෙ.ව. 12:00',
+        '12:00 පෙරවරු, 12:00 පෙ.ව.',
         // Carbon::parse('2018-02-10 01:30:00')->isoFormat('h:mm A, h:mm a')
-        'පෙරවරු 1:30, පෙ.ව. 1:30',
+        '1:30 පෙරවරු, 1:30 පෙ.ව.',
         // Carbon::parse('2018-02-10 02:00:00')->isoFormat('h:mm A, h:mm a')
-        'පෙරවරු 2:00, පෙ.ව. 2:00',
+        '2:00 පෙරවරු, 2:00 පෙ.ව.',
         // Carbon::parse('2018-02-10 06:00:00')->isoFormat('h:mm A, h:mm a')
-        'පෙරවරු 6:00, පෙ.ව. 6:00',
+        '6:00 පෙරවරු, 6:00 පෙ.ව.',
         // Carbon::parse('2018-02-10 10:00:00')->isoFormat('h:mm A, h:mm a')
-        'පෙරවරු 10:00, පෙ.ව. 10:00',
+        '10:00 පෙරවරු, 10:00 පෙ.ව.',
         // Carbon::parse('2018-02-10 12:00:00')->isoFormat('h:mm A, h:mm a')
-        'පස්වරු 12:00, ප.ව. 12:00',
+        '12:00 පස්වරු, 12:00 ප.ව.',
         // Carbon::parse('2018-02-10 17:00:00')->isoFormat('h:mm A, h:mm a')
-        'පස්වරු 5:00, ප.ව. 5:00',
+        '5:00 පස්වරු, 5:00 ප.ව.',
         // Carbon::parse('2018-02-10 21:30:00')->isoFormat('h:mm A, h:mm a')
-        'පස්වරු 9:30, ප.ව. 9:30',
+        '9:30 පස්වරු, 9:30 ප.ව.',
         // Carbon::parse('2018-02-10 23:00:00')->isoFormat('h:mm A, h:mm a')
-        'පස්වරු 11:00, ප.ව. 11:00',
+        '11:00 පස්වරු, 11:00 ප.ව.',
         // Carbon::parse('2018-01-01 00:00:00')->ordinal('hour')
         '0 වැනි',
         // Carbon::now()->subSeconds(1)->diffForHumans()
@@ -175,13 +175,13 @@ class SiTest extends LocalizationTestCase
         // Carbon::now()->subYears(2)->diffForHumans(null, false, true)
         'වසර 2කට පෙර',
         // Carbon::now()->addSecond()->diffForHumans()
-        'තත්පර 1කින්',
+        'තත්පර 1 කින්',
         // Carbon::now()->addSecond()->diffForHumans(null, false, true)
-        'තත්පර 1කින්',
+        'තත්පර 1 කින්',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now())
-        'තත්පර 1කින්',
+        'තත්පර 1 කින්',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now(), false, true)
-        'තත්පර 1කින්',
+        'තත්පර 1 කින්',
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond())
         'තත්පර 1කට පෙර',
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond(), false, true)
@@ -195,13 +195,13 @@ class SiTest extends LocalizationTestCase
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond()->addSecond(), true, true)
         'තත්පර 2',
         // Carbon::now()->addSecond()->diffForHumans(null, false, true, 1)
-        'තත්පර 1කින්',
+        'තත්පර 1 කින්',
         // Carbon::now()->addMinute()->addSecond()->diffForHumans(null, true, false, 2)
         'මිනිත්තු 1 තත්පර 1',
         // Carbon::now()->addYears(2)->addMonths(3)->addDay()->addSecond()->diffForHumans(null, true, true, 4)
         'වසර 2 මාස 3 දින 1 තත්පර 1',
         // Carbon::now()->addYears(3)->diffForHumans(null, null, false, 4)
-        'වසර 3කින්',
+        'වසර 3 කින්',
         // Carbon::now()->subMonths(5)->diffForHumans(null, null, true, 4)
         'මාස 5කට පෙර',
         // Carbon::now()->subYears(2)->subMonths(3)->subDay()->subSecond()->diffForHumans(null, null, true, 4)
@@ -213,11 +213,11 @@ class SiTest extends LocalizationTestCase
         // Carbon::now()->addWeek()->addDays(6)->diffForHumans(null, true, false, 2)
         'සති 1 දින 6',
         // Carbon::now()->addWeek()->addDays(6)->diffForHumans(["join" => true, "parts" => 2])
-        'සති 1 දින 6න්',
+        'සති 1 දින 6 න්',
         // Carbon::now()->addWeeks(2)->addHour()->diffForHumans(null, true, false, 2)
         'සති 2 පැය 1',
         // Carbon::now()->addHour()->diffForHumans(["aUnit" => true])
-        'පැයකින්',
+        'පැය 1 කින්',
         // CarbonInterval::days(2)->forHumans()
         'දින 2',
         // CarbonInterval::create('P1DT3H')->forHumans(true)

--- a/tests/Localization/SiTest.php
+++ b/tests/Localization/SiTest.php
@@ -97,95 +97,95 @@ class SiTest extends LocalizationTestCase
         // Carbon::parse('2018-04-10 00:00:00')->isoFormat('DDDo')
         '100 වැනි',
         // Carbon::parse('2018-02-10 00:00:00', 'Europe/Paris')->isoFormat('h:mm a z')
-        '12:00 පෙ.ව. CET',
+        'පෙ.ව. 12:00 CET',
         // Carbon::parse('2018-02-10 00:00:00')->isoFormat('h:mm A, h:mm a')
-        '12:00 පෙර වරු, 12:00 පෙ.ව.',
+        'පෙරවරු 12:00, පෙ.ව. 12:00',
         // Carbon::parse('2018-02-10 01:30:00')->isoFormat('h:mm A, h:mm a')
-        '1:30 පෙර වරු, 1:30 පෙ.ව.',
+        'පෙරවරු 1:30, පෙ.ව. 1:30',
         // Carbon::parse('2018-02-10 02:00:00')->isoFormat('h:mm A, h:mm a')
-        '2:00 පෙර වරු, 2:00 පෙ.ව.',
+        'පෙරවරු 2:00, පෙ.ව. 2:00',
         // Carbon::parse('2018-02-10 06:00:00')->isoFormat('h:mm A, h:mm a')
-        '6:00 පෙර වරු, 6:00 පෙ.ව.',
+        'පෙරවරු 6:00, පෙ.ව. 6:00',
         // Carbon::parse('2018-02-10 10:00:00')->isoFormat('h:mm A, h:mm a')
-        '10:00 පෙර වරු, 10:00 පෙ.ව.',
+        'පෙරවරු 10:00, පෙ.ව. 10:00',
         // Carbon::parse('2018-02-10 12:00:00')->isoFormat('h:mm A, h:mm a')
-        '12:00 පස් වරු, 12:00 ප.ව.',
+        'පස්වරු 12:00, ප.ව. 12:00',
         // Carbon::parse('2018-02-10 17:00:00')->isoFormat('h:mm A, h:mm a')
-        '5:00 පස් වරු, 5:00 ප.ව.',
+        'පස්වරු 5:00, ප.ව. 5:00',
         // Carbon::parse('2018-02-10 21:30:00')->isoFormat('h:mm A, h:mm a')
-        '9:30 පස් වරු, 9:30 ප.ව.',
+        'පස්වරු 9:30, ප.ව. 9:30',
         // Carbon::parse('2018-02-10 23:00:00')->isoFormat('h:mm A, h:mm a')
-        '11:00 පස් වරු, 11:00 ප.ව.',
+        'පස්වරු 11:00, ප.ව. 11:00',
         // Carbon::parse('2018-01-01 00:00:00')->ordinal('hour')
         '0 වැනි',
         // Carbon::now()->subSeconds(1)->diffForHumans()
-        'තත්පර 1 කට පෙර',
+        'තත්පර 1කට පෙර',
         // Carbon::now()->subSeconds(1)->diffForHumans(null, false, true)
-        'තත්පර 1 කට පෙර',
+        'තත්පර 1කට පෙර',
         // Carbon::now()->subSeconds(2)->diffForHumans()
-        'තත්පර 2 කට පෙර',
+        'තත්පර 2කට පෙර',
         // Carbon::now()->subSeconds(2)->diffForHumans(null, false, true)
-        'තත්පර 2 කට පෙර',
+        'තත්පර 2කට පෙර',
         // Carbon::now()->subMinutes(1)->diffForHumans()
-        'මිනිත්තු 1 කට පෙර',
+        'මිනිත්තු 1කට පෙර',
         // Carbon::now()->subMinutes(1)->diffForHumans(null, false, true)
-        'මිනිත්තු 1 කට පෙර',
+        'මිනිත්තු 1කට පෙර',
         // Carbon::now()->subMinutes(2)->diffForHumans()
-        'මිනිත්තු 2 කට පෙර',
+        'මිනිත්තු 2කට පෙර',
         // Carbon::now()->subMinutes(2)->diffForHumans(null, false, true)
-        'මිනිත්තු 2 කට පෙර',
+        'මිනිත්තු 2කට පෙර',
         // Carbon::now()->subHours(1)->diffForHumans()
-        'පැය 1 කට පෙර',
+        'පැය 1කට පෙර',
         // Carbon::now()->subHours(1)->diffForHumans(null, false, true)
-        'පැය 1 කට පෙර',
+        'පැය 1කට පෙර',
         // Carbon::now()->subHours(2)->diffForHumans()
-        'පැය 2 කට පෙර',
+        'පැය 2කට පෙර',
         // Carbon::now()->subHours(2)->diffForHumans(null, false, true)
-        'පැය 2 කට පෙර',
+        'පැය 2කට පෙර',
         // Carbon::now()->subDays(1)->diffForHumans()
-        'දින 1 කට පෙර',
+        'දින 1කට පෙර',
         // Carbon::now()->subDays(1)->diffForHumans(null, false, true)
-        'දින 1 කට පෙර',
+        'දින 1කට පෙර',
         // Carbon::now()->subDays(2)->diffForHumans()
-        'දින 2 කට පෙර',
+        'දින 2කට පෙර',
         // Carbon::now()->subDays(2)->diffForHumans(null, false, true)
-        'දින 2 කට පෙර',
+        'දින 2කට පෙර',
         // Carbon::now()->subWeeks(1)->diffForHumans()
-        'සති 1 කට පෙර',
+        'සති 1කට පෙර',
         // Carbon::now()->subWeeks(1)->diffForHumans(null, false, true)
-        'සති 1 කට පෙර',
+        'සති 1කට පෙර',
         // Carbon::now()->subWeeks(2)->diffForHumans()
-        'සති 2 කට පෙර',
+        'සති 2කට පෙර',
         // Carbon::now()->subWeeks(2)->diffForHumans(null, false, true)
-        'සති 2 කට පෙර',
+        'සති 2කට පෙර',
         // Carbon::now()->subMonths(1)->diffForHumans()
-        'මාස 1 කට පෙර',
+        'මාස 1කට පෙර',
         // Carbon::now()->subMonths(1)->diffForHumans(null, false, true)
-        'මාස 1 කට පෙර',
+        'මාස 1කට පෙර',
         // Carbon::now()->subMonths(2)->diffForHumans()
-        'මාස 2 කට පෙර',
+        'මාස 2කට පෙර',
         // Carbon::now()->subMonths(2)->diffForHumans(null, false, true)
-        'මාස 2 කට පෙර',
+        'මාස 2කට පෙර',
         // Carbon::now()->subYears(1)->diffForHumans()
-        'වසර 1 කට පෙර',
+        'වසර 1කට පෙර',
         // Carbon::now()->subYears(1)->diffForHumans(null, false, true)
-        'වසර 1 කට පෙර',
+        'වසර 1කට පෙර',
         // Carbon::now()->subYears(2)->diffForHumans()
-        'වසර 2 කට පෙර',
+        'වසර 2කට පෙර',
         // Carbon::now()->subYears(2)->diffForHumans(null, false, true)
-        'වසර 2 කට පෙර',
+        'වසර 2කට පෙර',
         // Carbon::now()->addSecond()->diffForHumans()
-        'තත්පර 1 කින්',
+        'තත්පර 1කින්',
         // Carbon::now()->addSecond()->diffForHumans(null, false, true)
-        'තත්පර 1 කින්',
+        'තත්පර 1කින්',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now())
-        'තත්පර 1 කින්',
+        'තත්පර 1කින්',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now(), false, true)
-        'තත්පර 1 කින්',
+        'තත්පර 1කින්',
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond())
-        'තත්පර 1 කට පෙර',
+        'තත්පර 1කට පෙර',
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond(), false, true)
-        'තත්පර 1 කට පෙර',
+        'තත්පර 1කට පෙර',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now(), true)
         'තත්පර 1',
         // Carbon::now()->addSecond()->diffForHumans(Carbon::now(), true, true)
@@ -195,17 +195,17 @@ class SiTest extends LocalizationTestCase
         // Carbon::now()->diffForHumans(Carbon::now()->addSecond()->addSecond(), true, true)
         'තත්පර 2',
         // Carbon::now()->addSecond()->diffForHumans(null, false, true, 1)
-        'තත්පර 1 කින්',
+        'තත්පර 1කින්',
         // Carbon::now()->addMinute()->addSecond()->diffForHumans(null, true, false, 2)
         'මිනිත්තු 1 තත්පර 1',
         // Carbon::now()->addYears(2)->addMonths(3)->addDay()->addSecond()->diffForHumans(null, true, true, 4)
         'වසර 2 මාස 3 දින 1 තත්පර 1',
         // Carbon::now()->addYears(3)->diffForHumans(null, null, false, 4)
-        'වසර 3 කින්',
+        'වසර 3කින්',
         // Carbon::now()->subMonths(5)->diffForHumans(null, null, true, 4)
-        'මාස 5 කට පෙර',
+        'මාස 5කට පෙර',
         // Carbon::now()->subYears(2)->subMonths(3)->subDay()->subSecond()->diffForHumans(null, null, true, 4)
-        'වසර 2 මාස 3 දින 1 තත්පර 1 කට පෙර',
+        'වසර 2 මාස 3 දින 1 තත්පර 1කට පෙර',
         // Carbon::now()->addWeek()->addHours(10)->diffForHumans(null, true, false, 2)
         'සති 1 පැය 10',
         // Carbon::now()->addWeek()->addDays(6)->diffForHumans(null, true, false, 2)
@@ -213,11 +213,11 @@ class SiTest extends LocalizationTestCase
         // Carbon::now()->addWeek()->addDays(6)->diffForHumans(null, true, false, 2)
         'සති 1 දින 6',
         // Carbon::now()->addWeek()->addDays(6)->diffForHumans(["join" => true, "parts" => 2])
-        'සති 1 දින 6 න්',
+        'සති 1 දින 6න්',
         // Carbon::now()->addWeeks(2)->addHour()->diffForHumans(null, true, false, 2)
         'සති 2 පැය 1',
         // Carbon::now()->addHour()->diffForHumans(["aUnit" => true])
-        'පැයක් කින්',
+        'පැයකින්',
         // CarbonInterval::days(2)->forHumans()
         'දින 2',
         // CarbonInterval::create('P1DT3H')->forHumans(true)


### PR DESCRIPTION
Updated a couple of translations according to the usual usage in Sinhala.

Major changed are,

- `12:00 පෙරවරු, 12:00 පෙ.ව.` should be `පෙරවරු 12:00, පෙ.ව. 12:00`,

- In `තත්පර 1 කට පෙර`, space between `1` and `කට` should be removed. Also when using `කින්` and `න්`, leading space should be removed.

- `පෙර වරු`, `පස් වරු` should be `පෙරවරු`, `පස් වරු`. (Without space)

