### PR TITLE
Update .gitattributes export-ignore rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,14 +1,15 @@
-/.codecov.yml export-ignore
-/.editorconfig export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
-/.php_cs.dist export-ignore
-/.styleci.yml export-ignore
-/.travis.yml export-ignore
-/build.php export-ignore
-/phpdoc.php export-ignore
-/phpstan.neon export-ignore
-/phpunit.xml.dist export-ignore
-/tests export-ignore
+/.editorconfig      export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.multi-tester.yml  export-ignore
+/.php_cs.dist       export-ignore
+/.styleci.yml       export-ignore
+/.travis.yml        export-ignore
+/build.php          export-ignore
+/phpdoc.php         export-ignore
+/phpstan.neon       export-ignore
+/phpunit.xml.dist   export-ignore
+/.github            export-ignore
+/tests              export-ignore
 
 * text=auto eol=lf


### PR DESCRIPTION
Update `.gitattributes` `export-ignore` rules

 - Remove `.codecov.yml` that is no longer used.
 - Add `.multi-tester.yml` file
 - Add `.github` directory.
 - Fix alignments in all `export-ignore` rules.

Thank you 🙏🏿.