### PR TITLE
Implement dynamic intervals

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "require-dev": {
         "doctrine/orm": "^2.7",
         "friendsofphp/php-cs-fixer": "^2.14 || ^3.0",
-        "kylekatarnls/multi-tester": "2.x-dev",
+        "kylekatarnls/multi-tester": "^2.0",
         "phpmd/phpmd": "^2.8",
         "phpstan/phpstan": "^0.11",
         "phpunit/phpunit": "^7.5 || ^8.0",

--- a/phpdoc.php
+++ b/phpdoc.php
@@ -87,7 +87,7 @@ function cleanClassName($name)
         $name = "\\$name";
     }
 
-    return preg_replace('/^\\\\(DateTime(?:Immutable)?|Interface|Zone|[A-Za-z]*Exception|Closure)$/i', '$1', preg_replace('/^\\\\Carbon\\\\/', '', $name));
+    return preg_replace('/^\\\\(Date(?:Time(?:Immutable|Interface|Zone)?|Interval)|[A-Za-z]*Exception|Closure)$/i', '$1', preg_replace('/^\\\\Carbon\\\\/', '', $name));
 }
 
 function dumpParameter($method, ReflectionParameter $parameter)

--- a/phpdoc.php
+++ b/phpdoc.php
@@ -29,12 +29,12 @@ $trait = __DIR__.'/src/Carbon/Traits/Date.php';
 $code = '';
 $overrideTyping = [
     $carbon => [
-        'createFromImmutable' => ['static Carbon', 'DateTimeImmutable $dateTime', 'Create a new Carbon object from an immutable date.'],
+        // 'createFromImmutable' => ['static Carbon', 'DateTimeImmutable $dateTime', 'Create a new Carbon object from an immutable date.'],
         'createFromFormat' => ['static Carbon', 'string $format, string $time, string|DateTimeZone $timezone = null', 'Parse a string into a new Carbon object according to the specified format.'],
         '__set_state' => ['static Carbon', 'array $array', 'https://php.net/manual/en/datetime.set-state.php'],
     ],
     $immutable => [
-        'createFromMutable' => ['static CarbonImmutable', 'DateTime $dateTime', 'Create a new CarbonImmutable object from an immutable date.'],
+        // 'createFromMutable' => ['static CarbonImmutable', 'DateTime $dateTime', 'Create a new CarbonImmutable object from an immutable date.'],
         'createFromFormat' => ['static CarbonImmutable', 'string $format, string $time, string|DateTimeZone $timezone = null', 'Parse a string into a new CarbonImmutable object according to the specified format.'],
         '__set_state' => ['static CarbonImmutable', 'array $array', 'https://php.net/manual/en/datetime.set-state.php'],
     ],

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,3 +16,4 @@ parameters:
         - '*/tests/Laravel/*.php'
         - '*/tests/Cli/*.php'
         - '*/tests/CarbonPeriod/Fixtures/filters.php'
+        - '*/tests/Fixtures/dynamicInterval.php'

--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -12,7 +12,6 @@ namespace Carbon;
 
 use Carbon\Traits\Date;
 use DateTime;
-use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
 
@@ -503,7 +502,6 @@ use DateTimeZone;
  * @method        string         longRelativeToNowDiffForHumans(DateTimeInterface $other = null, int $parts = 1)      Get the difference (long format, 'RelativeToNow' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
  * @method        string         shortRelativeToOtherDiffForHumans(DateTimeInterface $other = null, int $parts = 1)   Get the difference (short format, 'RelativeToOther' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
  * @method        string         longRelativeToOtherDiffForHumans(DateTimeInterface $other = null, int $parts = 1)    Get the difference (long format, 'RelativeToOther' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
- * @method        static Carbon  createFromImmutable(DateTimeImmutable $dateTime)                                     Create a new Carbon object from an immutable date.
  * @method        static Carbon  createFromFormat(string $format, string $time, string|DateTimeZone $timezone = null) Parse a string into a new Carbon object according to the specified format.
  * @method        static Carbon  __set_state(array $array)                                                            https://php.net/manual/en/datetime.set-state.php
  *

--- a/src/Carbon/CarbonConverterInterface.php
+++ b/src/Carbon/CarbonConverterInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon;
+
+use DateTimeInterface;
+
+interface CarbonConverterInterface
+{
+    public function convertDate(DateTimeInterface $dateTime, bool $negated = false): DateTimeInterface;
+}

--- a/src/Carbon/CarbonImmutable.php
+++ b/src/Carbon/CarbonImmutable.php
@@ -11,7 +11,6 @@
 namespace Carbon;
 
 use Carbon\Traits\Date;
-use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
@@ -503,7 +502,6 @@ use DateTimeZone;
  * @method        string                 longRelativeToNowDiffForHumans(DateTimeInterface $other = null, int $parts = 1)      Get the difference (long format, 'RelativeToNow' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
  * @method        string                 shortRelativeToOtherDiffForHumans(DateTimeInterface $other = null, int $parts = 1)   Get the difference (short format, 'RelativeToOther' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
  * @method        string                 longRelativeToOtherDiffForHumans(DateTimeInterface $other = null, int $parts = 1)    Get the difference (long format, 'RelativeToOther' mode) in a human readable format in the current locale. ($other and $parts parameters can be swapped.)
- * @method        static CarbonImmutable createFromMutable(DateTime $dateTime)                                                Create a new CarbonImmutable object from an immutable date.
  * @method        static CarbonImmutable createFromFormat(string $format, string $time, string|DateTimeZone $timezone = null) Parse a string into a new CarbonImmutable object according to the specified format.
  * @method        static CarbonImmutable __set_state(array $array)                                                            https://php.net/manual/en/datetime.set-state.php
  *

--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -731,9 +731,9 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
      * @example $date->add(15, 'days')
      * @example $date->add(CarbonInterval::days(4))
      *
-     * @param string|DateInterval $unit
-     * @param int                 $value
-     * @param bool|null           $overflow
+     * @param string|DateInterval|Closure|CarbonConverterInterface $unit
+     * @param int                                                  $value
+     * @param bool|null                                            $overflow
      *
      * @return static
      */
@@ -3399,6 +3399,15 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
     public function range($end = null, $interval = null, $unit = null);
 
     /**
+     * Call native PHP DateTime/DateTimeImmutable add() method.
+     *
+     * @param DateInterval $interval
+     *
+     * @return static
+     */
+    public function rawAdd(DateInterval $interval);
+
+    /**
      * Create a Carbon instance from a specific format.
      *
      * @param string                         $format Datetime format
@@ -3435,6 +3444,15 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
      * @return static
      */
     public static function rawParse($time = null, $tz = null);
+
+    /**
+     * Call native PHP DateTime/DateTimeImmutable sub() method.
+     *
+     * @param DateInterval $interval
+     *
+     * @return static
+     */
+    public function rawSub(DateInterval $interval);
 
     /**
      * Remove all macros and generic macros.
@@ -4067,9 +4085,9 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
      * @example $date->sub(15, 'days')
      * @example $date->sub(CarbonInterval::days(4))
      *
-     * @param string|DateInterval $unit
-     * @param int                 $value
-     * @param bool|null           $overflow
+     * @param string|DateInterval|Closure|CarbonConverterInterface $unit
+     * @param int                                                  $value
+     * @param bool|null                                            $overflow
      *
      * @return static
      */

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -20,6 +20,7 @@ use Carbon\Exceptions\UnknownGetterException;
 use Carbon\Exceptions\UnknownSetterException;
 use Carbon\Exceptions\UnknownUnitException;
 use Carbon\Traits\IntervalRounding;
+use Carbon\Traits\IntervalStep;
 use Carbon\Traits\Mixin;
 use Carbon\Traits\Options;
 use Closure;
@@ -173,9 +174,10 @@ use Throwable;
  * @method $this ceilMicrosecond(float $precision = 1) Ceil the current instance microsecond with given precision.
  * @method $this ceilMicroseconds(float $precision = 1) Ceil the current instance microsecond with given precision.
  */
-class CarbonInterval extends DateInterval
+class CarbonInterval extends DateInterval implements CarbonConverterInterface
 {
     use IntervalRounding;
+    use IntervalStep;
     use Mixin {
         Mixin::mixin as baseMixin;
     }
@@ -332,6 +334,11 @@ class CarbonInterval extends DateInterval
      */
     public function __construct($years = 1, $months = null, $weeks = null, $days = null, $hours = null, $minutes = null, $seconds = null, $microseconds = null)
     {
+        if ($years instanceof Closure) {
+            $this->step = $years;
+            $years = null;
+        }
+
         if ($years instanceof DateInterval) {
             parent::__construct(static::getDateIntervalSpec($years));
             $this->f = $years->f;
@@ -556,6 +563,7 @@ class CarbonInterval extends DateInterval
         $date = new static($this->spec());
         $date->invert = $this->invert;
         $date->f = $this->f;
+        $date->step = $this->step;
 
         return $date;
     }
@@ -841,6 +849,10 @@ class CarbonInterval extends DateInterval
             $instance->f = $microseconds;
         }
 
+        if ($interval instanceof self && is_a($className, self::class, true)) {
+            $instance->setStep($interval->getStep());
+        }
+
         static::copyNegativeUnits($interval, $instance);
 
         return $instance;
@@ -889,8 +901,8 @@ class CarbonInterval extends DateInterval
      * Always return a new instance. Parse only strings and only these likely to be intervals (skip dates
      * and recurrences). Throw an exception for invalid format, but otherwise return null.
      *
-     * @param mixed|int|DateInterval|string|null $interval interval or number of the given $unit
-     * @param string|null                        $unit     if specified, $interval must be an integer
+     * @param mixed|int|DateInterval|string|Closure|null $interval interval or number of the given $unit
+     * @param string|null                                $unit     if specified, $interval must be an integer
      *
      * @return static|null
      */
@@ -902,6 +914,10 @@ class CarbonInterval extends DateInterval
 
         if ($interval instanceof DateInterval) {
             return static::instance($interval);
+        }
+
+        if ($interval instanceof Closure) {
+            return new static($interval);
         }
 
         if (!is_string($interval)) {

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -658,8 +658,12 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
         foreach ($arguments as $argument) {
             if ($this->dateInterval === null &&
                 (
-                    is_string($argument) && preg_match('/^(\d.*|P[T0-9].*|(?:\h*\d+(?:\.\d+)?\h*[a-z]+)+)$/i', $argument) ||
-                    $argument instanceof DateInterval
+                    is_string($argument) && preg_match(
+                        '/^(\d(\d(?![\/-])|[^\d\/-]([\/-])?)*|P[T0-9].*|(?:\h*\d+(?:\.\d+)?\h*[a-z]+)+)$/i',
+                        $argument
+                    ) ||
+                    $argument instanceof DateInterval ||
+                    $argument instanceof Closure
                 ) &&
                 $parsed = @CarbonInterval::make($argument)
             ) {
@@ -754,7 +758,7 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
             throw new InvalidIntervalException('Invalid interval.');
         }
 
-        if ($interval->spec() === 'PT0S' && !$interval->f) {
+        if ($interval->spec() === 'PT0S' && !$interval->f && !$interval->getStep()) {
             throw new InvalidIntervalException('Empty interval is not accepted.');
         }
 

--- a/src/Carbon/Traits/IntervalStep.php
+++ b/src/Carbon/Traits/IntervalStep.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Carbon\Traits;
+
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
+use Closure;
+use DateTimeImmutable;
+use DateTimeInterface;
+
+trait IntervalStep
+{
+    /**
+     * Step to apply instead of a fixed interval to get the new date.
+     *
+     * @var Closure|null
+     */
+    protected $step;
+
+    /**
+     * Get the dynamic step in use.
+     *
+     * @return Closure
+     */
+    public function getStep(): ?Closure
+    {
+        return $this->step;
+    }
+
+    /**
+     * Set a step to apply instead of a fixed interval to get the new date.
+     *
+     * Or pass null to switch to fixed interval.
+     *
+     * @param Closure|null $step
+     */
+    public function setStep(?Closure $step): void
+    {
+        $this->step = $step;
+    }
+
+    /**
+     * Take a date and apply either the step if set, or the current interval else.
+     *
+     * The interval/step is applied negatively (typically subtraction instead of addition) if $negated is true.
+     *
+     * @param DateTimeInterface $dateTime
+     * @param bool              $negated
+     *
+     * @return CarbonInterface
+     */
+    public function convertDate(DateTimeInterface $dateTime, bool $negated = false): DateTimeInterface
+    {
+        if ($this->step) {
+            return ($this->step)($dateTime, $negated);
+        }
+
+        $dateTime = $dateTime instanceof CarbonInterface ? $dateTime : $this->resolveCarbon($dateTime);
+
+        if ($negated) {
+            return $dateTime->rawSub($this);
+        }
+
+        return $dateTime->rawAdd($this);
+    }
+
+    /**
+     * Convert DateTimeImmutable instance to CarbonImmutable instance and DateTime instance to Carbon instance.
+     *
+     * @param DateTimeInterface $dateTime
+     *
+     * @return Carbon|CarbonImmutable
+     */
+    private function resolveCarbon(DateTimeInterface $dateTime)
+    {
+        if ($dateTime instanceof DateTimeImmutable) {
+            return CarbonImmutable::instance($dateTime);
+        }
+
+        return Carbon::instance($dateTime);
+    }
+}

--- a/src/Carbon/Traits/Units.php
+++ b/src/Carbon/Traits/Units.php
@@ -10,9 +10,11 @@
  */
 namespace Carbon\Traits;
 
+use Carbon\CarbonConverterInterface;
 use Carbon\CarbonInterface;
 use Carbon\CarbonInterval;
 use Carbon\Exceptions\UnitException;
+use Closure;
 use DateInterval;
 
 /**
@@ -167,15 +169,27 @@ trait Units
     }
 
     /**
+     * Call native PHP DateTime/DateTimeImmutable add() method.
+     *
+     * @param DateInterval $interval
+     *
+     * @return static
+     */
+    public function rawAdd(DateInterval $interval)
+    {
+        return parent::add($interval);
+    }
+
+    /**
      * Add given units or interval to the current instance.
      *
      * @example $date->add('hour', 3)
      * @example $date->add(15, 'days')
      * @example $date->add(CarbonInterval::days(4))
      *
-     * @param string|DateInterval $unit
-     * @param int                 $value
-     * @param bool|null           $overflow
+     * @param string|DateInterval|Closure|CarbonConverterInterface $unit
+     * @param int                                                  $value
+     * @param bool|null                                            $overflow
      *
      * @return static
      */
@@ -183,6 +197,14 @@ trait Units
     {
         if (is_string($unit) && func_num_args() === 1) {
             $unit = CarbonInterval::make($unit);
+        }
+
+        if ($unit instanceof CarbonConverterInterface) {
+            return $this->resolveCarbon($unit->convertDate($this, false));
+        }
+
+        if ($unit instanceof Closure) {
+            return $this->resolveCarbon($unit($this, false));
         }
 
         if ($unit instanceof DateInterval) {
@@ -306,15 +328,27 @@ trait Units
     }
 
     /**
+     * Call native PHP DateTime/DateTimeImmutable sub() method.
+     *
+     * @param DateInterval $interval
+     *
+     * @return static
+     */
+    public function rawSub(DateInterval $interval)
+    {
+        return parent::sub($interval);
+    }
+
+    /**
      * Subtract given units or interval to the current instance.
      *
      * @example $date->sub('hour', 3)
      * @example $date->sub(15, 'days')
      * @example $date->sub(CarbonInterval::days(4))
      *
-     * @param string|DateInterval $unit
-     * @param int                 $value
-     * @param bool|null           $overflow
+     * @param string|DateInterval|Closure|CarbonConverterInterface $unit
+     * @param int                                                  $value
+     * @param bool|null                                            $overflow
      *
      * @return static
      */
@@ -322,6 +356,14 @@ trait Units
     {
         if (is_string($unit) && func_num_args() === 1) {
             $unit = CarbonInterval::make($unit);
+        }
+
+        if ($unit instanceof CarbonConverterInterface) {
+            return $this->resolveCarbon($unit->convertDate($this, true));
+        }
+
+        if ($unit instanceof Closure) {
+            return $this->resolveCarbon($unit($this, true));
         }
 
         if ($unit instanceof DateInterval) {

--- a/tests/Carbon/AddTest.php
+++ b/tests/Carbon/AddTest.php
@@ -13,16 +13,35 @@ namespace Tests\Carbon;
 
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
+use DateTime;
 use Tests\AbstractTestCase;
 
 class AddTest extends AbstractTestCase
 {
     public function testAddMethod()
     {
-        $date = Carbon::createFromDate(1975);
         $this->assertSame(1977, Carbon::createFromDate(1975)->add(2, 'year')->year);
         $this->assertSame(1977, Carbon::createFromDate(1975)->add('year', 2)->year);
         $this->assertSame(1977, Carbon::createFromDate(1975)->add('2 years')->year);
+        $lastNegated = null;
+        $date = Carbon::createFromDate(1975)->add(
+            function (DateTime $date, bool $negated = false) use (&$lastNegated): DateTime {
+                $lastNegated = $negated;
+
+                return new DateTime($date->format('Y-m-d H:i:s') . ' + 2 years');
+            }
+        );
+        $this->assertInstanceOf(Carbon::class, $date);
+        $this->assertSame(1977, $date->year);
+        $this->assertFalse($lastNegated);
+        /** @var CarbonInterval $interval */
+        $interval = include __DIR__ . '/../Fixtures/dynamicInterval.php';
+        $date = Carbon::parse('2020-06-04')->add($interval);
+        $this->assertInstanceOf(Carbon::class, $date);
+        $this->assertSame('2020-06-08', $date->format('Y-m-d'));
+        $date = Carbon::parse('2020-06-23')->add($interval);
+        $this->assertInstanceOf(Carbon::class, $date);
+        $this->assertSame('2020-07-16', $date->format('Y-m-d'));
     }
 
     public function testAddYearsPositive()

--- a/tests/Carbon/AddTest.php
+++ b/tests/Carbon/AddTest.php
@@ -28,14 +28,14 @@ class AddTest extends AbstractTestCase
             function (DateTime $date, bool $negated = false) use (&$lastNegated): DateTime {
                 $lastNegated = $negated;
 
-                return new DateTime($date->format('Y-m-d H:i:s') . ' + 2 years');
+                return new DateTime($date->format('Y-m-d H:i:s').' + 2 years');
             }
         );
         $this->assertInstanceOf(Carbon::class, $date);
         $this->assertSame(1977, $date->year);
         $this->assertFalse($lastNegated);
         /** @var CarbonInterval $interval */
-        $interval = include __DIR__ . '/../Fixtures/dynamicInterval.php';
+        $interval = include __DIR__.'/../Fixtures/dynamicInterval.php';
         $date = Carbon::parse('2020-06-04')->add($interval);
         $this->assertInstanceOf(Carbon::class, $date);
         $this->assertSame('2020-06-08', $date->format('Y-m-d'));

--- a/tests/Carbon/SubTest.php
+++ b/tests/Carbon/SubTest.php
@@ -28,7 +28,7 @@ class SubTest extends AbstractTestCase
             function (DateTime $date, bool $negated = false) use (&$lastNegated): DateTime {
                 $lastNegated = $negated;
 
-                return new DateTime($date->format('Y-m-d H:i:s') . ' - 2 years');
+                return new DateTime($date->format('Y-m-d H:i:s').' - 2 years');
             }
         );
         $this->assertInstanceOf(Carbon::class, $date);
@@ -41,11 +41,11 @@ class SubTest extends AbstractTestCase
             function (DateTime $date, bool $negated = false) use (&$lastNegated): DateTime {
                 $lastNegated = $negated;
 
-                return new DateTime($date->format('Y-m-d H:i:s') . ' - 2 years');
+                return new DateTime($date->format('Y-m-d H:i:s').' - 2 years');
             }
         )->year);
         /** @var CarbonInterval $interval */
-        $interval = include __DIR__ . '/../Fixtures/dynamicInterval.php';
+        $interval = include __DIR__.'/../Fixtures/dynamicInterval.php';
         $date = Carbon::parse('2020-06-08')->sub($interval);
         $this->assertInstanceOf(Carbon::class, $date);
         $this->assertSame('2020-05-31', $date->format('Y-m-d'));

--- a/tests/Carbon/SubTest.php
+++ b/tests/Carbon/SubTest.php
@@ -13,6 +13,7 @@ namespace Tests\Carbon;
 
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
+use DateTime;
 use Tests\AbstractTestCase;
 
 class SubTest extends AbstractTestCase
@@ -22,9 +23,35 @@ class SubTest extends AbstractTestCase
         $this->assertSame(1973, Carbon::createFromDate(1975)->sub(2, 'year')->year);
         $this->assertSame(1973, Carbon::createFromDate(1975)->sub('year', 2)->year);
         $this->assertSame(1973, Carbon::createFromDate(1975)->sub('2 years')->year);
+        $lastNegated = null;
+        $date = Carbon::createFromDate(1975)->sub(
+            function (DateTime $date, bool $negated = false) use (&$lastNegated): DateTime {
+                $lastNegated = $negated;
+
+                return new DateTime($date->format('Y-m-d H:i:s') . ' - 2 years');
+            }
+        );
+        $this->assertInstanceOf(Carbon::class, $date);
+        $this->assertSame(1973, $date->year);
         $this->assertSame(1973, Carbon::createFromDate(1975)->subtract(2, 'year')->year);
         $this->assertSame(1973, Carbon::createFromDate(1975)->subtract('year', 2)->year);
         $this->assertSame(1973, Carbon::createFromDate(1975)->subtract('2 years')->year);
+        $lastNegated = null;
+        $this->assertSame(1973, Carbon::createFromDate(1975)->subtract(
+            function (DateTime $date, bool $negated = false) use (&$lastNegated): DateTime {
+                $lastNegated = $negated;
+
+                return new DateTime($date->format('Y-m-d H:i:s') . ' - 2 years');
+            }
+        )->year);
+        /** @var CarbonInterval $interval */
+        $interval = include __DIR__ . '/../Fixtures/dynamicInterval.php';
+        $date = Carbon::parse('2020-06-08')->sub($interval);
+        $this->assertInstanceOf(Carbon::class, $date);
+        $this->assertSame('2020-05-31', $date->format('Y-m-d'));
+        $date = Carbon::parse('2020-07-16')->subtract($interval);
+        $this->assertInstanceOf(Carbon::class, $date);
+        $this->assertSame('2020-06-30', $date->format('Y-m-d'));
     }
 
     public function testSubYearsPositive()

--- a/tests/CarbonImmutable/AddTest.php
+++ b/tests/CarbonImmutable/AddTest.php
@@ -13,6 +13,7 @@ namespace Tests\CarbonImmutable;
 
 use Carbon\CarbonImmutable as Carbon;
 use Carbon\CarbonInterval;
+use DateTimeImmutable;
 use Tests\AbstractTestCase;
 
 class AddTest extends AbstractTestCase
@@ -22,6 +23,25 @@ class AddTest extends AbstractTestCase
         $this->assertSame(1977, Carbon::createFromDate(1975)->add(2, 'year')->year);
         $this->assertSame(1977, Carbon::createFromDate(1975)->add('year', 2)->year);
         $this->assertSame(1977, Carbon::createFromDate(1975)->add('2 years')->year);
+        $lastNegated = null;
+        $date = Carbon::createFromDate(1975)->add(
+            function (DateTimeImmutable $date, bool $negated = false) use (&$lastNegated): DateTimeImmutable {
+                $lastNegated = $negated;
+
+                return new DateTimeImmutable($date->format('Y-m-d H:i:s') . ' + 2 years');
+            }
+        );
+        $this->assertInstanceOf(Carbon::class, $date);
+        $this->assertSame(1977, $date->year);
+        $this->assertFalse($lastNegated);
+        /** @var CarbonInterval $interval */
+        $interval = include __DIR__ . '/../Fixtures/dynamicInterval.php';
+        $date = Carbon::parse('2020-06-04')->add($interval);
+        $this->assertInstanceOf(Carbon::class, $date);
+        $this->assertSame('2020-06-08', $date->format('Y-m-d'));
+        $date = Carbon::parse('2020-06-23')->add($interval);
+        $this->assertInstanceOf(Carbon::class, $date);
+        $this->assertSame('2020-07-16', $date->format('Y-m-d'));
     }
 
     public function testAddYearsPositive()

--- a/tests/CarbonImmutable/AddTest.php
+++ b/tests/CarbonImmutable/AddTest.php
@@ -28,14 +28,14 @@ class AddTest extends AbstractTestCase
             function (DateTimeImmutable $date, bool $negated = false) use (&$lastNegated): DateTimeImmutable {
                 $lastNegated = $negated;
 
-                return new DateTimeImmutable($date->format('Y-m-d H:i:s') . ' + 2 years');
+                return new DateTimeImmutable($date->format('Y-m-d H:i:s').' + 2 years');
             }
         );
         $this->assertInstanceOf(Carbon::class, $date);
         $this->assertSame(1977, $date->year);
         $this->assertFalse($lastNegated);
         /** @var CarbonInterval $interval */
-        $interval = include __DIR__ . '/../Fixtures/dynamicInterval.php';
+        $interval = include __DIR__.'/../Fixtures/dynamicInterval.php';
         $date = Carbon::parse('2020-06-04')->add($interval);
         $this->assertInstanceOf(Carbon::class, $date);
         $this->assertSame('2020-06-08', $date->format('Y-m-d'));

--- a/tests/CarbonImmutable/SubTest.php
+++ b/tests/CarbonImmutable/SubTest.php
@@ -47,7 +47,7 @@ class SubTest extends AbstractTestCase
         )->year);
         $this->assertTrue($lastNegated);
         /** @var CarbonInterval $interval */
-        $interval = include __DIR__².'/../Fixtures/dynamicInterval.php';
+        $interval = include __DIR__.'/../Fixtures/dynamicInterval.php';
         $date = Carbon::parse('2020-06-08')->sub($interval);
         $this->assertInstanceOf(Carbon::class, $date);
         $this->assertSame('2020-05-31', $date->format('Y-m-d'));

--- a/tests/CarbonImmutable/SubTest.php
+++ b/tests/CarbonImmutable/SubTest.php
@@ -13,6 +13,7 @@ namespace Tests\CarbonImmutable;
 
 use Carbon\CarbonImmutable as Carbon;
 use Carbon\CarbonInterval;
+use DateTimeImmutable;
 use Tests\AbstractTestCase;
 
 class SubTest extends AbstractTestCase
@@ -22,9 +23,37 @@ class SubTest extends AbstractTestCase
         $this->assertSame(1973, Carbon::createFromDate(1975)->sub(2, 'year')->year);
         $this->assertSame(1973, Carbon::createFromDate(1975)->sub('year', 2)->year);
         $this->assertSame(1973, Carbon::createFromDate(1975)->sub('2 years')->year);
+        $lastNegated = null;
+        $date = Carbon::createFromDate(1975)->sub(
+            function (DateTimeImmutable $date, bool $negated = false) use (&$lastNegated): DateTimeImmutable {
+                $lastNegated = $negated;
+
+                return new DateTimeImmutable($date->format('Y-m-d H:i:s') . ' - 2 years');
+            }
+        );
+        $this->assertInstanceOf(Carbon::class, $date);
+        $this->assertSame(1973, $date->year);
+        $this->assertTrue($lastNegated);
         $this->assertSame(1973, Carbon::createFromDate(1975)->subtract(2, 'year')->year);
         $this->assertSame(1973, Carbon::createFromDate(1975)->subtract('year', 2)->year);
         $this->assertSame(1973, Carbon::createFromDate(1975)->subtract('2 years')->year);
+        $lastNegated = null;
+        $this->assertSame(1973, Carbon::createFromDate(1975)->subtract(
+            function (DateTimeImmutable $date, bool $negated = false) use (&$lastNegated): DateTimeImmutable {
+                $lastNegated = $negated;
+
+                return new DateTimeImmutable($date->format('Y-m-d H:i:s') . ' - 2 years');
+            }
+        )->year);
+        $this->assertTrue($lastNegated);
+        /** @var CarbonInterval $interval */
+        $interval = include __DIR__ . '/../Fixtures/dynamicInterval.php';
+        $date = Carbon::parse('2020-06-08')->sub($interval);
+        $this->assertInstanceOf(Carbon::class, $date);
+        $this->assertSame('2020-05-31', $date->format('Y-m-d'));
+        $date = Carbon::parse('2020-07-16')->subtract($interval);
+        $this->assertInstanceOf(Carbon::class, $date);
+        $this->assertSame('2020-06-30', $date->format('Y-m-d'));
     }
 
     public function testSubYearsPositive()

--- a/tests/CarbonImmutable/SubTest.php
+++ b/tests/CarbonImmutable/SubTest.php
@@ -28,7 +28,7 @@ class SubTest extends AbstractTestCase
             function (DateTimeImmutable $date, bool $negated = false) use (&$lastNegated): DateTimeImmutable {
                 $lastNegated = $negated;
 
-                return new DateTimeImmutable($date->format('Y-m-d H:i:s') . ' - 2 years');
+                return new DateTimeImmutable($date->format('Y-m-d H:i:s').' - 2 years');
             }
         );
         $this->assertInstanceOf(Carbon::class, $date);
@@ -42,12 +42,12 @@ class SubTest extends AbstractTestCase
             function (DateTimeImmutable $date, bool $negated = false) use (&$lastNegated): DateTimeImmutable {
                 $lastNegated = $negated;
 
-                return new DateTimeImmutable($date->format('Y-m-d H:i:s') . ' - 2 years');
+                return new DateTimeImmutable($date->format('Y-m-d H:i:s').' - 2 years');
             }
         )->year);
         $this->assertTrue($lastNegated);
         /** @var CarbonInterval $interval */
-        $interval = include __DIR__ . '/../Fixtures/dynamicInterval.php';
+        $interval = include __DIR__².'/../Fixtures/dynamicInterval.php';
         $date = Carbon::parse('2020-06-08')->sub($interval);
         $this->assertInstanceOf(Carbon::class, $date);
         $this->assertSame('2020-05-31', $date->format('Y-m-d'));

--- a/tests/CarbonInterval/AddTest.php
+++ b/tests/CarbonInterval/AddTest.php
@@ -14,6 +14,8 @@ namespace Tests\CarbonInterval;
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
 use DateInterval;
+use DateTime;
+use DateTimeImmutable;
 use Tests\AbstractTestCase;
 
 class AddTest extends AbstractTestCase
@@ -63,7 +65,7 @@ class AddTest extends AbstractTestCase
     {
         date_default_timezone_set('UTC');
 
-        $date = new \DateTime();
+        $date = new DateTime();
         $diff = $date->diff((clone $date)->modify('3 weeks'));
         $ci = CarbonInterval::create(4, 3, 6, 7, 8, 10, 11)->add($diff);
         $this->assertCarbonInterval($ci, 4, 3, 70, 8, 10, 11);
@@ -73,7 +75,7 @@ class AddTest extends AbstractTestCase
     {
         date_default_timezone_set('UTC');
 
-        $date = new \DateTime();
+        $date = new DateTime();
         $diff = $date->diff((clone $date)->modify('-3 weeks'));
         $ci = CarbonInterval::create(4, 3, 6, 7, 8, 10, 11)->add($diff);
         $this->assertCarbonInterval($ci, 4, 3, 28, 8, 10, 11);
@@ -147,5 +149,13 @@ class AddTest extends AbstractTestCase
         );
 
         CarbonInterval::day()->add(Carbon::now());
+    }
+
+    public function testConvertDate()
+    {
+        $this->assertCarbon(CarbonInterval::days(3)->convertDate(new DateTime('2020-06-14')), 2020, 6, 17, 0, 0, 0);
+        $this->assertCarbon(CarbonInterval::days(3)->convertDate(new DateTimeImmutable('2020-06-14')), 2020, 6, 17, 0, 0, 0);
+        $this->assertCarbon(CarbonInterval::days(3)->convertDate(new DateTime('2020-06-14'), true), 2020, 6, 11, 0, 0, 0);
+        $this->assertCarbon(CarbonInterval::days(3)->convertDate(new DateTimeImmutable('2020-06-14'), true), 2020, 6, 11, 0, 0, 0);
     }
 }

