### PR TITLE
Fix for formats that contains microseconds, as in informix databases

### DIFF
--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -659,6 +659,10 @@ trait Creator
         $function = static::$createFromFormatFunction;
 
         if (!$function) {
+            if ($format === 'Y-m-d H:i:s.u' && strstr($time, '.') == null )
+            {
+                $time .= '.000';
+            }
             return static::rawCreateFromFormat($format, $time, $tz);
         }
 


### PR DESCRIPTION
Hi Brian !!
I want to congratulate you for this great piece of software.
I had to patch to work with Laravel 5.8 + abram odbc + informix, because informix sends microseconds in timestamps.
In Creator.php
createFromFormat fails when $format is Y-m-d H:i:s.u and $time does not include microseconds.
Mi change appends zero microseconds (.000) to $time

Regarding phpunit, it gave me errors even without changing anything, so I think this little patch is inocuous and useful.

I hope my contribution is useful to the comunity.
Best regards 

Martin

