### PR TITLE
Drop fixes for old PHP versions

### DIFF
--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -921,9 +921,6 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
         $interval = static::instance($start->diffAsDateInterval($end, $absolute));
         $interval->fixDiffInterval();
 
-        // The line below fixes https://bugs.php.net/bug.php?id=77007
-        $interval->abs($absolute);
-
         $interval->startDate = $start;
         $interval->endDate = $end;
 

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -919,7 +919,6 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
         $start = $start instanceof CarbonInterface ? $start : Carbon::make($start);
         $end = $end instanceof CarbonInterface ? $end : Carbon::make($end);
         $interval = static::instance($start->diffAsDateInterval($end, $absolute));
-        $interval->fixDiffInterval();
 
         $interval->startDate = $start;
         $interval->endDate = $end;
@@ -2802,29 +2801,6 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
 
         $this->f *= self::NEGATIVE;
         $this->invert();
-    }
-
-    /**
-     * Work-around for https://bugs.php.net/bug.php?id=77145
-     *
-     * @SuppressWarnings(UnusedPrivateMethod)
-     *
-     * @codeCoverageIgnore
-     */
-    private function fixDiffInterval(): void
-    {
-        if ($this->f > 0 && $this->y === -1 && $this->m === 11 && $this->d >= 27 && $this->h === 23 && $this->i === 59 && $this->s === 59) {
-            $this->y = 0;
-            $this->m = 0;
-            $this->d = 0;
-            $this->h = 0;
-            $this->i = 0;
-            $this->s = 0;
-            $this->f = (1000000 - round($this->f * 1000000)) / 1000000;
-            $this->invert();
-        } elseif ($this->f < 0) {
-            $this->fixNegativeMicroseconds();
-        }
     }
 
     /**

--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -77,12 +77,6 @@ trait Creator
             static::mockConstructorParameters($time, $tz);
         }
 
-        // Work-around for PHP bug https://bugs.php.net/bug.php?id=67127
-        if (strpos((string) .1, '.') === false) {
-            $locale = setlocale(LC_NUMERIC, '0');
-            setlocale(LC_NUMERIC, 'C');
-        }
-
         try {
             parent::__construct($time ?: 'now', static::safeCreateDateTimeZone($tz) ?: null);
         } catch (Exception $exception) {
@@ -90,10 +84,6 @@ trait Creator
         }
 
         $this->constructedObjectId = spl_object_hash($this);
-
-        if (isset($locale)) {
-            setlocale(LC_NUMERIC, $locale);
-        }
 
         static::setLastErrors(parent::getLastErrors());
     }

--- a/src/Carbon/Traits/Units.php
+++ b/src/Carbon/Traits/Units.php
@@ -297,18 +297,6 @@ trait Units
             $value *= static::MICROSECONDS_PER_MILLISECOND;
         }
 
-        // Work-around for bug https://bugs.php.net/bug.php?id=75642
-        if ($unit === 'micro' || $unit === 'microsecond') {
-            $microseconds = $this->micro + $value;
-            $second = (int) floor($microseconds / static::MICROSECONDS_PER_SECOND);
-            $microseconds %= static::MICROSECONDS_PER_SECOND;
-            if ($microseconds < 0) {
-                $microseconds += static::MICROSECONDS_PER_SECOND;
-            }
-            $date = $date->microseconds($microseconds);
-            $unit = 'second';
-            $value = $second;
-        }
         $date = $date->modify("$value $unit");
 
         if (isset($timeString)) {


### PR DESCRIPTION
- Drop [PHP <= 7.2 bug fix 77007](https://bugs.php.net/bug.php?id=77007)
- Drop [PHP <= 7.2 bug fix 77145](https://bugs.php.net/bug.php?id=77145)
- Drop [PHP <= 7.1 bug fix 67127](https://bugs.php.net/bug.php?id=67127)
- Drop [PHP <= 7.2 bug fix 75642](https://bugs.php.net/bug.php?id=75642)