### PR TITLE
Error diffFiltered(): "Unknown getter 'locale'"

### DIFF
--- a/src/Carbon/Traits/Options.php
+++ b/src/Carbon/Traits/Options.php
@@ -408,7 +408,7 @@ trait Options
             'localSerializer' => 'toJsonFormat',
             'localMacros' => 'macros',
             'localGenericMacros' => 'genericMacros',
-            'locale' => 'locale',
+            'localTranslator' => 'locale',
             'tzName' => 'timezone',
             'localFormatFunction' => 'formatFunction',
         ];


### PR DESCRIPTION
When $property equal 'locale' not found class attribute. 
Not sure if the 'localTranslator' property is correct. But surely 'locale' doesn't work.