### PR TITLE
Gets rid of useless calls to useStrictMode()

### DIFF
--- a/tests/Carbon/ConstructTest.php
+++ b/tests/Carbon/ConstructTest.php
@@ -151,7 +151,6 @@ class ConstructTest extends AbstractTestCase
         $timezone = 5;
         $c = new Carbon('2019-02-12 23:00:00', $timezone);
         $this->assertSame('+05:00', $c->tzName);
-        Carbon::useStrictMode(true);
     }
 
     public function testMockingWithMicroseconds()

--- a/tests/Carbon/CreateSafeTest.php
+++ b/tests/Carbon/CreateSafeTest.php
@@ -38,7 +38,6 @@ class CreateSafeTest extends AbstractTestCase
     {
         Carbon::useStrictMode(false);
         $this->assertFalse(Carbon::createSafe(null, null, null, null, null, -1));
-        Carbon::useStrictMode(true);
     }
 
     public function testCreateSafeThrowsExceptionForSecondGreaterThan59()
@@ -188,7 +187,6 @@ class CreateSafeTest extends AbstractTestCase
     {
         Carbon::useStrictMode(false);
         $this->assertFalse(Carbon::createSafe(2016, 2, 30, 17, 16, 15));
-        Carbon::useStrictMode(true);
     }
 
     public function testCreateSafePassesForFebruaryInLeapYear()

--- a/tests/Carbon/StrictModeTest.php
+++ b/tests/Carbon/StrictModeTest.php
@@ -16,18 +16,6 @@ use Tests\AbstractTestCase;
 
 class StrictModeTest extends AbstractTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-        Carbon::useStrictMode();
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-        Carbon::useStrictMode();
-    }
-
     public function testSafeCreateDateTimeZoneWithStrictMode1()
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/CarbonInterval/StrictModeTest.php
+++ b/tests/CarbonInterval/StrictModeTest.php
@@ -17,18 +17,6 @@ use Tests\AbstractTestCase;
 
 class StrictModeTest extends AbstractTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-        Carbon::useStrictMode();
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-        Carbon::useStrictMode();
-    }
-
     public function testSetWithStrictMode()
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/CarbonPeriod/StrictModeTest.php
+++ b/tests/CarbonPeriod/StrictModeTest.php
@@ -17,18 +17,6 @@ use Tests\AbstractTestCase;
 
 class StrictModeTest extends AbstractTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-        Carbon::useStrictMode();
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-        Carbon::useStrictMode();
-    }
-
     public function testCallWithStrictMode()
     {
         $this->expectException(\BadMethodCallException::class);

--- a/tests/CarbonTimeZone/ConversionsTest.php
+++ b/tests/CarbonTimeZone/ConversionsTest.php
@@ -150,7 +150,6 @@ class ConversionsTest extends AbstractTestCaseWithOldNow
     {
         Carbon::useStrictMode(false);
         $this->assertFalse((new CarbonTimeZone(-15))->toRegionTimeZone());
-        Carbon::useStrictMode(true);
     }
 
     public function testInvalidRegionForOffsetInStrictMode()


### PR DESCRIPTION
This PR gets rid of useless calls to `useStrictMode` static function.