### PR TITLE
Implemented Create Strict API

### DIFF
--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -1065,7 +1065,6 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
      */
     public static function createStrict($year = 0, $month = 1, $day = 1, $hour = 0, $minute = 0, $second = 0, $tz = null);
 
-
     /**
      * Create a Carbon instance from just a date. The time portion is set to now.
      *

--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -1061,7 +1061,7 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
      *
      * @throws InvalidFormatException
      *
-     * @return static|false
+     * @return static
      */
     public static function createStrict($year = 0, $month = 1, $day = 1, $hour = 0, $minute = 0, $second = 0, $tz = null);
 

--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -1039,6 +1039,34 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
     public static function create($year = 0, $month = 1, $day = 1, $hour = 0, $minute = 0, $second = 0, $tz = null);
 
     /**
+     * Create a new Carbon instance from a specific date and time, returning only itself or throwing an exception if an
+     * invalid format is provided.
+     *
+     * If any of $year, $month or $day are set to null their now() values will
+     * be used.
+     *
+     * If $hour is null it will be set to its now() value and the default
+     * values for $minute and $second will be their now() values.
+     *
+     * If $hour is not null then the default values for $minute and $second
+     * will be 0.
+     *
+     * @param int|null                 $year
+     * @param int|null                 $month
+     * @param int|null                 $day
+     * @param int|null                 $hour
+     * @param int|null                 $minute
+     * @param int|null                 $second
+     * @param DateTimeZone|string|null $tz
+     *
+     * @throws InvalidFormatException
+     *
+     * @return static|false
+     */
+    public static function createStrict($year = 0, $month = 1, $day = 1, $hour = 0, $minute = 0, $second = 0, $tz = null);
+
+
+    /**
      * Create a Carbon instance from just a date. The time portion is set to now.
      *
      * @param int|null                 $year

--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -422,6 +422,42 @@ trait Creator
     }
 
     /**
+     * Create a new Carbon instance from a specific date and time, returning only itself or throwing an exception if an
+     * invalid format is provided.
+     *
+     * If any of $year, $month or $day are set to null their now() values will
+     * be used.
+     *
+     * If $hour is null it will be set to its now() value and the default
+     * values for $minute and $second will be their now() values.
+     *
+     * If $hour is not null then the default values for $minute and $second
+     * will be 0.
+     *
+     * @param int|null                 $year
+     * @param int|null                 $month
+     * @param int|null                 $day
+     * @param int|null                 $hour
+     * @param int|null                 $minute
+     * @param int|null                 $second
+     * @param DateTimeZone|string|null $tz
+     *
+     * @throws InvalidFormatException
+     *
+     * @return static
+     */
+    public static function createStrict($year = 0, $month = 1, $day = 1, $hour = 0, $minute = 0, $second = 0, $tz = null)
+    {
+        $instance = static::create($year, $month, $day, $hour, $minute, $second, $tz);
+
+        if (!$instance) {
+            throw new InvalidFormatException(implode(PHP_EOL, static::$lastErrors['errors']));
+        }
+
+        return $instance;
+    }
+
+    /**
      * Create a new safe Carbon instance from a specific date and time.
      *
      * If any of $year, $month or $day are set to null their now() values will

--- a/tests/Carbon/CreateStrictTest.php
+++ b/tests/Carbon/CreateStrictTest.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon;
+
+use Carbon\Carbon;
+use InvalidArgumentException;
+use Tests\AbstractTestCase;
+
+class CreateStrictTest extends AbstractTestCase
+{
+    public function testCreateStrictReturnsDateInstance()
+    {
+        $d = Carbon::createStrict();
+        $this->assertInstanceOfCarbon($d);
+    }
+
+    public function testCreateWithInvalidMonth()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('month must be between 0 and 99, -5 given');
+
+        Carbon::createStrict(null, -5);
+    }
+
+    public function testCreateWithInvalidMonthNonStrictMode()
+    {
+        Carbon::useStrictMode(false);
+        $this->assertFalse(Carbon::isStrictModeEnabled());
+
+        $this->expectException(InvalidArgumentException::class);
+        Carbon::createStrict(null, -5);
+
+        Carbon::useStrictMode(true);
+        $this->assertTrue(Carbon::isStrictModeEnabled());
+    }
+}


### PR DESCRIPTION
Realising that this new version has the same issue as 2.x, this method might be useful for creating a Carbon interface only.