### PR TITLE
Add Doctrine Types Annotations

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -49,6 +49,11 @@ $rules = array(
 );
 
 return Config::create()->setRules($rules)
-             ->setFinder(Finder::create()->in(__DIR__.'/src'))
+             ->setFinder(
+                Finder::create()
+                    ->in(__DIR__.'/src')
+                    ->notPath('Carbon/Doctrine/DateTimeType.php')
+                    ->notPath('Carbon/Doctrine/DateTimeImmutableType.php')
+             )
              ->setUsingCache(true)
              ->setRiskyAllowed(true);

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -36,3 +36,8 @@ enabled:
   - unneeded_control_parentheses
   - unused_use
   - whitespacy_lines
+
+finder:
+  exclude:
+    - "src/Carbon/Doctrine/DateTimeType.php"
+    - "src/Carbon/Doctrine/DateTimeImmutableType.php"

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -38,6 +38,6 @@ enabled:
   - whitespacy_lines
 
 finder:
-  exclude:
+  not-path:
     - "src/Carbon/Doctrine/DateTimeType.php"
     - "src/Carbon/Doctrine/DateTimeImmutableType.php"

--- a/src/Carbon/Doctrine/CarbonTypeConverter.php
+++ b/src/Carbon/Doctrine/CarbonTypeConverter.php
@@ -13,8 +13,14 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Exception;
 
+/**
+ * @template T of CarbonInterface
+ */
 trait CarbonTypeConverter
 {
+    /**
+     * @return class-string<T>
+     */
     protected function getCarbonClassName(): string
     {
         return Carbon::class;
@@ -42,6 +48,8 @@ trait CarbonTypeConverter
 
     /**
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @return T|null
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
@@ -78,6 +86,8 @@ trait CarbonTypeConverter
 
     /**
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @return string|null
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {

--- a/src/Carbon/Doctrine/DateTimeImmutableType.php
+++ b/src/Carbon/Doctrine/DateTimeImmutableType.php
@@ -11,8 +11,12 @@ use Doctrine\DBAL\Types\VarDateTimeImmutableType;
 
 class DateTimeImmutableType extends VarDateTimeImmutableType implements CarbonDoctrineType
 {
+    /** @use CarbonTypeConverter<CarbonImmutable> */
     use CarbonTypeConverter;
 
+    /**
+     * @return class-string<CarbonImmutable>
+     */
     protected function getCarbonClassName(): string
     {
         return CarbonImmutable::class;

--- a/src/Carbon/Doctrine/DateTimeType.php
+++ b/src/Carbon/Doctrine/DateTimeType.php
@@ -6,9 +6,11 @@
  */
 namespace Carbon\Doctrine;
 
+use Carbon\Carbon;
 use Doctrine\DBAL\Types\VarDateTimeType;
 
 class DateTimeType extends VarDateTimeType implements CarbonDoctrineType
 {
+    /** @use CarbonTypeConverter<Carbon> */
     use CarbonTypeConverter;
 }


### PR DESCRIPTION
## Description

This PR's purpose is to allow [phpstan-doctrine](https://github.com/phpstan/phpstan-doctrine) to recognise `Carbon`|`CarbonImmutable` and `carbon`|`carbon_immutable` usages in entities. The main beneficiaries of this are those using the library in a Symfony project with Doctrine.

## Features / Changes
- [x] adding type hints using generics to the needed types in `src/Carbon/Doctrine`
- [x] ignoring [these files](https://github.com/briannesbitt/Carbon/compare/master...AlexandruGG:feature/doctrine-types-annotations?expand=1#diff-644bd23a8e99e566f73e70a02a0d1a387c088927c32ef3cb75f3367e72f4334bR55-R56) in PHP-CS-FIXER - this is because the rule [phpdoc_to_comment](https://cs.symfony.com/doc/rules/phpdoc/phpdoc_to_comment.html) currently breaks the `@use` annotation for traits. It's been reported in various forms in multiple issues, one example [here](https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4446#issuecomment-561703207). Sadly there is no way to ignore a single line with this tool, only an entire file; should not be a big issue though, as those files are very small 

## Testing
- [x] Manually tested that phpstan-doctrine works as expected in a separate project with these changes
- [x] Ran PHPStan in this project at max level to ensure the typings added are correct

## Notes
- this was recommended as the best approach by @ondrejmirtes here: https://github.com/phpstan/phpstan-doctrine/pull/192#issuecomment-850258319
- I tested and this will work with both ways of using this library with Doctrine if all types are registered in phpstan-doctrine, i.e:

A)
```
datetime_immutable: \Carbon\Doctrine\DateTimeImmutableType
datetime: \Carbon\Doctrine\DateTimeType
```

B)
```
carbon_immutable: \Carbon\Doctrine\CarbonImmutableType
carbon: \Carbon\Doctrine\CarbonType
```