### PR TITLE
Fix #2101 iterate over every timezone to find it

### DIFF
--- a/src/Carbon/CarbonTimeZone.php
+++ b/src/Carbon/CarbonTimeZone.php
@@ -173,14 +173,15 @@ class CarbonTimeZone extends DateTimeZone
     }
 
     /**
-     * Returns the first region string (such as "America/Toronto") that matches the current timezone.
+     * Returns the first region string (such as "America/Toronto") that matches the current timezone or
+     * false if no match is found.
      *
      * @see timezone_name_from_abbr native PHP function.
      *
      * @param DateTimeInterface|null $date
      * @param int                    $isDst
      *
-     * @return string
+     * @return string|false
      */
     public function toRegionName(DateTimeInterface $date = null, $isDst = 1)
     {
@@ -191,16 +192,30 @@ class CarbonTimeZone extends DateTimeZone
             return $name;
         }
 
+        $date = $date ?: Carbon::now($this);
+
         // Integer construction no longer supported since PHP 8
         // @codeCoverageIgnoreStart
         try {
-            $offset = @$this->getOffset($date ?: Carbon::now($this)) ?: 0;
+            $offset = @$this->getOffset($date) ?: 0;
         } catch (\Throwable $e) {
             $offset = 0;
         }
         // @codeCoverageIgnoreEnd
 
-        return @timezone_name_from_abbr('', $offset, $isDst);
+        $name = @timezone_name_from_abbr('', $offset, $isDst);
+
+        if ($name) {
+            return $name;
+        }
+
+        foreach (timezone_identifiers_list() as $timezone) {
+            if (Carbon::instance($date)->tz($timezone)->getOffset() === $offset) {
+                return $timezone;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/CarbonTimeZone/ConversionsTest.php
+++ b/tests/CarbonTimeZone/ConversionsTest.php
@@ -37,6 +37,8 @@ class ConversionsTest extends AbstractTestCase
         $this->assertFalse((new CarbonTimeZone(-15))->toRegionName());
         $date = Carbon::parse('2018-12-20');
         $this->assertSame('America/Chicago', (new CarbonTimeZone('America/Toronto'))->toOffsetTimeZone($date)->toRegionName($date));
+        $date = Carbon::parse('2020-06-11T12:30:00-02:30');
+        $this->assertSame('America/St_Johns', $date->getTimezone()->toRegionName($date));
     }
 
     public function testToRegionTimeZone()


### PR DESCRIPTION
Enable to find some timezones `timezone_name_from_abbr()` is not able to find.