### PR TITLE
Add ReturnTypeWillChange attribute

### DIFF
--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -27,6 +27,7 @@ use Closure;
 use DateInterval;
 use Exception;
 use ReflectionException;
+use ReturnTypeWillChange;
 use Throwable;
 
 /**
@@ -965,6 +966,7 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
      *
      * @link http://php.net/manual/en/dateinterval.createfromdatestring.php
      */
+    #[ReturnTypeWillChange]
     public static function createFromDateString($time)
     {
         $interval = @parent::createFromDateString(strtr($time, [

--- a/src/Carbon/Traits/Converter.php
+++ b/src/Carbon/Traits/Converter.php
@@ -19,6 +19,7 @@ use Carbon\Exceptions\UnitException;
 use Closure;
 use DateTime;
 use DateTimeImmutable;
+use ReturnTypeWillChange;
 
 /**
  * Trait Converter.
@@ -75,6 +76,7 @@ trait Converter
      *
      * @return string
      */
+    #[ReturnTypeWillChange]
     public function format($format)
     {
         $function = $this->localFormatFunction ?: static::$formatFunction;

--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -21,6 +21,7 @@ use Closure;
 use DateTimeInterface;
 use DateTimeZone;
 use Exception;
+use ReturnTypeWillChange;
 
 /**
  * Trait Creator.
@@ -657,6 +658,7 @@ trait Creator
      *
      * @return static|false
      */
+    #[ReturnTypeWillChange]
     public static function createFromFormat($format, $time, $tz = null)
     {
         $function = static::$createFromFormatFunction;
@@ -899,6 +901,7 @@ trait Creator
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public static function getLastErrors()
     {
         return static::$lastErrors;

--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -31,6 +31,7 @@ use DateTimeInterface;
 use DateTimeZone;
 use InvalidArgumentException;
 use ReflectionException;
+use ReturnTypeWillChange;
 use Throwable;
 
 /**
@@ -631,6 +632,7 @@ trait Date
      *
      * @link http://php.net/manual/en/datetime.gettimezone.php
      */
+    #[ReturnTypeWillChange]
     public function getTimezone()
     {
         return CarbonTimeZone::instance(parent::getTimezone());
@@ -1398,6 +1400,7 @@ trait Date
      *
      * @return static
      */
+    #[ReturnTypeWillChange]
     public function setDate($year, $month, $day)
     {
         return parent::setDate((int) $year, (int) $month, (int) $day);
@@ -1414,6 +1417,7 @@ trait Date
      *
      * @return static
      */
+    #[ReturnTypeWillChange]
     public function setISODate($year, $week, $day = 1)
     {
         return parent::setISODate((int) $year, (int) $week, (int) $day);
@@ -1449,6 +1453,7 @@ trait Date
      *
      * @return static
      */
+    #[ReturnTypeWillChange]
     public function setTime($hour, $minute, $second = 0, $microseconds = 0)
     {
         return parent::setTime((int) $hour, (int) $minute, (int) $second, (int) $microseconds);
@@ -1463,6 +1468,7 @@ trait Date
      *
      * @return static
      */
+    #[ReturnTypeWillChange]
     public function setTimestamp($unixTimestamp)
     {
         [$timestamp, $microseconds] = self::getIntegerAndDecimalParts($unixTimestamp);
@@ -1521,6 +1527,7 @@ trait Date
      *
      * @return static
      */
+    #[ReturnTypeWillChange]
     public function setTimezone($value)
     {
         return parent::setTimezone(static::safeCreateDateTimeZone($value));

--- a/src/Carbon/Traits/Difference.php
+++ b/src/Carbon/Traits/Difference.php
@@ -19,6 +19,7 @@ use Carbon\Translator;
 use Closure;
 use DateInterval;
 use DateTimeInterface;
+use ReturnTypeWillChange;
 
 /**
  * Trait Difference.
@@ -117,6 +118,7 @@ trait Difference
      *
      * @return DateInterval
      */
+    #[ReturnTypeWillChange]
     public function diff($date = null, $absolute = false)
     {
         return parent::diff($this->resolveCarbon($date), (bool) $absolute);

--- a/src/Carbon/Traits/Modifiers.php
+++ b/src/Carbon/Traits/Modifiers.php
@@ -11,6 +11,7 @@
 namespace Carbon\Traits;
 
 use Carbon\CarbonInterface;
+use ReturnTypeWillChange;
 
 /**
  * Trait Modifiers.
@@ -429,6 +430,7 @@ trait Modifiers
      *
      * @see https://php.net/manual/en/datetime.modify.php
      */
+    #[ReturnTypeWillChange]
     public function modify($modify)
     {
         return parent::modify((string) $modify);

--- a/src/Carbon/Traits/Serialization.php
+++ b/src/Carbon/Traits/Serialization.php
@@ -11,6 +11,7 @@
 namespace Carbon\Traits;
 
 use Carbon\Exceptions\InvalidFormatException;
+use ReturnTypeWillChange;
 
 /**
  * Trait Serialization.
@@ -91,6 +92,7 @@ trait Serialization
      *
      * @return static
      */
+    #[ReturnTypeWillChange]
     public static function __set_state($dump)
     {
         if (\is_string($dump)) {
@@ -125,6 +127,7 @@ trait Serialization
     /**
      * Set locale if specified on unserialize() called.
      */
+    #[ReturnTypeWillChange]
     public function __wakeup()
     {
         if (get_parent_class() && method_exists(parent::class, '__wakeup')) {

--- a/src/Carbon/Traits/Units.php
+++ b/src/Carbon/Traits/Units.php
@@ -16,6 +16,7 @@ use Carbon\CarbonInterval;
 use Carbon\Exceptions\UnitException;
 use Closure;
 use DateInterval;
+use ReturnTypeWillChange;
 
 /**
  * Trait Units.
@@ -193,6 +194,7 @@ trait Units
      *
      * @return static
      */
+    #[ReturnTypeWillChange]
     public function add($unit, $value = 1, $overflow = null)
     {
         if (\is_string($unit) && \func_num_args() === 1) {
@@ -352,6 +354,7 @@ trait Units
      *
      * @return static
      */
+    #[ReturnTypeWillChange]
     public function sub($unit, $value = 1, $overflow = null)
     {
         if (\is_string($unit) && \func_num_args() === 1) {

--- a/tests/CarbonPeriod/Fixtures/AbstractCarbon.php
+++ b/tests/CarbonPeriod/Fixtures/AbstractCarbon.php
@@ -13,6 +13,7 @@ namespace Tests\CarbonPeriod\Fixtures;
 
 use Carbon\CarbonInterface;
 use DateTime;
+use ReturnTypeWillChange;
 
 abstract class AbstractCarbon extends DateTime implements CarbonInterface
 {
@@ -26,46 +27,55 @@ abstract class AbstractCarbon extends DateTime implements CarbonInterface
         return new static($dump);
     }
 
+    #[ReturnTypeWillChange]
     public function add($unit, $value = 1, $overflow = null)
     {
         return parent::add($unit);
     }
 
+    #[ReturnTypeWillChange]
     public function sub($unit, $value = 1, $overflow = null)
     {
         return parent::sub($unit);
     }
 
+    #[ReturnTypeWillChange]
     public function modify($modify)
     {
         return parent::modify($modify);
     }
 
+    #[ReturnTypeWillChange]
     public function setDate($year, $month, $day)
     {
         return parent::setDate($year, $month, $day);
     }
 
+    #[ReturnTypeWillChange]
     public function setISODate($year, $month, $day = 1)
     {
         return parent::setISODate($year, $month, $day = 1);
     }
 
+    #[ReturnTypeWillChange]
     public function setTime($hour, $minute, $second = 0, $microseconds = 0)
     {
         return parent::setTime($hour, $minute, $second, $microseconds);
     }
 
+    #[ReturnTypeWillChange]
     public function setTimestamp($unixTimestamp)
     {
         return parent::setTimestamp($unixTimestamp);
     }
 
+    #[ReturnTypeWillChange]
     public function setTimezone($value)
     {
         return parent::setTimezone($value);
     }
 
+    #[ReturnTypeWillChange]
     public static function createFromFormat($format, $time, $tz = null)
     {
         return parent::createFromFormat($format, $time, $tz);

--- a/tests/CarbonTimeZone/Fixtures/UnknownZone.php
+++ b/tests/CarbonTimeZone/Fixtures/UnknownZone.php
@@ -12,9 +12,11 @@ declare(strict_types=1);
 namespace Tests\CarbonTimeZone\Fixtures;
 
 use Carbon\CarbonTimeZone;
+use ReturnTypeWillChange;
 
 class UnknownZone extends CarbonTimeZone
 {
+    #[ReturnTypeWillChange]
     public function getName()
     {
         return 'foobar';


### PR DESCRIPTION
Return types were added to internal methods in PHP 8.1. To suppress deprecation warnings, the `ReturnTypeWillChange` attribute can be added to inherited methods with no return types defined. Thanks to the backward compatible syntax of attributes, this does not break anything for lower PHP versions.

RFC: https://wiki.php.net/rfc/internal_method_return_types