### PR TITLE
Modernize type casting.

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -16,6 +16,7 @@ $rules = [
     ],
     'ereg_to_preg' => true,
     'line_ending' => true,
+    'modernize_types_casting' => true,
     'native_function_invocation' => [
         'include' => ['@compiler_optimized'],
     ],

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -4,6 +4,7 @@ enabled:
   - concat_without_spaces
   - extra_empty_lines
   - method_separation
+  - modernize_types_casting
   - multiline_array_trailing_comma
   - no_empty_lines_after_phpdocs
   - operators_spaces

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,5 +1,7 @@
 preset: psr2
 
+risky: true
+
 enabled:
   - concat_without_spaces
   - extra_empty_lines

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -353,7 +353,7 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
 
         $spec = $years;
 
-        if (!\is_string($spec) || \floatval($years) || preg_match('/^[0-9.]/', $years)) {
+        if (!\is_string($spec) || (float) $years || preg_match('/^[0-9.]/', $years)) {
             $spec = static::PERIOD_PREFIX;
 
             $spec .= $years > 0 ? $years.static::PERIOD_YEARS : '';
@@ -536,7 +536,7 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
                 }
 
                 $interval = mb_substr($interval, mb_strlen($match[0]));
-                $instance->$unit += \intval($match[0]);
+                $instance->$unit += (int) ($match[0]);
 
                 continue;
             }
@@ -679,8 +679,8 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
         preg_match_all($pattern, $intervalDefinition, $parts, PREG_SET_ORDER);
 
         while ([$part, $value, $unit] = array_shift($parts)) {
-            $intValue = \intval($value);
-            $fraction = \floatval($value) - $intValue;
+            $intValue = (int) $value;
+            $fraction = (float) $value - $intValue;
 
             // Fix calculation precision
             switch (round($fraction, 6)) {
@@ -1860,7 +1860,7 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
             [$value, $unit] = [$unit, $value];
         }
 
-        return $this->add($unit, -\floatval($value));
+        return $this->add($unit, -(float) $value);
     }
 
     /**

--- a/src/Carbon/Traits/Comparison.php
+++ b/src/Carbon/Traits/Comparison.php
@@ -949,7 +949,7 @@ trait Comparison
         $tester = trim($tester);
 
         if (preg_match('/^\d+$/', $tester)) {
-            return $this->year === \intval($tester);
+            return $this->year === (int) $tester;
         }
 
         if (preg_match('/^\d{3,}-\d{1,2}$/', $tester)) {

--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -969,7 +969,7 @@ trait Date
 
             // @property int 1 through 366
             case $name === 'dayOfYear':
-                return 1 + \intval($this->rawFormat('z'));
+                return 1 + (int) ($this->rawFormat('z'));
 
             // @property-read int 365 or 366
             case $name === 'daysInYear':
@@ -1339,7 +1339,7 @@ trait Date
      */
     public function weekday($value = null)
     {
-        $dayOfWeek = ($this->dayOfWeek + 7 - \intval($this->getTranslationMessage('first_day_of_week') ?? 0)) % 7;
+        $dayOfWeek = ($this->dayOfWeek + 7 - (int) ($this->getTranslationMessage('first_day_of_week') ?? 0)) % 7;
 
         return \is_null($value) ? $dayOfWeek : $this->addDays($value - $dayOfWeek);
     }
@@ -1918,7 +1918,7 @@ trait Date
                 's' => 'second',
                 'ss' => ['getPaddedUnit', ['second']],
                 'S' => function (CarbonInterface $date) {
-                    return \strval((string) floor($date->micro / 100000));
+                    return (string) ((string) floor($date->micro / 100000));
                 },
                 'SS' => function (CarbonInterface $date) {
                     return str_pad((string) floor($date->micro / 10000), 2, '0', STR_PAD_LEFT);
@@ -2025,7 +2025,7 @@ trait Date
             ':period' => (string) $period,
         ]);
 
