### PR TITLE
Fix use of "anteayer" and "antier" in spanish translations

### DIFF
--- a/src/Carbon/Lang/es.php
+++ b/src/Carbon/Lang/es.php
@@ -66,7 +66,7 @@ return [
     'diff_yesterday_regexp' => 'ayer(?:\\s+a)?(?:\\s+las)?',
     'diff_tomorrow' => 'mañana',
     'diff_tomorrow_regexp' => 'mañana(?:\\s+a)?(?:\\s+las)?',
-    'diff_before_yesterday' => 'antier',
+    'diff_before_yesterday' => 'anteayer',
     'diff_after_tomorrow' => 'pasado mañana',
     'formats' => [
         'LT' => 'H:mm',

--- a/src/Carbon/Lang/es_MX.php
+++ b/src/Carbon/Lang/es_MX.php
@@ -14,6 +14,7 @@
  * - RAP    bug-glibc-locales@gnu.org
  */
 return array_replace_recursive(require __DIR__.'/es.php', [
+    'diff_before_yesterday' => 'antier',
     'first_day_of_week' => 0,
     'day_of_first_week_of_year' => 1,
 ]);


### PR DESCRIPTION
As mentioned in the issue #2238 , I've replaced the use of "antier" by "anteayer" in the generic spanish translation, and moved "antier" to mexican spanish translation.