### PR TITLE
Proposed change for fixing #2217

### DIFF
--- a/src/Carbon/Traits/Options.php
+++ b/src/Carbon/Traits/Options.php
@@ -413,7 +413,8 @@ trait Options
             'localFormatFunction' => 'formatFunction',
         ];
         foreach ($map as $property => $key) {
-            $value = $this->$property ?? null;
+            if (property_exists($this, $property)) $value = $this->$property ?? null;
+                else $value = null;
             if ($value !== null) {
                 $settings[$key] = $value;
             }


### PR DESCRIPTION
Well, if using `property_exists` before trying to acces prop, we can assure that it exists and no exception is triggered.
Closes  #2217