### PR TITLE
Add `ReturnTypeWillChange` to `CarbonInterface::jsonSerialize`

### DIFF
--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -3022,6 +3022,7 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
      *
      * @return array|string
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize();
 
     /**


### PR DESCRIPTION
This was added in https://github.com/briannesbitt/Carbon/pull/2364 and then removed in 865611d45f116ff00b8b584bd37a1c8e4e6fc4b9. I think this was removed accidentally as there's a deprecation notice when running PHP 8.1:

> Return type of Carbon\CarbonInterface::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in vendor/nesbot/carbon/src/Carbon/CarbonInterface.php:3025