### PR TITLE
Fix "Cannot call abstract method Carbon\CarbonInterface::hasMacro()" error

### DIFF
--- a/src/Carbon/PHPStan/MacroScanner.php
+++ b/src/Carbon/PHPStan/MacroScanner.php
@@ -20,19 +20,9 @@ final class MacroScanner
      */
     public function hasMethod(string $className, string $methodName): bool
     {
-        $reflectionClass = new ReflectionClass($className);
-
-        if (!$reflectionClass->implementsInterface(CarbonInterface::class)) {
-            return false;
-        }
-
-        $hasMacroMethod = $reflectionClass->getMethod('hasMacro');
-
-        if ($hasMacroMethod->isAbstract()) {
-            return false;
-        }
-
-        return $className::hasMacro($methodName);
+        return is_a($className, CarbonInterface::class, true) &&
+            is_callable([$className, 'hasMacro']) &&
+            $className::hasMacro($methodName);
     }
 
     /**

--- a/src/Carbon/PHPStan/MacroScanner.php
+++ b/src/Carbon/PHPStan/MacroScanner.php
@@ -20,7 +20,19 @@ final class MacroScanner
      */
     public function hasMethod(string $className, string $methodName): bool
     {
-        return is_a($className, CarbonInterface::class, true) && $className::hasMacro($methodName);
+        $reflectionClass = new ReflectionClass($className);
+
+        if (!$reflectionClass->implementsInterface(CarbonInterface::class)) {
+            return false;
+        }
+
+        $hasMacroMethod = $reflectionClass->getMethod('hasMacro');
+
+        if ($hasMacroMethod->isAbstract()) {
+            return false;
+        }
+
+        return $className::hasMacro($methodName);
     }
 
     /**

--- a/tests/PHPStan/MacroExtensionTest.php
+++ b/tests/PHPStan/MacroExtensionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\PHPStan;
 
 use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Carbon\CarbonInterval;
 use Carbon\PHPStan\MacroScanner;
 use Tests\AbstractTestCase;
@@ -22,6 +23,7 @@ class MacroExtensionTest extends AbstractTestCase
 
         $this->assertTrue($scanner->hasMethod(Carbon::class, 'foo'));
         $this->assertFalse($scanner->hasMethod(CarbonInterval::class, 'foo'));
+        $this->assertFalse($scanner->hasMethod(CarbonInterface::class, 'foo'));
     }
 
     public function testGetMacro()


### PR DESCRIPTION
If the variable `$className` is `CarbonInterface::class` itself or an abstract class that hasn't implemented the `getMethod` method yet, it will throw an error `Cannot call abstract method Carbon\CarbonInterface::hasMacro()`