### PR TITLE
Implement context() method

### DIFF
--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -603,6 +603,16 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
     }
 
     /**
+     * Return the current context from inside a macro callee or a new one if static.
+     *
+     * @return static
+     */
+    protected static function this()
+    {
+        return end(static::$macroContextStack) ?: new static(0);
+    }
+
+    /**
      * Creates a CarbonInterval from string.
      *
      * Format:

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -583,7 +583,13 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
             $interval = new static(0);
             $localStrictModeEnabled = $interval->localStrictModeEnabled;
             $interval->localStrictModeEnabled = true;
-            $result = $interval->$method(...$parameters);
+
+            $result = static::hasMacro($method)
+                ? static::bindMacroContext(null, function () use (&$method, &$parameters, &$interval) {
+                    return $interval->callMacro($method, $parameters);
+                })
+                : $interval->$method(...$parameters);
+
             $interval->localStrictModeEnabled = $localStrictModeEnabled;
 
             return $result;

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -583,7 +583,15 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
      */
     public static function __callStatic($method, $parameters)
     {
-        return (new static)->$method(...$parameters);
+        $date = new static();
+
+        if (static::hasMacro($method)) {
+            return static::bindMacroContext(null, function () use (&$method, &$parameters, &$date) {
+                return $date->callMacro($method, $parameters);
+            });
+        }
+
+        return $date->$method(...$parameters);
     }
 
     /**

--- a/src/Carbon/Traits/Mixin.php
+++ b/src/Carbon/Traits/Mixin.php
@@ -165,6 +165,16 @@ trait Mixin
     }
 
     /**
+     * Return the current context from inside a macro callee or a null if static.
+     *
+     * @return static|null
+     */
+    protected static function context()
+    {
+        return end(static::$macroContextStack) ?: null;
+    }
+
+    /**
      * Return the current context from inside a macro callee or a new one if static.
      *
      * @return static


### PR DESCRIPTION
Allow to know from a mixin if the call is static or on an instance:

```php
Carbon::macro('getContext', static function () {
  return static::context();
});
Carbon::getContext(); // null
$date = Carbon::parse('2020-12-10');
$date->getContext(); // $date
```