### PR TITLE
Fix TestBaseCase

### DIFF
--- a/tests/Jenssegers/TestCaseBase.php
+++ b/tests/Jenssegers/TestCaseBase.php
@@ -6,12 +6,14 @@ namespace Tests\Jenssegers;
 use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 
-class TestCaseBase extends TestCase
+abstract class TestCaseBase extends TestCase
 {
     public const LOCALE = 'en';
 
-    public function setUp(): void
+    protected function setUp(): void
     {
+        parent::setUp();
+
         date_default_timezone_set('UTC');
         Carbon::setLocale(static::LOCALE);
 


### PR DESCRIPTION
This PR fixes `TestBaseCase`:

- No tests are executed, so the class should be abstract
- No override of setUp is recommended
- As a good practice, the parent setUp should always be called.