### PR TITLE
Fixes for PHP 8.1

### DIFF
--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -26,6 +26,7 @@ use DateTimeInterface;
 use DateTimeZone;
 use JsonSerializable;
 use ReflectionException;
+use ReturnTypeWillChange;
 use Throwable;
 
 /**
@@ -3017,6 +3018,7 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
      *
      * @return array|string
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize();
 
     /**

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -32,6 +32,7 @@ use InvalidArgumentException;
 use Iterator;
 use JsonSerializable;
 use ReflectionException;
+use ReturnTypeWillChange;
 use RuntimeException;
 
 /**
@@ -2163,6 +2164,7 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
      *
      * @return CarbonInterface[]
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/src/Carbon/Lang/nl.php
+++ b/src/Carbon/Lang/nl.php
@@ -71,9 +71,9 @@ return [
     'period_recurrences' => ':count keer',
     'period_interval' => function ($interval) {
         /** @var string $output */
-        $output = preg_replace('/^(een|één|1)\s+/', '', $interval);
+        $output = preg_replace('/^(een|één|1)\s+/', '', $interval ?? '');
 
-        if (preg_match('/^(een|één|1)( jaar|j| uur|u)/', $interval)) {
+        if (preg_match('/^(een|één|1)( jaar|j| uur|u)/', $interval ?? '')) {
             return "elk $output";
         }
 

--- a/src/Carbon/Lang/nl.php
+++ b/src/Carbon/Lang/nl.php
@@ -69,11 +69,11 @@ return [
     'diff_after_tomorrow' => 'overmorgen',
     'diff_before_yesterday' => 'eergisteren',
     'period_recurrences' => ':count keer',
-    'period_interval' => function ($interval) {
+    'period_interval' => function (string $interval) {
         /** @var string $output */
-        $output = preg_replace('/^(een|één|1)\s+/', '', $interval ?? '');
+        $output = preg_replace('/^(een|één|1)\s+/', '', $interval);
 
-        if (preg_match('/^(een|één|1)( jaar|j| uur|u)/', $interval ?? '')) {
+        if (preg_match('/^(een|één|1)( jaar|j| uur|u)/', $interval)) {
             return "elk $output";
         }
 

--- a/src/Carbon/Lang/nl.php
+++ b/src/Carbon/Lang/nl.php
@@ -69,7 +69,7 @@ return [
     'diff_after_tomorrow' => 'overmorgen',
     'diff_before_yesterday' => 'eergisteren',
     'period_recurrences' => ':count keer',
-    'period_interval' => function (string $interval) {
+    'period_interval' => function (string $interval = '') {
         /** @var string $output */
         $output = preg_replace('/^(een|één|1)\s+/', '', $interval);
 

--- a/src/Carbon/Lang/oc.php
+++ b/src/Carbon/Lang/oc.php
@@ -86,7 +86,7 @@ return [
         $ordinal = [1 => 'èr', 2 => 'nd'][(int) $number] ?? 'en';
 
         // feminine for year, week, hour, minute, second
-        if (preg_match('/^[yYwWhHgGis]$/', $period)) {
+        if (preg_match('/^[yYwWhHgGis]$/', $period ?? '')) {
             $ordinal .= 'a';
         }
 

--- a/src/Carbon/Lang/oc.php
+++ b/src/Carbon/Lang/oc.php
@@ -82,11 +82,11 @@ return [
     'weekdays' => ['dimenge', 'diluns', 'dimars', 'dimècres', 'dijòus', 'divendres', 'dissabte'],
     'weekdays_short' => ['dg', 'dl', 'dm', 'dc', 'dj', 'dv', 'ds'],
     'weekdays_min' => ['dg', 'dl', 'dm', 'dc', 'dj', 'dv', 'ds'],
-    'ordinal' => function ($number, $period) {
+    'ordinal' => function ($number, string $period) {
         $ordinal = [1 => 'èr', 2 => 'nd'][(int) $number] ?? 'en';
 
         // feminine for year, week, hour, minute, second
-        if (preg_match('/^[yYwWhHgGis]$/', $period ?? '')) {
+        if (preg_match('/^[yYwWhHgGis]$/', $period)) {
             $ordinal .= 'a';
         }
 

--- a/src/Carbon/Lang/oc.php
+++ b/src/Carbon/Lang/oc.php
@@ -82,7 +82,7 @@ return [
     'weekdays' => ['dimenge', 'diluns', 'dimars', 'dimècres', 'dijòus', 'divendres', 'dissabte'],
     'weekdays_short' => ['dg', 'dl', 'dm', 'dc', 'dj', 'dv', 'ds'],
     'weekdays_min' => ['dg', 'dl', 'dm', 'dc', 'dj', 'dv', 'ds'],
-    'ordinal' => function ($number, string $period) {
+    'ordinal' => function ($number, string $period = '') {
         $ordinal = [1 => 'èr', 2 => 'nd'][(int) $number] ?? 'en';
 
         // feminine for year, week, hour, minute, second

--- a/src/Carbon/Language.php
+++ b/src/Carbon/Language.php
@@ -11,6 +11,7 @@
 namespace Carbon;
 
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 class Language implements JsonSerializable
 {
@@ -332,6 +333,7 @@ class Language implements JsonSerializable
      *
      * @return string
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getIsoDescription();

--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -2022,7 +2022,7 @@ trait Date
         $number = $this->$key;
         $result = $this->translate('ordinal', [
             ':number' => $number,
-            ':period' => $period,
+            ':period' => (string) $period,
         ]);
 
         return \strval($result === 'ordinal' ? $number : $result);

--- a/src/Carbon/Traits/Localization.php
+++ b/src/Carbon/Traits/Localization.php
@@ -643,7 +643,7 @@ trait Localization
         return static::executeWithLocale($locale, function ($newLocale, TranslatorInterface $translator) {
             return $newLocale &&
                 $translator->trans('period_recurrences') !== 'period_recurrences' &&
-                $translator->trans('period_interval') !== 'period_interval' &&
+                $translator->trans('period_interval', ['']) !== 'period_interval' &&
                 $translator->trans('period_start_date') !== 'period_start_date' &&
                 $translator->trans('period_end_date') !== 'period_end_date';
         });

--- a/src/Carbon/Traits/Localization.php
+++ b/src/Carbon/Traits/Localization.php
@@ -643,7 +643,7 @@ trait Localization
         return static::executeWithLocale($locale, function ($newLocale, TranslatorInterface $translator) {
             return $newLocale &&
                 $translator->trans('period_recurrences') !== 'period_recurrences' &&
-                $translator->trans('period_interval', ['']) !== 'period_interval' &&
+                $translator->trans('period_interval') !== 'period_interval' &&
                 $translator->trans('period_start_date') !== 'period_start_date' &&
                 $translator->trans('period_end_date') !== 'period_end_date';
         });


### PR DESCRIPTION
Since my PR #2338 return types have also been added to `JsonSerializable::jsonSerialize()`.

I've also fixed a few cases of passing null to non-nullable arguments that I've missed in #2337.