### PR TITLE
Add getTimestampMs method to output millisecond-precise timestamps

### DIFF
--- a/src/Carbon/Traits/Timestamp.php
+++ b/src/Carbon/Traits/Timestamp.php
@@ -138,6 +138,16 @@ trait Timestamp
     }
 
     /**
+     * Returns the timestamp with millisecond precision.
+     *
+     * @return int
+     */
+    public function getTimestampMs()
+    {
+        return (int) $this->getPreciseTimestamp(3);
+    }
+
+    /**
      * @alias getTimestamp
      *
      * Returns the UNIX timestamp for the current date.

--- a/tests/Carbon/NowAndOtherStaticHelpersTest.php
+++ b/tests/Carbon/NowAndOtherStaticHelpersTest.php
@@ -48,6 +48,12 @@ class NowAndOtherStaticHelpersTest extends AbstractTestCase
         $this->assertSame(1515260050987126000.0, $dt->getPreciseTimestamp(9));
     }
 
+    public function testGetTimestampMs()
+    {
+        $dt = Carbon::parse('2018-01-06 12:34:10.987126');
+        $this->assertSame(1515260050987, $dt->getTimestampMs());
+    }
+
     public function testNowWithTimezone()
     {
         $dt = Carbon::now('Europe/London');

--- a/tests/CarbonImmutable/NowAndOtherStaticHelpersTest.php
+++ b/tests/CarbonImmutable/NowAndOtherStaticHelpersTest.php
@@ -47,6 +47,12 @@ class NowAndOtherStaticHelpersTest extends AbstractTestCase
         $this->assertSame(1515260050987126000.0, $dt->getPreciseTimestamp(9));
     }
 
+    public function testGetTimestampMs()
+    {
+        $dt = Carbon::parse('2018-01-06 12:34:10.987126');
+        $this->assertSame(1515260050987, $dt->getTimestampMs());
+    }
+
     public function testNowWithTimezone()
     {
         $dt = Carbon::now('Europe/London');


### PR DESCRIPTION
Hi there! Firstly, thank you for your continued work on Carbon, I don't know what I'd do without it! 

This PR adds a new `getTimestampMs()` method to compliment the already existing `createFromTimestampMs()` method. 

This is mostly a helper method to easily return a millisecond-precise timestamp as an `integer`. It also reads more naturally than the currently available methods (which return a `float`):

**Before**
```php
$timestamp = (int) $carbonDate->getPreciseTimestamp(3);

// OR

$timestamp = (int) $carbonDate->valueOf();
```

**After**
```php
$timestamp = $carbonDate->getTimestampMs();
```

Please let me know if there's any questions or feedback. I'm also happy to submit a PR to the docs if this gets merged.

Thanks!