### PR TITLE
Clean-up .styleci.yml and .php_cs.dist

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -51,8 +51,10 @@ return (new Config())->setRules($rules)
              ->setFinder(
                 Finder::create()
                     ->in(__DIR__.'/src')
-                    ->notPath('Carbon/Doctrine/DateTimeType.php')
-                    ->notPath('Carbon/Doctrine/DateTimeImmutableType.php')
+                    ->notPath([
+                        'Carbon/Doctrine/DateTimeImmutableType.php',
+                        'Carbon/Doctrine/DateTimeType.php',
+                    ])
              )
              ->setUsingCache(true)
              ->setRiskyAllowed(true);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -50,10 +50,10 @@ $rules = [
 return (new Config())->setRules($rules)
              ->setFinder(
                 Finder::create()
-                    ->in(__DIR__.'/src')
+                    ->in(__DIR__)
                     ->notPath([
-                        'Carbon/Doctrine/DateTimeImmutableType.php',
-                        'Carbon/Doctrine/DateTimeType.php',
+                        'src/Carbon/Doctrine/DateTimeImmutableType.php',
+                        'src/Carbon/Doctrine/DateTimeType.php',
                     ])
              )
              ->setUsingCache(true)

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -45,7 +45,6 @@ $rules = array(
     'unary_operator_spaces' => true,
     'line_ending' => true,
     'blank_line_after_namespace' => true,
-    'no_unused_imports' => true,
 );
 
 return Config::create()->setRules($rules)

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -47,7 +47,7 @@ $rules = [
     'unary_operator_spaces' => true,
 ];
 
-return Config::create()->setRules($rules)
+return (new Config())->setRules($rules)
              ->setFinder(
                 Finder::create()
                     ->in(__DIR__.'/src')

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -3,16 +3,16 @@
 use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
 
-$rules = array(
+$rules = [
     '@PSR2' => true,
-    'array_syntax' => array(
+    'array_syntax' => [
         'syntax' => 'short',
-    ),
+    ],
     'blank_line_before_statement' => true,
     'cast_spaces' => true,
-    'concat_space' => array(
+    'concat_space' => [
         'spacing' => 'none',
-    ),
+    ],
     'ereg_to_preg' => true,
     'native_function_invocation' => [
         'include' => ['@compiler_optimized'],
@@ -45,7 +45,7 @@ $rules = array(
     'unary_operator_spaces' => true,
     'line_ending' => true,
     'blank_line_after_namespace' => true,
-);
+];
 
 return Config::create()->setRules($rules)
              ->setFinder(

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -8,12 +8,14 @@ $rules = [
     'array_syntax' => [
         'syntax' => 'short',
     ],
+    'blank_line_after_namespace' => true,
     'blank_line_before_statement' => true,
     'cast_spaces' => true,
     'concat_space' => [
         'spacing' => 'none',
     ],
     'ereg_to_preg' => true,
+    'line_ending' => true,
     'native_function_invocation' => [
         'include' => ['@compiler_optimized'],
     ],
@@ -43,8 +45,6 @@ $rules = [
     'trailing_comma_in_multiline_array' => true,
     'trim_array_spaces' => true,
     'unary_operator_spaces' => true,
-    'line_ending' => true,
-    'blank_line_after_namespace' => true,
 ];
 
 return Config::create()->setRules($rules)

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -9,7 +9,6 @@ enabled:
   - no_empty_lines_after_phpdocs
   - operators_spaces
   - ordered_use
-  # - phpdoc_align
   - phpdoc_indent
   - phpdoc_inline_tag
   - phpdoc_no_access

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -3,7 +3,6 @@ preset: psr2
 enabled:
   - concat_without_spaces
   - extra_empty_lines
-  - short_array_syntax
   - method_separation
   - multiline_array_trailing_comma
   - no_empty_lines_after_phpdocs
@@ -22,6 +21,7 @@ enabled:
   - phpdoc_types
   - phpdoc_var_without_name
   - return
+  - short_array_syntax
   - short_bool_cast
   - single_quote
   - spaces_after_semicolon
@@ -38,5 +38,5 @@ enabled:
 
 finder:
   not-path:
-    - "src/Carbon/Doctrine/DateTimeType.php"
     - "src/Carbon/Doctrine/DateTimeImmutableType.php"
+    - "src/Carbon/Doctrine/DateTimeType.php"

--- a/build.php
+++ b/build.php
@@ -7,8 +7,8 @@ if (preg_match('/On branch ([^\n]+)\n/', shell_exec('git status'), $match)) {
 }
 shell_exec('git fetch --all --tags --prune');
 $remotes = explode("\n", trim(shell_exec('git remote')));
-$tagsCommand = count($remotes)
-    ? 'git ls-remote --tags '.(in_array('upstream', $remotes) ? 'upstream' : (in_array('origin', $remotes) ? 'origin' : $remotes[0]))
+$tagsCommand = \count($remotes)
+    ? 'git ls-remote --tags '.(\in_array('upstream', $remotes) ? 'upstream' : (\in_array('origin', $remotes) ? 'origin' : $remotes[0]))
     : 'git tag';
 $tags = array_map(function ($ref) {
     $ref = explode('refs/tags/', $ref);
@@ -19,10 +19,10 @@ $tags = array_map(function ($ref) {
 }));
 usort($tags, 'version_compare');
 
-$tag = isset($argv[1]) && !in_array($argv[1], ['last', 'latest']) ? $argv[1] : end($tags);
+$tag = isset($argv[1]) && !\in_array($argv[1], ['last', 'latest']) ? $argv[1] : end($tags);
 
 if (strtolower($tag) !== 'all') {
-    if (!in_array($tag, $tags)) {
+    if (!\in_array($tag, $tags)) {
         echo "Tag must be one of remote tags available:\n";
         foreach ($tags as $_tag) {
             echo "  - $_tag\n";
@@ -61,7 +61,7 @@ foreach ($tags as $tag) {
     foreach (['src', 'vendor', 'Carbon'] as $directory) {
         if (is_dir($directory)) {
             $directory = realpath($directory);
-            $base = dirname($directory);
+            $base = \dirname($directory);
 
             $files = new RecursiveIteratorIterator(
                 new RecursiveDirectoryIterator($directory),
@@ -72,7 +72,7 @@ foreach ($tags as $tag) {
                 if (!$file->isDir()) {
                     $filePath = $file->getRealPath();
 
-                    $zip->addFile($filePath, substr($filePath, strlen($base) + 1));
+                    $zip->addFile($filePath, substr($filePath, \strlen($base) + 1));
                 }
             }
         }

--- a/phpdoc.php
+++ b/phpdoc.php
@@ -131,7 +131,7 @@ function dumpParameter($method, ReflectionParameter $parameter)
 }
 
 foreach ($tags as $tag) {
-    if (is_array($tag)) {
+    if (\is_array($tag)) {
         [$tag, $pattern] = $tag;
     }
 
@@ -290,7 +290,7 @@ foreach ($tags as $tag) {
                         "Sub one $unitName to the instance (using date interval).",
                     ];
 
-                    if (in_array($unit, [
+                    if (\in_array($unit, [
                         'month',
                         'quarter',
                         'year',
@@ -467,13 +467,13 @@ function compileDoc($autoDocLines, $file)
     $autoDoc = '';
     $columnsMaxLengths = [];
     foreach ($autoDocLines as &$editableLine) {
-        if (is_array($editableLine)) {
+        if (\is_array($editableLine)) {
             if (($editableLine[1] ?? '') === 'self') {
                 $editableLine[1] = $class === 'Carbon' ? '$this' : $class;
             }
 
             foreach ($editableLine as $column => $text) {
-                $length = strlen($text);
+                $length = \strlen($text);
                 $max = $columnsMaxLengths[$column] ?? 0;
 
                 if ($length > $max) {
@@ -485,7 +485,7 @@ function compileDoc($autoDocLines, $file)
 
     foreach ($autoDocLines as $line) {
         $autoDoc .= "\n *";
-        if (is_string($line)) {
+        if (\is_string($line)) {
             if (!empty($line)) {
                 $autoDoc .= " $line";
             }
@@ -564,7 +564,7 @@ foreach ($carbonMethods as $method) {
                 $doc[0],
             ];
 
-            for ($i = 1; $i < count($doc); $i++) {
+            for ($i = 1; $i < \count($doc); $i++) {
                 $staticMethods[] = ['', '', '', $doc[$i]];
                 $staticImmutableMethods[] = ['', '', '', $doc[$i]];
             }

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -282,7 +282,7 @@ abstract class AbstractTestCase extends TestCase
         foreach ($dates as $date) {
             if ($date instanceof DateTime) {
                 $date = Carbon::instance($date);
-            } elseif (is_string($date)) {
+            } elseif (\is_string($date)) {
                 $date = Carbon::parse($date);
             }
 

--- a/tests/Carbon/ArraysTest.php
+++ b/tests/Carbon/ArraysTest.php
@@ -96,7 +96,7 @@ class ArraysTest extends AbstractTestCase
     {
         $date = new DumpCarbon();
         $date->breakFormat();
-        $this->assertTrue(is_array($date->__debugInfo()));
+        $this->assertTrue(\is_array($date->__debugInfo()));
     }
 
     public function testDebuggingUninitializedInstances()

--- a/tests/Carbon/CreateStrictTest.php
+++ b/tests/Carbon/CreateStrictTest.php
@@ -59,6 +59,7 @@ class CreateStrictTest extends AbstractTestCase
         Carbon::useStrictMode(false);
 
         $exception = null;
+
         try {
             Carbon::createStrict(null, -1);
         } catch (OutOfRangeException $e) {

--- a/tests/Carbon/GettersTest.php
+++ b/tests/Carbon/GettersTest.php
@@ -231,7 +231,7 @@ class GettersTest extends AbstractTestCase
     public function testGetAgeWithRealAge()
     {
         $d = Carbon::createFromDate(1975, 5, 21);
-        $age = intval(substr((string) (intval(date('Ymd')) - intval(date('Ymd', $d->timestamp))), 0, -4));
+        $age = \intval(substr((string) (\intval(date('Ymd')) - \intval(date('Ymd', $d->timestamp))), 0, -4));
 
         $this->assertSame($age, $d->age);
     }

--- a/tests/Carbon/InstanceTest.php
+++ b/tests/Carbon/InstanceTest.php
@@ -140,7 +140,7 @@ class InstanceTest extends AbstractTestCase
 
     public function testChildCast()
     {
-        $class = get_class(new class extends Carbon {
+        $class = \get_class(new class extends Carbon {
             public function foo()
             {
                 return 42;
@@ -158,7 +158,7 @@ class InstanceTest extends AbstractTestCase
 
     public function testSiblingCast()
     {
-        $class = get_class(new class extends DateTime {
+        $class = \get_class(new class extends DateTime {
             public function foo()
             {
                 return 42;

--- a/tests/Carbon/LocalizationTest.php
+++ b/tests/Carbon/LocalizationTest.php
@@ -684,7 +684,7 @@ class LocalizationTest extends AbstractTestCase
 
     public function testGetAvailableLocales()
     {
-        $this->assertCount(count(glob(__DIR__.'/../../src/Carbon/Lang/*.php')), Carbon::getAvailableLocales());
+        $this->assertCount(\count(glob(__DIR__.'/../../src/Carbon/Lang/*.php')), Carbon::getAvailableLocales());
 
         /** @var Translator $translator */
         $translator = Carbon::getTranslator();
@@ -711,7 +711,7 @@ class LocalizationTest extends AbstractTestCase
         Carbon::setTranslator($translator);
 
         $this->expectException(NotLocaleAwareException::class);
-        $this->expectExceptionMessage(get_class($translator).' does neither implements Symfony\\Contracts\\Translation\\LocaleAwareInterface nor getLocale() method.');
+        $this->expectExceptionMessage(\get_class($translator).' does neither implements Symfony\\Contracts\\Translation\\LocaleAwareInterface nor getLocale() method.');
 
         Carbon::now()->locale();
     }
@@ -719,7 +719,7 @@ class LocalizationTest extends AbstractTestCase
     public function testGetAvailableLocalesInfo()
     {
         $infos = Carbon::getAvailableLocalesInfo();
-        $this->assertCount(count(Carbon::getAvailableLocales()), Carbon::getAvailableLocalesInfo());
+        $this->assertCount(\count(Carbon::getAvailableLocales()), Carbon::getAvailableLocalesInfo());
         $this->assertArrayHasKey('en', $infos);
         $this->assertInstanceOf(Language::class, $infos['en']);
         $this->assertSame('English', $infos['en']->getIsoName());

--- a/tests/Carbon/MacroTest.php
+++ b/tests/Carbon/MacroTest.php
@@ -28,7 +28,7 @@ class MacroTest extends AbstractTestCaseWithOldNow
 
     public function testCarbonIsMacroableWhenNotCalledDynamically()
     {
-        if (!function_exists('easter_days')) {
+        if (!\function_exists('easter_days')) {
             $this->markTestSkipped('This test requires ext-calendar to be enabled.');
         }
 
@@ -51,7 +51,7 @@ class MacroTest extends AbstractTestCaseWithOldNow
 
     public function testCarbonIsMacroableWhenNotCalledDynamicallyUsingThis()
     {
-        if (!function_exists('easter_days')) {
+        if (!\function_exists('easter_days')) {
             $this->markTestSkipped('This test requires ext-calendar to be enabled.');
         }
 
@@ -75,7 +75,7 @@ class MacroTest extends AbstractTestCaseWithOldNow
 
     public function testCarbonIsMacroableWhenCalledStatically()
     {
-        if (!function_exists('easter_days')) {
+        if (!\function_exists('easter_days')) {
             $this->markTestSkipped('This test requires ext-calendar to be enabled.');
         }
 

--- a/tests/Carbon/SettersTest.php
+++ b/tests/Carbon/SettersTest.php
@@ -554,7 +554,7 @@ class SettersTest extends AbstractTestCase
             $second = mt_rand(0, 59);
             $microsecond = mt_rand(0, 999999);
             $units = ['millennium', 'century', 'decade', 'year', 'quarter', 'month', 'day', 'hour', 'minute', 'second', 'week'];
-            $overflowUnit = $units[mt_rand(0, count($units) - 1)];
+            $overflowUnit = $units[mt_rand(0, \count($units) - 1)];
             $units = [
                 'year' => 10,
                 'month' => 12,
@@ -564,7 +564,7 @@ class SettersTest extends AbstractTestCase
                 'second' => 60,
                 'microsecond' => 1000000,
             ];
-            $valueUnit = array_keys($units)[mt_rand(0, count($units) - 1)];
+            $valueUnit = array_keys($units)[mt_rand(0, \count($units) - 1)];
             $value = mt_rand() > 0.5 ?
                 mt_rand(-9999, 9999) :
                 mt_rand(-60, 60);
@@ -669,7 +669,7 @@ class SettersTest extends AbstractTestCase
             $second = mt_rand(0, 59);
             $microsecond = mt_rand(0, 999999);
             $units = ['millennium', 'century', 'decade', 'year', 'quarter', 'month', 'day', 'hour', 'minute', 'second', 'week'];
-            $overflowUnit = $units[mt_rand(0, count($units) - 1)];
+            $overflowUnit = $units[mt_rand(0, \count($units) - 1)];
             $units = [
                 'year' => 10,
                 'month' => 12,
@@ -679,7 +679,7 @@ class SettersTest extends AbstractTestCase
                 'second' => 60,
                 'microsecond' => 1000000,
             ];
-            $valueUnit = array_keys($units)[mt_rand(0, count($units) - 1)];
+            $valueUnit = array_keys($units)[mt_rand(0, \count($units) - 1)];
             $value = mt_rand() > 0.5 ?
                 mt_rand(-9999, 9999) :
                 mt_rand(-60, 60);
@@ -764,7 +764,7 @@ class SettersTest extends AbstractTestCase
             $second = mt_rand(0, 59);
             $microsecond = mt_rand(0, 999999);
             $units = ['millennium', 'century', 'decade', 'year', 'quarter', 'month', 'day', 'hour', 'minute', 'second', 'week'];
-            $overflowUnit = $units[mt_rand(0, count($units) - 1)];
+            $overflowUnit = $units[mt_rand(0, \count($units) - 1)];
             $units = [
                 'year' => 10,
                 'month' => 12,
@@ -774,7 +774,7 @@ class SettersTest extends AbstractTestCase
                 'second' => 60,
                 'microsecond' => 1000000,
             ];
-            $valueUnit = array_keys($units)[mt_rand(0, count($units) - 1)];
+            $valueUnit = array_keys($units)[mt_rand(0, \count($units) - 1)];
             $value = mt_rand() > 0.5 ?
                 mt_rand(-9999, 9999) :
                 mt_rand(-60, 60);

--- a/tests/CarbonImmutable/GettersTest.php
+++ b/tests/CarbonImmutable/GettersTest.php
@@ -156,7 +156,7 @@ class GettersTest extends AbstractTestCase
     public function testGetAgeWithRealAge()
     {
         $d = Carbon::createFromDate(1975, 5, 21);
-        $age = intval(substr((string) (intval(date('Ymd')) - intval(date('Ymd', $d->timestamp))), 0, -4));
+        $age = \intval(substr((string) (\intval(date('Ymd')) - \intval(date('Ymd', $d->timestamp))), 0, -4));
 
         $this->assertSame($age, $d->age);
     }

--- a/tests/CarbonImmutable/InstanceTest.php
+++ b/tests/CarbonImmutable/InstanceTest.php
@@ -141,7 +141,7 @@ class InstanceTest extends AbstractTestCase
 
     public function testChildCast()
     {
-        $class = get_class(new class extends Carbon {
+        $class = \get_class(new class extends Carbon {
             public function foo()
             {
                 return 42;
@@ -159,7 +159,7 @@ class InstanceTest extends AbstractTestCase
 
     public function testSiblingCast()
     {
-        $class = get_class(new class extends DateTime {
+        $class = \get_class(new class extends DateTime {
             public function foo()
             {
                 return 42;

--- a/tests/CarbonImmutable/LocalizationTest.php
+++ b/tests/CarbonImmutable/LocalizationTest.php
@@ -653,7 +653,7 @@ class LocalizationTest extends AbstractTestCase
 
     public function testGetAvailableLocales()
     {
-        $this->assertCount(count(glob(__DIR__.'/../../src/Carbon/Lang/*.php')), Carbon::getAvailableLocales());
+        $this->assertCount(\count(glob(__DIR__.'/../../src/Carbon/Lang/*.php')), Carbon::getAvailableLocales());
 
         /** @var Translator $translator */
         $translator = Carbon::getTranslator();
@@ -680,7 +680,7 @@ class LocalizationTest extends AbstractTestCase
         Carbon::setTranslator($translator);
 
         $this->expectException(NotLocaleAwareException::class);
-        $this->expectExceptionMessage(get_class($translator).' does neither implements Symfony\\Contracts\\Translation\\LocaleAwareInterface nor getLocale() method.');
+        $this->expectExceptionMessage(\get_class($translator).' does neither implements Symfony\\Contracts\\Translation\\LocaleAwareInterface nor getLocale() method.');
 
         Carbon::now()->locale();
     }
@@ -688,7 +688,7 @@ class LocalizationTest extends AbstractTestCase
     public function testGetAvailableLocalesInfo()
     {
         $infos = Carbon::getAvailableLocalesInfo();
-        $this->assertCount(count(Carbon::getAvailableLocales()), Carbon::getAvailableLocalesInfo());
+        $this->assertCount(\count(Carbon::getAvailableLocales()), Carbon::getAvailableLocalesInfo());
         $this->assertArrayHasKey('en', $infos);
         $this->assertInstanceOf(Language::class, $infos['en']);
         $this->assertSame('English', $infos['en']->getIsoName());

--- a/tests/CarbonImmutable/MacroTest.php
+++ b/tests/CarbonImmutable/MacroTest.php
@@ -20,7 +20,7 @@ class MacroTest extends AbstractTestCaseWithOldNow
 {
     public function testCarbonIsMacroableWhenNotCalledDynamically()
     {
-        if (!function_exists('easter_days')) {
+        if (!\function_exists('easter_days')) {
             $this->markTestSkipped('This test requires ext-calendar to be enabled.');
         }
 
@@ -43,7 +43,7 @@ class MacroTest extends AbstractTestCaseWithOldNow
 
     public function testCarbonIsMacroableWhenNotCalledDynamicallyUsingThis()
     {
-        if (!function_exists('easter_days')) {
+        if (!\function_exists('easter_days')) {
             $this->markTestSkipped('This test requires ext-calendar to be enabled.');
         }
 
@@ -67,7 +67,7 @@ class MacroTest extends AbstractTestCaseWithOldNow
 
     public function testCarbonIsMacroableWhenCalledStatically()
     {
-        if (!function_exists('easter_days')) {
+        if (!\function_exists('easter_days')) {
             $this->markTestSkipped('This test requires ext-calendar to be enabled.');
         }
 

--- a/tests/CarbonInterval/ToDateIntervalTest.php
+++ b/tests/CarbonInterval/ToDateIntervalTest.php
@@ -15,7 +15,7 @@ class ToDateIntervalTest extends AbstractTestCase
     {
         $interval = CarbonInterval::days(5)->hours(3)->minutes(50)->microseconds(123456)->invert()->toDateInterval();
 
-        $this->assertSame('DateInterval', get_class($interval));
+        $this->assertSame('DateInterval', \get_class($interval));
 
         $this->assertSame(1, $interval->invert);
         $this->assertSame(5, $interval->d);
@@ -29,7 +29,7 @@ class ToDateIntervalTest extends AbstractTestCase
     {
         $interval = CarbonInterval::days(5)->hours(3)->minutes(50)->microseconds(123456)->invert()->cast(DateInterval::class);
 
-        $this->assertSame('DateInterval', get_class($interval));
+        $this->assertSame('DateInterval', \get_class($interval));
 
         $this->assertSame(1, $interval->invert);
         $this->assertSame(5, $interval->d);

--- a/tests/CarbonPeriod/CloneTest.php
+++ b/tests/CarbonPeriod/CloneTest.php
@@ -21,7 +21,7 @@ class CloneTest extends AbstractTestCase
         $period = CarbonPeriod::create('R4/2012-07-01T00:00:00/P7D');
         $clone = $period->clone();
 
-        $this->assertSame(strval($period), strval($clone));
+        $this->assertSame(\strval($period), \strval($clone));
         $this->assertNotSame($period, $clone);
         $this->assertEquals($period, $clone);
     }
@@ -31,7 +31,7 @@ class CloneTest extends AbstractTestCase
         $period = CarbonPeriod::create('R4/2012-07-01T00:00:00/P7D');
         $clone = $period->copy();
 
-        $this->assertSame(strval($period), strval($clone));
+        $this->assertSame(\strval($period), \strval($clone));
         $this->assertNotSame($period, $clone);
         $this->assertEquals($period, $clone);
     }

--- a/tests/CarbonPeriod/CreateTest.php
+++ b/tests/CarbonPeriod/CreateTest.php
@@ -641,7 +641,7 @@ class CreateTest extends AbstractTestCase
                     $this->getEndDate()->format('j');
             }
         };
-        $subClass = get_class($period);
+        $subClass = \get_class($period);
 
         $this->assertInstanceOf(CarbonPeriod::class, $period);
         $this->assertNotSame(CarbonPeriod::class, $subClass);

--- a/tests/CarbonPeriod/DynamicIntervalTest.php
+++ b/tests/CarbonPeriod/DynamicIntervalTest.php
@@ -33,7 +33,7 @@ class DynamicIntervalTest extends AbstractTestCase
             $dates[] = $date->day;
         }
 
-        $this->assertSame(10, count($period));
+        $this->assertSame(10, \count($period));
         $this->assertSame(array_merge(range(1, 5), range(8, 12)), $dates);
     }
 }

--- a/tests/CarbonPeriod/IteratorTest.php
+++ b/tests/CarbonPeriod/IteratorTest.php
@@ -205,7 +205,7 @@ class IteratorTest extends AbstractTestCase
                 $this->assertFalse($period->valid());
             }
 
-            if (count($results) >= $this->iterationLimit) {
+            if (\count($results) >= $this->iterationLimit) {
                 $this->fail('Infinite loop detected when traversing the period.');
             }
         }
@@ -234,7 +234,7 @@ class IteratorTest extends AbstractTestCase
                 $this->assertTrue($period->valid());
             }
 
-            if (count($results) >= $this->iterationLimit) {
+            if (\count($results) >= $this->iterationLimit) {
                 $this->fail('Infinite loop detected when traversing the period.');
             }
         }
@@ -265,7 +265,7 @@ class IteratorTest extends AbstractTestCase
                 $this->assertTrue($period->valid());
             }
 
-            if (count($results) >= $this->iterationLimit) {
+            if (\count($results) >= $this->iterationLimit) {
                 $this->fail('Infinite loop detected when traversing the period.');
             }
         }
@@ -293,7 +293,7 @@ class IteratorTest extends AbstractTestCase
             $this->assertEquals($current, $period->current());
             $this->assertTrue($period->valid());
 
-            if (count($results) >= $this->iterationLimit) {
+            if (\count($results) >= $this->iterationLimit) {
                 $this->fail('Infinite loop detected when traversing the period.');
             }
         }
@@ -344,7 +344,7 @@ class IteratorTest extends AbstractTestCase
 
             $period->next();
 
-            if (count($results) >= $this->iterationLimit) {
+            if (\count($results) >= $this->iterationLimit) {
                 $this->fail('Infinite loop detected when traversing the period.');
             }
         }

--- a/tests/CarbonPeriod/MacroTest.php
+++ b/tests/CarbonPeriod/MacroTest.php
@@ -38,7 +38,7 @@ class MacroTest extends AbstractTestCase
             $period = $this;
 
             return $period->addFilter(function ($date) {
-                return !in_array($date->dayOfWeek, [Carbon::SATURDAY, Carbon::SUNDAY]);
+                return !\in_array($date->dayOfWeek, [Carbon::SATURDAY, Carbon::SUNDAY]);
             });
         });
 
@@ -101,7 +101,7 @@ class MacroTest extends AbstractTestCase
         CarbonPeriod::macro('countWeekdaysBetween', function ($from, $to) {
             return CarbonPeriod::create($from, $to)
                 ->addFilter(function ($date) {
-                    return !in_array($date->dayOfWeek, [Carbon::SATURDAY, Carbon::SUNDAY]);
+                    return !\in_array($date->dayOfWeek, [Carbon::SATURDAY, Carbon::SUNDAY]);
                 })
                 ->count();
         });

--- a/tests/CarbonPeriod/ToDatePeriodTest.php
+++ b/tests/CarbonPeriod/ToDatePeriodTest.php
@@ -22,7 +22,7 @@ class ToDatePeriodTest extends AbstractTestCase
         $result = $period->toDatePeriod();
 
         $this->assertFalse($period->isEndExcluded());
-        $this->assertSame('DatePeriod', get_class($result));
+        $this->assertSame('DatePeriod', \get_class($result));
         $this->assertSame('2021-01-05', $result->getStartDate()->format('Y-m-d'));
         $this->assertSame('2021-02-15', $result->getEndDate()->format('Y-m-d'));
         // CarbonPeriod includes end date by default while DatePeriod will always exclude it
@@ -35,7 +35,7 @@ class ToDatePeriodTest extends AbstractTestCase
         $newInstance = CarbonPeriod::instance($result);
 
         $this->assertTrue($period->isEndExcluded());
-        $this->assertSame('DatePeriod', get_class($result));
+        $this->assertSame('DatePeriod', \get_class($result));
         $this->assertSame('2021-01-05', $result->getStartDate()->format('Y-m-d'));
         $this->assertSame('2021-02-14', $result->getEndDate()->format('Y-m-d'));
         $dates = iterator_to_array($result);
@@ -47,7 +47,7 @@ class ToDatePeriodTest extends AbstractTestCase
         $result = $period->toDatePeriod();
         $newInstance = CarbonPeriod::instance($result);
 
-        $this->assertSame('DatePeriod', get_class($result));
+        $this->assertSame('DatePeriod', \get_class($result));
         $this->assertSame('2021-01-05', $result->getStartDate()->format('Y-m-d'));
         $this->assertNull($result->getEndDate());
         $dates = iterator_to_array($result);

--- a/tests/CarbonTimeZone/ConversionsTest.php
+++ b/tests/CarbonTimeZone/ConversionsTest.php
@@ -23,8 +23,8 @@ class ConversionsTest extends AbstractTestCaseWithOldNow
 {
     public function testToString()
     {
-        $this->assertSame('+06:00', strval(new CarbonTimeZone(6)));
-        $this->assertSame('Europe/Paris', strval(new CarbonTimeZone('Europe/Paris')));
+        $this->assertSame('+06:00', \strval(new CarbonTimeZone(6)));
+        $this->assertSame('Europe/Paris', \strval(new CarbonTimeZone('Europe/Paris')));
     }
 
     public function testToRegionName()
@@ -124,17 +124,17 @@ class ConversionsTest extends AbstractTestCaseWithOldNow
         /** @var DateTimeZone $tz */
         $tz = (new CarbonTimeZone('America/Toronto'))->cast(DateTimeZone::class);
 
-        $this->assertSame(DateTimeZone::class, get_class($tz));
+        $this->assertSame(DateTimeZone::class, \get_class($tz));
         $this->assertSame('America/Toronto', $tz->getName());
 
         $obj = new class extends CarbonTimeZone {
         };
-        $class = get_class($obj);
+        $class = \get_class($obj);
 
         /** @var DateTimeZone $tz */
         $tz = (new CarbonTimeZone('America/Toronto'))->cast($class);
 
-        $this->assertSame($class, get_class($tz));
+        $this->assertSame($class, \get_class($tz));
         $this->assertSame('America/Toronto', $tz->getName());
     }
 

--- a/tests/CommonTraits/MacroContextNestingTest.php
+++ b/tests/CommonTraits/MacroContextNestingTest.php
@@ -24,7 +24,7 @@ class MacroContextNestingTest extends AbstractTestCaseWithOldNow
         return [
             [Carbon::class, Carbon::parse('2010-05-23'), null],
             [CarbonImmutable::class, CarbonImmutable::parse('2010-05-23'), null],
-            [CarbonInterval::class, CarbonInterval::make('P1M6D'), strval(CarbonInterval::second())],
+            [CarbonInterval::class, CarbonInterval::make('P1M6D'), \strval(CarbonInterval::second())],
             [CarbonPeriod::class, CarbonPeriod::create('2010-08-23', '2010-10-02'), null],
         ];
     }
@@ -56,9 +56,9 @@ class MacroContextNestingTest extends AbstractTestCaseWithOldNow
         $dates = $class::$macro2();
 
         $this->assertSame([
-            $reference ?: strval(new $class),
-            strval($sample),
-            $reference ?: strval(new $class),
+            $reference ?: \strval(new $class),
+            \strval($sample),
+            $reference ?: \strval(new $class),
         ], $dates);
     }
 
@@ -74,7 +74,7 @@ class MacroContextNestingTest extends AbstractTestCaseWithOldNow
         $class::macro($macro1, static function () {
             $context = self::context();
 
-            return $context ? get_class($context) : 'null';
+            return $context ? \get_class($context) : 'null';
         });
 
         $macro2 = 'macro'.(mt_rand(100, 999999) * 2 + 1);

--- a/tests/Jenssegers/JenssegersDate.php
+++ b/tests/Jenssegers/JenssegersDate.php
@@ -30,7 +30,7 @@ class JenssegersDate extends Carbon
 
     public static function jngParse($time = null, $tz = null)
     {
-        if (is_string($time)) {
+        if (\is_string($time)) {
             $time = static::translateTimeString($time, static::getLocale(), 'en');
         }
 
@@ -39,7 +39,7 @@ class JenssegersDate extends Carbon
 
     public static function jngCreateFromFormat($format, $time = null, $tz = null)
     {
-        if (is_string($time)) {
+        if (\is_string($time)) {
             $time = static::translateTimeString($time, static::getLocale(), 'en');
         }
 

--- a/tests/Language/LanguageTest.php
+++ b/tests/Language/LanguageTest.php
@@ -19,9 +19,9 @@ class LanguageTest extends AbstractTestCase
     public function testAll()
     {
         $all = Language::all();
-        $this->assertTrue(is_array($all));
+        $this->assertTrue(\is_array($all));
         $this->assertArrayHasKey('en', $all);
-        $this->assertTrue(is_array($all['en']));
+        $this->assertTrue(\is_array($all['en']));
         $this->assertArrayHasKey('isoName', $all['en']);
         $this->assertSame('English', $all['en']['isoName']);
     }
@@ -29,7 +29,7 @@ class LanguageTest extends AbstractTestCase
     public function testRegions()
     {
         $regions = Language::regions();
-        $this->assertTrue(is_array($regions));
+        $this->assertTrue(\is_array($regions));
         $this->assertArrayHasKey('US', $regions);
         $this->assertSame('United States of America', $regions['US']);
     }
@@ -240,11 +240,11 @@ class LanguageTest extends AbstractTestCase
     public function testToString()
     {
         $ar = new Language('ar');
-        $this->assertSame('ar', strval($ar));
+        $this->assertSame('ar', \strval($ar));
         $ar = new Language('ar_DZ');
-        $this->assertSame('ar_DZ', strval($ar));
+        $this->assertSame('ar_DZ', \strval($ar));
         $ar = new Language('ar_Shakl');
-        $this->assertSame('ar_Shakl', strval($ar));
+        $this->assertSame('ar_Shakl', \strval($ar));
     }
 
     public function testToJson()

--- a/tests/Localization/LanguagesCoverageTest.php
+++ b/tests/Localization/LanguagesCoverageTest.php
@@ -24,7 +24,7 @@ class LanguagesCoverageTest extends AbstractTestCase
         $tester = $this;
         $missingLanguages = array_filter($languages, function ($language) use ($tester, $tests) {
             $file = basename($language);
-            $covered = in_array(
+            $covered = \in_array(
                 str_replace(['_', '-', '@'], '', strtolower(substr($file, 0, -4))),
                 $tests
             );

--- a/tests/Localization/NlTest.php
+++ b/tests/Localization/NlTest.php
@@ -233,21 +233,21 @@ class NlTest extends LocalizationTestCase
 
     public function testPeriod()
     {
-        $this->assertSame('4 keer elke week van 2012-07-01 12:00:00', strval(CarbonPeriod::create('R4/2012-07-01T12:00:00/P7D')));
-        $this->assertSame('4 keer elk jaar van 2012-07-01 12:00:00', strval(CarbonPeriod::create('R4/2012-07-01T12:00:00/P1Y')));
-        $this->assertSame('4 keer elke 2 jaar van 2012-07-01 12:00:00', strval(CarbonPeriod::create('R4/2012-07-01T12:00:00/P2Y')));
-        $this->assertSame('4 keer elk jaar en 6 maanden van 2012-07-01 12:00:00', strval(CarbonPeriod::create('R4/2012-07-01T12:00:00/P1Y6M')));
-        $this->assertSame('Elke dag en 5 uur van 2015-09-30 12:50:00 tot 2015-10-03 19:00:00', strval(CarbonPeriod::create(
+        $this->assertSame('4 keer elke week van 2012-07-01 12:00:00', \strval(CarbonPeriod::create('R4/2012-07-01T12:00:00/P7D')));
+        $this->assertSame('4 keer elk jaar van 2012-07-01 12:00:00', \strval(CarbonPeriod::create('R4/2012-07-01T12:00:00/P1Y')));
+        $this->assertSame('4 keer elke 2 jaar van 2012-07-01 12:00:00', \strval(CarbonPeriod::create('R4/2012-07-01T12:00:00/P2Y')));
+        $this->assertSame('4 keer elk jaar en 6 maanden van 2012-07-01 12:00:00', \strval(CarbonPeriod::create('R4/2012-07-01T12:00:00/P1Y6M')));
+        $this->assertSame('Elke dag en 5 uur van 2015-09-30 12:50:00 tot 2015-10-03 19:00:00', \strval(CarbonPeriod::create(
             Carbon::parse('2015-09-30 12:50'),
             CarbonInterval::day()->hours(5),
             Carbon::parse('2015-10-03 19:00')
         )));
-        $this->assertSame('Elk uur en 30 minuten van 2015-09-30 12:50:00 tot 2015-10-03 19:00:00', strval(CarbonPeriod::create(
+        $this->assertSame('Elk uur en 30 minuten van 2015-09-30 12:50:00 tot 2015-10-03 19:00:00', \strval(CarbonPeriod::create(
             Carbon::parse('2015-09-30 12:50'),
             CarbonInterval::hour()->minutes(30),
             Carbon::parse('2015-10-03 19:00')
         )));
-        $this->assertSame('Elke 4 uur en 30 minuten van 2015-09-30 12:50:00 tot 2015-10-03 19:00:00', strval(CarbonPeriod::create(
+        $this->assertSame('Elke 4 uur en 30 minuten van 2015-09-30 12:50:00 tot 2015-10-03 19:00:00', \strval(CarbonPeriod::create(
             Carbon::parse('2015-09-30 12:50'),
             CarbonInterval::hours(4)->minutes(30),
             Carbon::parse('2015-10-03 19:00')


### PR DESCRIPTION
This PR cleans up  .styleci.yml and .php_cs.dist files.

This PR also enforces the same code-style on the whole project and not only `/src` while running php-cs-fixer.
as `.styleci.yml` already covers on the whole project (also `/tests`).
(See 964c15f8bb9b109ebfcce3a927920f4c19a353dc)
