### PR TITLE
Add no_extra_consecutive_blank_lines rule to php-cs-fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -23,6 +23,7 @@ $rules = [
         'include' => ['@compiler_optimized'],
     ],
     'no_blank_lines_after_phpdoc' => true,
+    'no_extra_blank_lines' => true,
     'no_short_bool_cast' => true,
     'no_unneeded_control_parentheses' => true,
     'no_unused_imports' => true,


### PR DESCRIPTION
Add `no_extra_consecutive_blank_lines` rule to `php-cs-fixer` 
( as for now duplicate empty lines are not removed )

---

_Note:_

This rule is already set in StyleCI and cannot be re-added ( cf. https://github.styleci.io/analyses/0gaB74 )