### PR TITLE
Use the return value from callback in withTestNow

### DIFF
--- a/src/Carbon/Traits/Test.php
+++ b/src/Carbon/Traits/Test.php
@@ -63,12 +63,16 @@ trait Test
      *
      * @param Closure|static|string|false|null $testNow real or mock Carbon instance
      * @param Closure|null $callback
+     *
+     * @return mixed
      */
     public static function withTestNow($testNow = null, $callback = null)
     {
         static::setTestNow($testNow);
-        $callback();
+        $result = $callback();
         static::setTestNow();
+
+        return $result;
     }
 
     /**

--- a/tests/Carbon/TestingAidsTest.php
+++ b/tests/Carbon/TestingAidsTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Tests\Carbon;
 
 use Carbon\Carbon;
+use stdClass;
 use Tests\AbstractTestCase;
 
 class TestingAidsTest extends AbstractTestCase
@@ -274,10 +275,16 @@ class TestingAidsTest extends AbstractTestCase
     {
         $self = $this;
         $testNow = '2020-09-16 10:20:00';
-        Carbon::withTestNow($testNow, static function () use ($self, $testNow) {
+        $object = new stdClass();
+
+        $result = Carbon::withTestNow($testNow, static function () use ($self, $testNow, $object) {
             $currentTime = Carbon::now();
             $self->assertSame($testNow, $currentTime->format('Y-m-d H:i:s'));
+
+            return $object;
         });
+
+        $this->assertSame($object, $result);
 
         $currentTime = Carbon::now();
         $this->assertNotEquals($testNow, $currentTime->format('Y-m-d H:i:s'));

--- a/tests/CarbonImmutable/TestingAidsTest.php
+++ b/tests/CarbonImmutable/TestingAidsTest.php
@@ -14,6 +14,7 @@ namespace Tests\CarbonImmutable;
 use Carbon\CarbonImmutable as Carbon;
 use Carbon\CarbonInterface;
 use Closure;
+use stdClass;
 use Tests\AbstractTestCase;
 
 class TestingAidsTest extends AbstractTestCase
@@ -262,10 +263,16 @@ class TestingAidsTest extends AbstractTestCase
     {
         $self = $this;
         $testNow = '2020-09-16 10:20:00';
-        Carbon::withTestNow($testNow, static function () use ($self, $testNow) {
+        $object = new stdClass();
+
+        $result = Carbon::withTestNow($testNow, static function () use ($self, $testNow, $object) {
             $currentTime = Carbon::now();
             $self->assertSame($testNow, $currentTime->format('Y-m-d H:i:s'));
+
+            return $object;
         });
+
+        $this->assertSame($object, $result);
 
         $currentTime = Carbon::now();
         $this->assertNotEquals($testNow, $currentTime->format('Y-m-d H:i:s'));


### PR DESCRIPTION
Title says it all. This makes it just slightly more useful. Sometimes just the creation of a thing relies on a static date.