### PR TITLE
Update croatian date format (hr)

### DIFF
--- a/src/Carbon/Lang/hr.php
+++ b/src/Carbon/Lang/hr.php
@@ -24,7 +24,7 @@
  * - Serhan Apaydın
  * - JD Isaacks
  * - tomhorvat
- * - Stjepan
+ * - Stjepan Majdak
  * - Vanja Retkovac (vr00)
  */
 return [
@@ -59,10 +59,10 @@ return [
     'formats' => [
         'LT' => 'H:mm',
         'LTS' => 'H:mm:ss',
-        'L' => 'DD.MM.YYYY',
-        'LL' => 'D. MMMM YYYY',
-        'LLL' => 'D. MMMM YYYY H:mm',
-        'LLLL' => 'dddd, D. MMMM YYYY H:mm',
+        'L' => 'D. M. YYYY.',
+        'LL' => 'D. MMMM YYYY.',
+        'LLL' => 'D. MMMM YYYY. H:mm',
+        'LLLL' => 'dddd, D. MMMM YYYY. H:mm',
     ],
     'calendar' => [
         'sameDay' => '[danas u] LT',


### PR DESCRIPTION
This is the official croatian date writing.

e.g. today is 29. 1. 2021.