### PR TITLE
Fix issue with Symfony\Translate v4.4.27

### DIFF
--- a/src/Carbon/Translator.php
+++ b/src/Carbon/Translator.php
@@ -326,7 +326,7 @@ class Translator extends Translation\Translator
 
         $previousLocale = $this->getLocale();
 
-        if ($previousLocale === $locale) {
+        if ($previousLocale === $locale && isset($this->messages[$locale])) {
             return true;
         }
 


### PR DESCRIPTION
This fixes an issue introduced by Symfony\Translate v4.4.27 changing the default return value of `getLocale()` to fallback to `\Locale::getDefault()` when php-intl is installed and enabled; and `'en'` when it is not. 

Previously, a newly initialized `Translator` object would have returned `null` from `getLocale()` on first initialization, which would have made this check pass. However, this change now means that the initialization that is supposed to occur from a fresh Translator calling setLocale() on itself will fail under the following conditions:
- The locale being initialized matches the one returned by `\Locale::getDefault()` on systems with php-intl installed and enabled
- Or the locale being initialized is `en` on systems where php-intl is not installed or enabled.

See https://github.com/symfony/translation/commit/c1cca3eb086bb62d98890631ef6bbc65ce913dd1#commitcomment-54056868, https://github.com/wintercms/winter/discussions/256, and https://github.com/octobercms/library/commit/ff2cec61078bcfc3c75117a37f8ea137458ebf91 for more information on affected projects.