--- a/tests/CarbonPeriod/DynamicIntervalTest.php
+++ b/tests/CarbonPeriod/DynamicIntervalTest.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\CarbonPeriod;
+
+use Carbon\Carbon;
+use Carbon\CarbonPeriod;
+use Tests\AbstractTestCase;
+
+class DynamicIntervalTest extends AbstractTestCase
+{
+    public function testDynamicIntervalInPeriod()
+    {
+        $weekDayStep = function (Carbon $date, bool $negated = false): Carbon {
+            if ($negated) {
+                return $date->previousWeekDay();
+            }
+
+            return $date->nextWeekDay();
+        };
+        $period = CarbonPeriod::create('2020-06-01', $weekDayStep, '2020-06-14');
+        $dates = [];
+
+        foreach ($period as $date) {
+            $dates[] = $date->day;
+        }
+
+        $this->assertSame(10, count($period));
+        $this->assertSame(array_merge(range(1, 5), range(8, 12)), $dates);
+    }
+}

--- a/tests/Fixtures/dynamicInterval.php
+++ b/tests/Fixtures/dynamicInterval.php
@@ -1,0 +1,13 @@
+<?php
+
+use Carbon\CarbonInterval;
+
+return new CarbonInterval(function (DateTimeInterface $date, bool $negated = false): DateTime {
+    $sign = $negated ? '-' : '+';
+    $days = $date->format('j');
+
+    return new DateTime(
+        $date->modify("$sign $days days")
+            ->format('Y-m-d H:i:s')
+    );
+});


### PR DESCRIPTION
This allow to use `Closure`'s as intervals:
```php
$weekDayStep = function (Carbon $date, bool $negated = false): Carbon {
    if ($negated) {
        return $date->previousWeekDay();
    }

    return $date->nextWeekDay();
};

Carbon::now()->add($weekDayStep); // call nextWeekDay
Carbon::now()->sub($weekDayStep); // call previousWeekDay
CarbonInterval::create($weekDayStep); // create a virtual interval representing 1 week day
CarbonPeriod::create('2020-06-01', $weekDayStep, '2020-06-14'); // iterate over every week days from June 1st to June 14th
```