### PR TITLE
Fix passing null to non-nullable arguments

### DIFF
--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -522,6 +522,8 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
             $interval = implode($match[1], $interval);
         }
 
+        $interval = $interval ?? '';
+
         for ($index = 0; $index < $length; $index++) {
             $expected = mb_substr($format, $index, 1);
             $nextCharacter = mb_substr($interval, 0, 1);

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -479,7 +479,7 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
                 $interval = $part;
             } elseif ($start === null && $parsed = Carbon::make($part)) {
                 $start = $part;
-            } elseif ($end === null && $parsed = Carbon::make(static::addMissingParts($start, $part))) {
+            } elseif ($end === null && $parsed = Carbon::make(static::addMissingParts($start ?? '', $part))) {
                 $end = $part;
             } else {
                 throw new InvalidPeriodParameterException("Invalid ISO 8601 specification: $iso.");

--- a/tests/Laravel/App.php
+++ b/tests/Laravel/App.php
@@ -11,7 +11,7 @@ class App implements ArrayAccess
     /**
      * @var string
      */
-    protected $locale;
+    protected $locale = 'en';
 
     /**
      * @var string


### PR DESCRIPTION
Passing null to non-nullable arguments of internal functions has been deprecated in PHP 8.1 ([RFC](https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg)).