### PR TITLE
Remove unnecessary check within `make` method

### DIFF
--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -873,8 +873,7 @@ trait Creator
         if (\is_string($var)) {
             $var = trim($var);
 
-            if (\is_string($var) &&
-                !preg_match('/^P[0-9T]/', $var) &&
+            if (!preg_match('/^P[0-9T]/', $var) &&
                 !preg_match('/^R[0-9]/', $var) &&
                 preg_match('/[a-z0-9]/i', $var)
             ) {


### PR DESCRIPTION
This is just a minor readability improvement.  
We already know that `$var` is a string ([`trim`](https://www.php.net/manual/en/function.trim.php) always returns a string), so there's no need for additional check.