### PR TITLE
Stop displaying coverage report for each PR

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 /.styleci.yml       export-ignore
 /.travis.yml        export-ignore
 /build.php          export-ignore
+/codecov.yml        export-ignore
 /phpdoc.php         export-ignore
 /phpstan.neon       export-ignore
 /phpunit.xml.dist   export-ignore

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
This PR disables the coverage report comment report for each PR.
IMO having access to hit via the PR status and the README badge is already sufficient.