-        return \strval($result === 'ordinal' ? $number : $result);
+        return (string) ($result === 'ordinal' ? $number : $result);
     }
 
     /**

--- a/src/Carbon/Traits/Difference.php
+++ b/src/Carbon/Traits/Difference.php
@@ -1136,6 +1136,6 @@ trait Difference
             $format = $format($current, $other) ?? '';
         }
 
-        return $this->isoFormat(\strval($format));
+        return $this->isoFormat((string) $format);
     }
 }

--- a/src/Carbon/Traits/Timestamp.php
+++ b/src/Carbon/Traits/Timestamp.php
@@ -173,8 +173,8 @@ trait Timestamp
         foreach (preg_split('`[^0-9.]+`', $numbers) as $chunk) {
             [$integerPart, $decimalPart] = explode('.', "$chunk.");
 
-            $integer += \intval($integerPart);
-            $decimal += \floatval("0.$decimalPart");
+            $integer += (int) $integerPart;
+            $decimal += (float) ("0.$decimalPart");
         }
 
         $overflow = floor($decimal);

--- a/src/Carbon/Traits/Units.php
+++ b/src/Carbon/Traits/Units.php
@@ -248,7 +248,7 @@ trait Units
     {
         $date = $this;
 
-        if (!is_numeric($value) || !\floatval($value)) {
+        if (!is_numeric($value) || !(float) $value) {
             return $date->isMutable() ? $date : $date->avoidMutation();
         }
 
@@ -392,7 +392,7 @@ trait Units
             [$value, $unit] = [$unit, $value];
         }
 
-        return $this->addUnit($unit, -\floatval($value), $overflow);
+        return $this->addUnit($unit, -(float) $value, $overflow);
     }
 
     /**

--- a/tests/Carbon/GettersTest.php
+++ b/tests/Carbon/GettersTest.php
@@ -231,7 +231,7 @@ class GettersTest extends AbstractTestCase
     public function testGetAgeWithRealAge()
     {
         $d = Carbon::createFromDate(1975, 5, 21);
-        $age = \intval(substr((string) (\intval(date('Ymd')) - \intval(date('Ymd', $d->timestamp))), 0, -4));
+        $age = (int) (substr((string) ((int) (date('Ymd')) - (int) (date('Ymd', $d->timestamp))), 0, -4));
 
         $this->assertSame($age, $d->age);
     }

--- a/tests/CarbonImmutable/GettersTest.php
+++ b/tests/CarbonImmutable/GettersTest.php
@@ -156,7 +156,7 @@ class GettersTest extends AbstractTestCase
     public function testGetAgeWithRealAge()
     {
         $d = Carbon::createFromDate(1975, 5, 21);
-        $age = \intval(substr((string) (\intval(date('Ymd')) - \intval(date('Ymd', $d->timestamp))), 0, -4));
+        $age = (int) (substr((string) ((int) (date('Ymd')) - (int) (date('Ymd', $d->timestamp))), 0, -4));
 
         $this->assertSame($age, $d->age);
     }

--- a/tests/CarbonPeriod/CloneTest.php
+++ b/tests/CarbonPeriod/CloneTest.php
@@ -21,7 +21,7 @@ class CloneTest extends AbstractTestCase
         $period = CarbonPeriod::create('R4/2012-07-01T00:00:00/P7D');
         $clone = $period->clone();
 
-        $this->assertSame(\strval($period), \strval($clone));
+        $this->assertSame((string) $period, (string) $clone);
         $this->assertNotSame($period, $clone);
         $this->assertEquals($period, $clone);
     }
@@ -31,7 +31,7 @@ class CloneTest extends AbstractTestCase
         $period = CarbonPeriod::create('R4/2012-07-01T00:00:00/P7D');
         $clone = $period->copy();
 
-        $this->assertSame(\strval($period), \strval($clone));
+        $this->assertSame((string) $period, (string) $clone);
         $this->assertNotSame($period, $clone);
         $this->assertEquals($period, $clone);
     }

--- a/tests/CarbonTimeZone/ConversionsTest.php
+++ b/tests/CarbonTimeZone/ConversionsTest.php
@@ -23,8 +23,8 @@ class ConversionsTest extends AbstractTestCaseWithOldNow
 {
     public function testToString()
     {
-        $this->assertSame('+06:00', \strval(new CarbonTimeZone(6)));
-        $this->assertSame('Europe/Paris', \strval(new CarbonTimeZone('Europe/Paris')));
+        $this->assertSame('+06:00', (string) (new CarbonTimeZone(6)));
+        $this->assertSame('Europe/Paris', (string) (new CarbonTimeZone('Europe/Paris')));
     }
 
     public function testToRegionName()

--- a/tests/CommonTraits/MacroContextNestingTest.php
+++ b/tests/CommonTraits/MacroContextNestingTest.php
@@ -24,7 +24,7 @@ class MacroContextNestingTest extends AbstractTestCaseWithOldNow
         return [
             [Carbon::class, Carbon::parse('2010-05-23'), null],
             [CarbonImmutable::class, CarbonImmutable::parse('2010-05-23'), null],
-            [CarbonInterval::class, CarbonInterval::make('P1M6D'), \strval(CarbonInterval::second())],
+            [CarbonInterval::class, CarbonInterval::make('P1M6D'), (string) (CarbonInterval::second())],
             [CarbonPeriod::class, CarbonPeriod::create('2010-08-23', '2010-10-02'), null],
         ];
     }
@@ -56,9 +56,9 @@ class MacroContextNestingTest extends AbstractTestCaseWithOldNow
         $dates = $class::$macro2();
 
         $this->assertSame([
-            $reference ?: \strval(new $class),
-            \strval($sample),
-            $reference ?: \strval(new $class),
+            $reference ?: (string) (new $class),
+            (string) $sample,
+            $reference ?: (string) (new $class),
         ], $dates);
     }
 

--- a/tests/Language/LanguageTest.php
+++ b/tests/Language/LanguageTest.php
@@ -240,11 +240,11 @@ class LanguageTest extends AbstractTestCase
     public function testToString()
     {
         $ar = new Language('ar');
-        $this->assertSame('ar', \strval($ar));
+        $this->assertSame('ar', (string) $ar);
         $ar = new Language('ar_DZ');
-        $this->assertSame('ar_DZ', \strval($ar));
+        $this->assertSame('ar_DZ', (string) $ar);
         $ar = new Language('ar_Shakl');
-        $this->assertSame('ar_Shakl', \strval($ar));
+        $this->assertSame('ar_Shakl', (string) $ar);
     }
 
     public function testToJson()

--- a/tests/Localization/NlTest.php
+++ b/tests/Localization/NlTest.php
@@ -233,21 +233,21 @@ class NlTest extends LocalizationTestCase
 
     public function testPeriod()
     {
-        $this->assertSame('4 keer elke week van 2012-07-01 12:00:00', \strval(CarbonPeriod::create('R4/2012-07-01T12:00:00/P7D')));
-        $this->assertSame('4 keer elk jaar van 2012-07-01 12:00:00', \strval(CarbonPeriod::create('R4/2012-07-01T12:00:00/P1Y')));
-        $this->assertSame('4 keer elke 2 jaar van 2012-07-01 12:00:00', \strval(CarbonPeriod::create('R4/2012-07-01T12:00:00/P2Y')));
-        $this->assertSame('4 keer elk jaar en 6 maanden van 2012-07-01 12:00:00', \strval(CarbonPeriod::create('R4/2012-07-01T12:00:00/P1Y6M')));
-        $this->assertSame('Elke dag en 5 uur van 2015-09-30 12:50:00 tot 2015-10-03 19:00:00', \strval(CarbonPeriod::create(
+        $this->assertSame('4 keer elke week van 2012-07-01 12:00:00', (string) (CarbonPeriod::create('R4/2012-07-01T12:00:00/P7D')));
+        $this->assertSame('4 keer elk jaar van 2012-07-01 12:00:00', (string) (CarbonPeriod::create('R4/2012-07-01T12:00:00/P1Y')));
+        $this->assertSame('4 keer elke 2 jaar van 2012-07-01 12:00:00', (string) (CarbonPeriod::create('R4/2012-07-01T12:00:00/P2Y')));
+        $this->assertSame('4 keer elk jaar en 6 maanden van 2012-07-01 12:00:00', (string) (CarbonPeriod::create('R4/2012-07-01T12:00:00/P1Y6M')));
+        $this->assertSame('Elke dag en 5 uur van 2015-09-30 12:50:00 tot 2015-10-03 19:00:00', (string) (CarbonPeriod::create(
             Carbon::parse('2015-09-30 12:50'),
             CarbonInterval::day()->hours(5),
             Carbon::parse('2015-10-03 19:00')
         )));
-        $this->assertSame('Elk uur en 30 minuten van 2015-09-30 12:50:00 tot 2015-10-03 19:00:00', \strval(CarbonPeriod::create(
+        $this->assertSame('Elk uur en 30 minuten van 2015-09-30 12:50:00 tot 2015-10-03 19:00:00', (string) (CarbonPeriod::create(
             Carbon::parse('2015-09-30 12:50'),
             CarbonInterval::hour()->minutes(30),
             Carbon::parse('2015-10-03 19:00')
         )));
-        $this->assertSame('Elke 4 uur en 30 minuten van 2015-09-30 12:50:00 tot 2015-10-03 19:00:00', \strval(CarbonPeriod::create(
+        $this->assertSame('Elke 4 uur en 30 minuten van 2015-09-30 12:50:00 tot 2015-10-03 19:00:00', (string) (CarbonPeriod::create(
             Carbon::parse('2015-09-30 12:50'),
             CarbonInterval::hours(4)->minutes(30),
             Carbon::parse('2015-10-03 19:00')


### PR DESCRIPTION
This PR add a new rule to `php-cs-fixer` and `styleci` in order to modernize  the types casting.