### PR TITLE
Improve exceptions testing

### DIFF
--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -20,6 +20,7 @@ use Closure;
 use DateTime;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
+use Throwable;
 
 abstract class AbstractTestCase extends TestCase
 {
@@ -257,7 +258,7 @@ abstract class AbstractTestCase extends TestCase
 
         try {
             $func();
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $exception = $e;
         }
 

--- a/tests/Carbon/CreateFromTimeTest.php
+++ b/tests/Carbon/CreateFromTimeTest.php
@@ -13,6 +13,7 @@ namespace Tests\Carbon;
 
 use Carbon\Carbon;
 use DateTimeZone;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 class CreateFromTimeTest extends AbstractTestCase
@@ -46,8 +47,9 @@ class CreateFromTimeTest extends AbstractTestCase
 
     public function testCreateFromTimeGreaterThan99()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('second must be between 0 and 99, 100 given');
+        $this->expectExceptionObject(new InvalidArgumentException(
+            'second must be between 0 and 99, 100 given'
+        ));
 
         Carbon::createFromTime(23, 5, 100);
     }

--- a/tests/Carbon/CreateSafeTest.php
+++ b/tests/Carbon/CreateSafeTest.php
@@ -26,10 +26,7 @@ class CreateSafeTest extends AbstractTestCase
 
     public function testCreateSafeThrowsExceptionForSecondLowerThanZero()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'second : -1 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('second', -1));
 
         Carbon::createSafe(null, null, null, null, null, -1);
     }
@@ -42,130 +39,91 @@ class CreateSafeTest extends AbstractTestCase
 
     public function testCreateSafeThrowsExceptionForSecondGreaterThan59()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'second : 60 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('second', 60));
 
         Carbon::createSafe(null, null, null, null, null, 60);
     }
 
     public function testCreateSafeThrowsExceptionForMinuteLowerThanZero()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'minute : -1 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('minute', -1));
 
         Carbon::createSafe(null, null, null, null, -1);
     }
 
     public function testCreateSafeThrowsExceptionForMinuteGreaterThan59()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'minute : 60 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('minute', 60));
 
         Carbon::createSafe(null, null, null, null, 60, 25);
     }
 
     public function testCreateSafeThrowsExceptionForHourLowerThanZero()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'hour : -6 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('hour', -6));
 
         Carbon::createSafe(null, null, null, -6);
     }
 
     public function testCreateSafeThrowsExceptionForHourGreaterThan24()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'hour : 25 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('hour', 25));
 
         Carbon::createSafe(null, null, null, 25, 16, 15);
     }
 
     public function testCreateSafeThrowsExceptionForDayLowerThanZero()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'day : -5 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('day', -5));
 
         Carbon::createSafe(null, null, -5);
     }
 
     public function testCreateSafeThrowsExceptionForDayGreaterThan31()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'day : 32 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('day', 32));
 
         Carbon::createSafe(null, null, 32, 17, 16, 15);
     }
 
     public function testCreateSafeThrowsExceptionForMonthLowerThanZero()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'month : -4 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('month', -4));
 
         Carbon::createSafe(null, -4);
     }
 
     public function testCreateSafeThrowsExceptionForMonthGreaterThan12()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'month : 13 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('month', 13));
 
         Carbon::createSafe(null, 13, 5, 17, 16, 15);
     }
 
     public function testCreateSafeThrowsExceptionForYearEqualToZero()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'year : 0 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('year', 0));
 
         Carbon::createSafe(0);
     }
 
     public function testCreateSafeThrowsExceptionForYearLowerThanZero()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'year : -5 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('year', -5));
 
         Carbon::createSafe(-5);
     }
 
     public function testCreateSafeThrowsExceptionForYearGreaterThan12()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'year : 10000 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('year', 10000));
 
         Carbon::createSafe(10000, 12, 5, 17, 16, 15);
     }
 
     public function testCreateSafeThrowsExceptionForInvalidDayInShortMonth()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'day : 31 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('day', 31));
 
         // 30 days in April
         Carbon::createSafe(2016, 4, 31, 17, 16, 15);
@@ -173,10 +131,7 @@ class CreateSafeTest extends AbstractTestCase
 
     public function testCreateSafeThrowsExceptionForInvalidDayForFebruaryInLeapYear()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'day : 30 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('day', 30));
 
         // 29 days in February for a leap year
         $this->assertTrue(Carbon::create(2016, 2)->isLeapYear());
@@ -197,10 +152,7 @@ class CreateSafeTest extends AbstractTestCase
 
     public function testCreateSafeThrowsExceptionForInvalidDayForFebruaryInNonLeapYear()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'day : 29 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('day', 29));
 
         // 28 days in February for a non-leap year
         $this->assertFalse(Carbon::create(2015, 2)->isLeapYear());
@@ -231,10 +183,7 @@ class CreateSafeTest extends AbstractTestCase
 
     public function testCreateSafeThrowsExceptionForWithNonIntegerValue()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'second : 15.1 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('second', 15.1));
 
         Carbon::createSafe(2015, 2, 10, 17, 16, 15.1);
     }

--- a/tests/Carbon/CreateStrictTest.php
+++ b/tests/Carbon/CreateStrictTest.php
@@ -20,20 +20,14 @@ class CreateStrictTest extends AbstractTestCase
 {
     public function testCreateStrictThrowsExceptionForSecondLowerThanZero()
     {
-        $this->expectException(OutOfRangeException::class);
-        $this->expectExceptionMessage(
-            'second must be between 0 and 99, -1 given'
-        );
+        $this->expectExceptionObject(new OutOfRangeException('second', 0, 99, -1));
 
         Carbon::createStrict(null, null, null, null, null, -1);
     }
 
     public function testCreateStrictThrowsExceptionForMonthOverRange()
     {
-        $this->expectException(OutOfRangeException::class);
-        $this->expectExceptionMessage(
-            'month must be between 0 and 99, 9001 given'
-        );
+        $this->expectExceptionObject(new OutOfRangeException('month', 0, 99, 9001));
 
         Carbon::createStrict(null, 9001);
     }

--- a/tests/Carbon/CreateTest.php
+++ b/tests/Carbon/CreateTest.php
@@ -13,6 +13,7 @@ namespace Tests\Carbon;
 
 use Carbon\Carbon;
 use Carbon\Exceptions\OutOfRangeException;
+use DateTime;
 use DateTimeZone;
 use InvalidArgumentException;
 use Tests\AbstractTestCase;
@@ -69,8 +70,9 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateWithInvalidMonth()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('month must be between 0 and 99, -5 given');
+        $this->expectExceptionObject(new InvalidArgumentException(
+            'month must be between 0 and 99, -5 given'
+        ));
 
         Carbon::create(null, -5);
     }
@@ -116,7 +118,9 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateWithInvalidDay()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionObject(new InvalidArgumentException(
+            'day must be between 0 and 99, -4 given'
+        ));
 
         Carbon::create(null, null, -4);
     }
@@ -137,7 +141,9 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateWithInvalidHour()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionObject(new InvalidArgumentException(
+            'hour must be between 0 and 99, -1 given'
+        ));
 
         Carbon::create(null, null, null, -1);
     }
@@ -156,7 +162,9 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateWithInvalidMinute()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionObject(new InvalidArgumentException(
+            'minute must be between 0 and 99, -2 given'
+        ));
 
         Carbon::create(2011, 1, 1, 0, -2, 0);
     }
@@ -175,7 +183,9 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateWithInvalidSecond()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionObject(new InvalidArgumentException(
+            'second must be between 0 and 99, -2 given'
+        ));
 
         Carbon::create(null, null, null, null, null, -2);
     }
@@ -203,14 +213,16 @@ class CreateTest extends AbstractTestCase
     public function testMake()
     {
         $this->assertCarbon(Carbon::make('2017-01-05'), 2017, 1, 5, 0, 0, 0);
-        $this->assertCarbon(Carbon::make(new \DateTime('2017-01-05')), 2017, 1, 5, 0, 0, 0);
+        $this->assertCarbon(Carbon::make(new DateTime('2017-01-05')), 2017, 1, 5, 0, 0, 0);
         $this->assertCarbon(Carbon::make(new Carbon('2017-01-05')), 2017, 1, 5, 0, 0, 0);
         $this->assertNull(Carbon::make(3));
     }
 
     public function testCreateWithInvalidTimezoneOffset()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionObject(new InvalidArgumentException(
+            'Unknown or bad timezone (-28236)'
+        ));
 
         Carbon::createFromDate(2000, 1, 1, -28236);
     }
@@ -345,8 +357,9 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateFromIsoFormatException()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Format wo not supported for creation.');
+        $this->expectExceptionObject(new InvalidArgumentException(
+            'Format wo not supported for creation.'
+        ));
 
         Carbon::createFromIsoFormat('YY D wo', '2019 April 4');
     }

--- a/tests/Carbon/DiffTest.php
+++ b/tests/Carbon/DiffTest.php
@@ -15,6 +15,7 @@ use Carbon\Carbon;
 use Carbon\CarbonInterface;
 use Carbon\CarbonInterval;
 use Closure;
+use DateTime;
 use Exception;
 use InvalidArgumentException;
 use Tests\AbstractTestCase;
@@ -1284,7 +1285,7 @@ class DiffTest extends AbstractTestCase
 
     public function testDiffForHumansWithDateTimeInstance()
     {
-        $feb15 = new \DateTime('2015-02-15');
+        $feb15 = new DateTime('2015-02-15');
         $mar15 = Carbon::parse('2015-03-15');
         $this->assertSame('1 month after', $mar15->diffForHumans($feb15));
     }
@@ -1311,7 +1312,7 @@ class DiffTest extends AbstractTestCase
     public function testDiffWithDateTime()
     {
         $dt1 = Carbon::createFromDate(2000, 1, 25)->endOfDay();
-        $dt2 = new \DateTime('2000-01-10');
+        $dt2 = new DateTime('2000-01-10');
 
         $this->assertSame(383, $dt1->diffInHours($dt2));
     }
@@ -1521,30 +1522,27 @@ class DiffTest extends AbstractTestCase
 
     public function testDiffWithInvalidType()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Expected null, string, DateTime or DateTimeInterface, integer given'
-        );
+        ));
 
         Carbon::createFromDate(2000, 1, 25)->diffInHours(10);
     }
 
     public function testDiffWithInvalidObject()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Expected null, string, DateTime or DateTimeInterface, Carbon\CarbonInterval given'
-        );
+        ));
 
         Carbon::createFromDate(2000, 1, 25)->diffInHours(new CarbonInterval());
     }
 
     public function testDiffForHumansWithIncorrectDateTimeStringWhichIsNotACarbonInstance()
     {
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new Exception(
             'Failed to parse time string (2018-04-13-08:00:00) at position 16'
-        );
+        ));
 
         $mar13 = Carbon::parse('2018-03-13');
         $mar13->diffForHumans('2018-04-13-08:00:00');

--- a/tests/Carbon/Exceptions/BadComparisonUnitExceptionTest.php
+++ b/tests/Carbon/Exceptions/BadComparisonUnitExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\BadComparisonUnitException;
+use Tests\AbstractTestCase;
+
+class BadComparisonUnitExceptionTest extends AbstractTestCase
+{
+    public function testComparisonUnitException():void
+    {
+        $exception = new BadComparisonUnitException('foo');
+
+        $this->assertSame("Bad comparison unit: 'foo'", $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/BadFluentConstructorExceptionTest.php
+++ b/tests/Carbon/Exceptions/BadFluentConstructorExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\BadFluentConstructorException;
+use Tests\AbstractTestCase;
+
+class BadFluentConstructorExceptionTest extends AbstractTestCase
+{
+    public function testBadFluentConstructorException(): void
+    {
+        $exception = new BadFluentConstructorException('foo');
+
+        $this->assertSame("Unknown fluent constructor 'foo'.", $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/BadFluentSetterExceptionTest.php
+++ b/tests/Carbon/Exceptions/BadFluentSetterExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\BadFluentSetterException;
+use Tests\AbstractTestCase;
+
+class BadFluentSetterExceptionTest extends AbstractTestCase
+{
+    public function testBadFluentSetterException(): void
+    {
+        $exception = new BadFluentSetterException('foo');
+
+        $this->assertSame("Unknown fluent setter 'foo'", $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/ImmutableExceptionTest.php
+++ b/tests/Carbon/Exceptions/ImmutableExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\ImmutableException;
+use Tests\AbstractTestCase;
+
+class ImmutableExceptionTest extends AbstractTestCase
+{
+    public function testImmutableException(): void
+    {
+        $exception = new ImmutableException('foo');
+
+        $this->assertSame('foo is immutable.', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/InvalidCastExceptionTest.php
+++ b/tests/Carbon/Exceptions/InvalidCastExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\InvalidCastException;
+use Tests\AbstractTestCase;
+
+class InvalidCastExceptionTest extends AbstractTestCase
+{
+    public function testInvalidCastException(): void
+    {
+        $exception = new InvalidCastException($message = 'message');
+
+        $this->assertSame($message, $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/InvalidDateExceptionTest.php
+++ b/tests/Carbon/Exceptions/InvalidDateExceptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\InvalidDateException;
+use Tests\AbstractTestCase;
+
+class InvalidDateExceptionTest extends AbstractTestCase
+{
+    public function testInvalidCastException(): void
+    {
+        $exception = new InvalidDateException('month', 13);
+
+        $this->assertSame('month', $exception->getField());
+        $this->assertSame(13, $exception->getValue());
+
+        $this->assertSame('month : 13 is not a valid value.', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/InvalidFormatExceptionTest.php
+++ b/tests/Carbon/Exceptions/InvalidFormatExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\InvalidFormatException;
+use Tests\AbstractTestCase;
+
+class InvalidFormatExceptionTest extends AbstractTestCase
+{
+    public function testInvalidFormatException(): void
+    {
+        $exception = new InvalidFormatException($message = 'message');
+
+        $this->assertSame($message, $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/InvalidIntervalExceptionTest.php
+++ b/tests/Carbon/Exceptions/InvalidIntervalExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\InvalidIntervalException;
+use Tests\AbstractTestCase;
+
+class InvalidIntervalExceptionTest extends AbstractTestCase
+{
+    public function testInvalidIntervalException(): void
+    {
+        $exception = new InvalidIntervalException($message = 'message');
+
+        $this->assertSame($message, $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/InvalidPeriodDateExceptionTest.php
+++ b/tests/Carbon/Exceptions/InvalidPeriodDateExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\InvalidPeriodDateException;
+use Tests\AbstractTestCase;
+
+class InvalidPeriodDateExceptionTest extends AbstractTestCase
+{
+    public function testInvalidPeriodDateException(): void
+    {
+        $exception = new InvalidPeriodDateException($message = 'message');
+
+        $this->assertSame($message, $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/InvalidPeriodParameterExceptionTest.php
+++ b/tests/Carbon/Exceptions/InvalidPeriodParameterExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\InvalidPeriodParameterException;
+use Tests\AbstractTestCase;
+
+class InvalidPeriodParameterExceptionTest extends AbstractTestCase
+{
+    public function testInvalidPeriodParameterException(): void
+    {
+        $exception = new InvalidPeriodParameterException($message = 'message');
+
+        $this->assertSame($message, $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/InvalidTimeZoneExceptionTest.php
+++ b/tests/Carbon/Exceptions/InvalidTimeZoneExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\InvalidTimeZoneException;
+use Tests\AbstractTestCase;
+
+class InvalidTimeZoneExceptionTest extends AbstractTestCase
+{
+    public function testInvalidTimeZoneException(): void
+    {
+        $exception = new InvalidTimeZoneException($message = 'message');
+
+        $this->assertSame($message, $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/InvalidTypeExceptionTest.php
+++ b/tests/Carbon/Exceptions/InvalidTypeExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\InvalidTypeException;
+use Tests\AbstractTestCase;
+
+class InvalidTypeExceptionTest extends AbstractTestCase
+{
+    public function testInvalidTypeException(): void
+    {
+        $exception = new InvalidTypeException($message = 'message');
+
+        $this->assertSame($message, $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/NotACarbonClassExceptionTest.php
+++ b/tests/Carbon/Exceptions/NotACarbonClassExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\NotACarbonClassException;
+use Tests\AbstractTestCase;
+
+class NotACarbonClassExceptionTest extends AbstractTestCase
+{
+    public function testNotACarbonClassException():void
+    {
+        $exception = new NotACarbonClassException('foo');
+
+        $this->assertSame('Given class does not implement Carbon\CarbonInterface: foo', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/NotAPeriodExceptionTest.php
+++ b/tests/Carbon/Exceptions/NotAPeriodExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\NotAPeriodException;
+use Tests\AbstractTestCase;
+
+class NotAPeriodExceptionTest extends AbstractTestCase
+{
+    public function testNotAPeriodException(): void
+    {
+        $exception = new NotAPeriodException($message = 'message');
+
+        $this->assertSame($message, $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/NotLocaleAwareExceptionTest.php
+++ b/tests/Carbon/Exceptions/NotLocaleAwareExceptionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\NotLocaleAwareException;
+use Generator;
+use stdClass;
+use Tests\AbstractTestCase;
+
+class NotLocaleAwareExceptionTest extends AbstractTestCase
+{
+    public function dataProviderTestNotAPeriodException(): Generator
+    {
+        yield [
+            new stdClass(),
+            'stdClass does neither implements Symfony\Contracts\Translation\LocaleAwareInterface nor getLocale() method.',
+        ];
+        yield [
+            'foo',
+            'string does neither implements Symfony\Contracts\Translation\LocaleAwareInterface nor getLocale() method.',
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderTestNotAPeriodException
+     *
+     * @param  mixed  $object
+     * @param  string  $message
+     *
+     * @return void
+     */
+    public function testNotAPeriodException($object, $message): void
+    {
+        $exception = new NotLocaleAwareException($object);
+
+        $this->assertSame($message, $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/OutOfRangeExceptionTest.php
+++ b/tests/Carbon/Exceptions/OutOfRangeExceptionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\OutOfRangeException;
+use Tests\AbstractTestCase;
+
+class OutOfRangeExceptionTest extends AbstractTestCase
+{
+    public function testOutOfRangeException(): void
+    {
+        $exception = new OutOfRangeException('month', 1, 12, -1);
+
+        $this->assertSame('month', $exception->getUnit());
+        $this->assertSame(1, $exception->getMin());
+        $this->assertSame(12, $exception->getMax());
+        $this->assertSame(-1, $exception->getValue());
+
+        $this->assertSame('month must be between 1 and 12, -1 given', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/ParseErrorExceptionTest.php
+++ b/tests/Carbon/Exceptions/ParseErrorExceptionTest.php
@@ -28,7 +28,7 @@ class ParseErrorExceptionTest extends AbstractTestCase
     {
         $exception = new ParseErrorException('string', 'int', 'help message');
 
-        $this->assertSame("Format expected string but get 'int'".PHP_EOL.'help message', $exception->getMessage());
+        $this->assertSame("Format expected string but get 'int'\nhelp message", $exception->getMessage());
         $this->assertSame(0, $exception->getCode());
         $this->assertNull($exception->getPrevious());
     }

--- a/tests/Carbon/Exceptions/ParseErrorExceptionTest.php
+++ b/tests/Carbon/Exceptions/ParseErrorExceptionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\ParseErrorException;
+use Tests\AbstractTestCase;
+
+class ParseErrorExceptionTest extends AbstractTestCase
+{
+    public function testParseErrorException(): void
+    {
+        $exception = new ParseErrorException('string', '');
+
+        $this->assertSame('Format expected string but data is missing', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+
+    public function testParseErrorExceptionWithActualAndHelp(): void
+    {
+        $exception = new ParseErrorException('string', 'int', 'help message');
+
+        $this->assertSame("Format expected string but get 'int'".PHP_EOL.'help message', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/UnitExceptionTest.php
+++ b/tests/Carbon/Exceptions/UnitExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\UnitException;
+use Tests\AbstractTestCase;
+
+class UnitExceptionTest extends AbstractTestCase
+{
+    public function testUnitException(): void
+    {
+        $exception = new UnitException($message = 'message');
+
+        $this->assertSame($message, $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/UnitNotConfiguredExceptionTest.php
+++ b/tests/Carbon/Exceptions/UnitNotConfiguredExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\UnitNotConfiguredException;
+use Tests\AbstractTestCase;
+
+class UnitNotConfiguredExceptionTest extends AbstractTestCase
+{
+    public function testUnitNotConfiguredException(): void
+    {
+        $exception = new UnitNotConfiguredException('foo');
+
+        $this->assertSame('Unit foo have no configuration to get total from other units.', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/UnknownGetterExceptionTest.php
+++ b/tests/Carbon/Exceptions/UnknownGetterExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\UnknownGetterException;
+use Tests\AbstractTestCase;
+
+class UnknownGetterExceptionTest extends AbstractTestCase
+{
+    public function testUnknownGetterException(): void
+    {
+        $exception = new UnknownGetterException('foo');
+
+        $this->assertSame("Unknown getter 'foo'", $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/UnknownMethodExceptionTest.php
+++ b/tests/Carbon/Exceptions/UnknownMethodExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\UnknownMethodException;
+use Tests\AbstractTestCase;
+
+class UnknownMethodExceptionTest extends AbstractTestCase
+{
+    public function testUnknownMethodException(): void
+    {
+        $exception = new UnknownMethodException('foo');
+
+        $this->assertSame('Method foo does not exist.', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/UnknownSetterExceptionTest.php
+++ b/tests/Carbon/Exceptions/UnknownSetterExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\UnknownSetterException;
+use Tests\AbstractTestCase;
+
+class UnknownSetterExceptionTest extends AbstractTestCase
+{
+    public function testUnknownSetterException(): void
+    {
+        $exception = new UnknownSetterException('foo');
+
+        $this->assertSame("Unknown setter 'foo'", $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/UnknownUnitExceptionTest.php
+++ b/tests/Carbon/Exceptions/UnknownUnitExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\UnknownUnitException;
+use Tests\AbstractTestCase;
+
+class UnknownUnitExceptionTest extends AbstractTestCase
+{
+    public function testUnknownUnitException(): void
+    {
+        $exception = new UnknownUnitException('foo');
+
+        $this->assertSame("Unknown unit 'foo'.", $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/Exceptions/UnreachableExceptionTest.php
+++ b/tests/Carbon/Exceptions/UnreachableExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Tests\Carbon\Exceptions;
+
+use Carbon\Exceptions\UnreachableException;
+use Tests\AbstractTestCase;
+
+class UnreachableExceptionTest extends AbstractTestCase
+{
+    public function testUnreachableException(): void
+    {
+        $exception = new UnreachableException($message = 'message');
+
+        $this->assertSame($message, $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}

--- a/tests/Carbon/GenericMacroTest.php
+++ b/tests/Carbon/GenericMacroTest.php
@@ -11,8 +11,10 @@ declare(strict_types=1);
  */
 namespace Tests\Carbon;
 
+use BadMethodCallException;
 use Carbon\Carbon;
 use Tests\AbstractTestCaseWithOldNow;
+use Throwable;
 
 class GenericMacroTest extends AbstractTestCaseWithOldNow
 {
@@ -34,9 +36,9 @@ class GenericMacroTest extends AbstractTestCaseWithOldNow
                 }
 
                 return new static($time);
-            } catch (\Throwable $exception) {
+            } catch (Throwable $exception) {
                 if (stripos($exception->getMessage(), 'Failed to parse') !== false) {
-                    throw new \BadMethodCallException('Try next macro', 0, $exception);
+                    throw new BadMethodCallException('Try next macro', 0, $exception);
                 }
 
                 throw $exception;
@@ -53,7 +55,7 @@ class GenericMacroTest extends AbstractTestCaseWithOldNow
 
         try {
             Carbon::fooBar();
-        } catch (\BadMethodCallException $exception) {
+        } catch (BadMethodCallException $exception) {
             $message = $exception->getMessage();
         }
 
@@ -63,7 +65,7 @@ class GenericMacroTest extends AbstractTestCaseWithOldNow
 
         try {
             $now->barBiz();
-        } catch (\BadMethodCallException $exception) {
+        } catch (BadMethodCallException $exception) {
             $message = $exception->getMessage();
         }
 
@@ -77,9 +79,9 @@ class GenericMacroTest extends AbstractTestCaseWithOldNow
 
             try {
                 return self::this()->modify($time);
-            } catch (\Throwable $exception) {
+            } catch (Throwable $exception) {
                 if (stripos($exception->getMessage(), 'Failed to parse') !== false) {
-                    throw new \BadMethodCallException('Try next macro', 0, $exception);
+                    throw new BadMethodCallException('Try next macro', 0, $exception);
                 }
 
                 throw $exception;
@@ -96,7 +98,7 @@ class GenericMacroTest extends AbstractTestCaseWithOldNow
 
         try {
             Carbon::fooBar();
-        } catch (\BadMethodCallException $exception) {
+        } catch (BadMethodCallException $exception) {
             $message = $exception->getMessage();
         }
 
@@ -106,7 +108,7 @@ class GenericMacroTest extends AbstractTestCaseWithOldNow
 
         try {
             $now->barBiz();
-        } catch (\BadMethodCallException $exception) {
+        } catch (BadMethodCallException $exception) {
             $message = $exception->getMessage();
         }
 
@@ -117,21 +119,21 @@ class GenericMacroTest extends AbstractTestCaseWithOldNow
     {
         Carbon::genericMacro(function ($method) {
             if (!str_starts_with($method, 'myPrefix')) {
-                throw new \BadMethodCallException('Try next macro', 0);
+                throw new BadMethodCallException('Try next macro', 0);
             }
 
             return 'first';
         });
         Carbon::genericMacro(function ($method) {
             if (!str_starts_with($method, 'myPrefix')) {
-                throw new \BadMethodCallException('Try next macro', 0);
+                throw new BadMethodCallException('Try next macro', 0);
             }
 
             return 'second';
         }, 1);
         Carbon::genericMacro(function ($method) {
             if (!str_starts_with($method, 'myPrefix')) {
-                throw new \BadMethodCallException('Try next macro', 0);
+                throw new BadMethodCallException('Try next macro', 0);
             }
 
             return 'third';
@@ -153,21 +155,21 @@ class GenericMacroTest extends AbstractTestCaseWithOldNow
     {
         Carbon::genericMacro(function ($method) {
             if (!str_starts_with($method, 'mlp')) {
-                throw new \BadMethodCallException('Try next macro', 0);
+                throw new BadMethodCallException('Try next macro', 0);
             }
 
             return 'first';
         });
         Carbon::genericMacro(function ($method) {
             if (!str_starts_with($method, 'mlp')) {
-                throw new \BadMethodCallException('Try next macro', 0);
+                throw new BadMethodCallException('Try next macro', 0);
             }
 
             return 'second';
         }, 1);
         Carbon::genericMacro(function ($method) {
             if (!str_starts_with($method, 'mlp')) {
-                throw new \BadMethodCallException('Try next macro', 0);
+                throw new BadMethodCallException('Try next macro', 0);
             }
 
             return 'third';
@@ -181,14 +183,14 @@ class GenericMacroTest extends AbstractTestCaseWithOldNow
             'genericMacros' => [
                 function ($method) {
                     if (!str_starts_with($method, 'mlp')) {
-                        throw new \BadMethodCallException('Try next macro', 0);
+                        throw new BadMethodCallException('Try next macro', 0);
                     }
 
                     return 'local-first';
                 },
                 function ($method) {
                     if (!str_starts_with($method, 'mlp')) {
-                        throw new \BadMethodCallException('Try next macro', 0);
+                        throw new BadMethodCallException('Try next macro', 0);
                     }
 
                     return 'local-second';

--- a/tests/Carbon/GettersTest.php
+++ b/tests/Carbon/GettersTest.php
@@ -12,13 +12,16 @@ declare(strict_types=1);
 namespace Tests\Carbon;
 
 use Carbon\Carbon;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 class GettersTest extends AbstractTestCase
 {
     public function testGettersThrowExceptionOnUnknownGetter()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionObject(new InvalidArgumentException(
+            "Unknown getter 'doesNotExit'"
+        ));
 
         /** @var mixed $d */
         $d = Carbon::create(1234, 5, 6, 7, 8, 9);

--- a/tests/Carbon/InstanceTest.php
+++ b/tests/Carbon/InstanceTest.php
@@ -16,6 +16,7 @@ use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 use DateTime;
 use DateTimeZone;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 class InstanceTest extends AbstractTestCase
@@ -129,10 +130,9 @@ class InstanceTest extends AbstractTestCase
 
     public function testInvalidCast()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'DateTimeZone has not the instance() method needed to cast the date.'
-        );
+        ));
 
         $carbon = new Carbon('2017-06-27 13:14:15.123456', 'Europe/Paris');
         $carbon->cast(DateTimeZone::class);

--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -12,7 +12,9 @@ declare(strict_types=1);
 namespace Tests\Carbon;
 
 use \DateTime;
+use BadMethodCallException;
 use Carbon\Carbon;
+use InvalidArgumentException;
 use stdClass;
 use Tests\AbstractTestCase;
 
@@ -660,10 +662,9 @@ class IsTest extends AbstractTestCase
 
     public function testIsSameAsWithInvalidArgument()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Expected null, string, DateTime or DateTimeInterface, stdClass given'
-        );
+        ));
 
         $current = Carbon::createFromDate(2012, 1, 2);
         $current->isSameAs('Y-m-d', new stdClass());
@@ -993,10 +994,9 @@ class IsTest extends AbstractTestCase
 
     public function testIsSameFoobar()
     {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new BadMethodCallException(
             'Method isSameFoobar does not exist.'
-        );
+        ));
 
         /** @var mixed $date */
         $date = Carbon::parse('12:00:00');
@@ -1005,10 +1005,9 @@ class IsTest extends AbstractTestCase
 
     public function testIsCurrentFoobar()
     {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new BadMethodCallException(
             'Method isCurrentFoobar does not exist.'
-        );
+        ));
 
         /** @var mixed $date */
         $date = Carbon::parse('12:00:00');

--- a/tests/Carbon/LocalizationTest.php
+++ b/tests/Carbon/LocalizationTest.php
@@ -16,6 +16,7 @@ use Carbon\CarbonInterval;
 use Carbon\Exceptions\NotLocaleAwareException;
 use Carbon\Language;
 use Carbon\Translator;
+use InvalidArgumentException;
 use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\MessageCatalogue;
@@ -710,8 +711,9 @@ class LocalizationTest extends AbstractTestCase
 
         Carbon::setTranslator($translator);
 
-        $this->expectException(NotLocaleAwareException::class);
-        $this->expectExceptionMessage(\get_class($translator).' does neither implements Symfony\\Contracts\\Translation\\LocaleAwareInterface nor getLocale() method.');
+        $this->expectExceptionObject(new NotLocaleAwareException(
+            $translator
+        ));
 
         Carbon::now()->locale();
     }
@@ -757,12 +759,11 @@ class LocalizationTest extends AbstractTestCase
 
     public function testTranslationCustomWithCustomTranslator()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Translator does not implement Symfony\Component\Translation\TranslatorInterface '.
             'and Symfony\Component\Translation\TranslatorBagInterface. '.
             'Symfony\Component\Translation\IdentityTranslator has been given.'
-        );
+        ));
 
         $date = Carbon::create(2018, 1, 1, 0, 0, 0);
         $date->setLocalTranslator(

--- a/tests/Carbon/MacroTest.php
+++ b/tests/Carbon/MacroTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  */
 namespace Tests\Carbon;
 
+use BadMethodCallException;
 use Carbon\Carbon;
 use Carbon\CarbonInterface;
 use DateTime;
@@ -233,20 +234,18 @@ class MacroTest extends AbstractTestCaseWithOldNow
 
     public function testCarbonRaisesExceptionWhenStaticMacroIsNotFound()
     {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new BadMethodCallException(
             'Method Carbon\Carbon::nonExistingStaticMacro does not exist.'
-        );
+        ));
 
         Carbon::nonExistingStaticMacro();
     }
 
     public function testCarbonRaisesExceptionWhenMacroIsNotFound()
     {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new BadMethodCallException(
             'Method nonExistingMacro does not exist.'
-        );
+        ));
 
         /** @var mixed $date */
         $date = Carbon::now();

--- a/tests/Carbon/ModifyTest.php
+++ b/tests/Carbon/ModifyTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Tests\Carbon;
 
 use Carbon\Carbon;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 class ModifyTest extends AbstractTestCase
@@ -197,10 +198,9 @@ class ModifyTest extends AbstractTestCase
 
     public function testAddRealUnitException()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Invalid unit for real timestamp add/sub: \'foobar\''
-        );
+        ));
 
         (new Carbon('2014-03-30 00:00:00'))->addRealUnit('foobar');
     }

--- a/tests/Carbon/RoundTest.php
+++ b/tests/Carbon/RoundTest.php
@@ -66,9 +66,9 @@ class RoundTest extends AbstractTestCase
 
     public function testRoundWithStringsException()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Rounding is only possible with single unit intervals.');
-
+        $this->expectExceptionObject(new InvalidArgumentException(
+            'Rounding is only possible with single unit intervals.'
+        ));
         Carbon::create(2315, 7, 18, 22, 42, 17.643971)->round('2 hours 5 minutes');
     }
 
@@ -83,8 +83,9 @@ class RoundTest extends AbstractTestCase
 
     public function testRoundWithIntervalException()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Rounding is only possible with single unit intervals.');
+        $this->expectExceptionObject(new InvalidArgumentException(
+            'Rounding is only possible with single unit intervals.'
+        ));
 
         Carbon::create(2315, 7, 18, 22, 42, 17.643971)->round(CarbonInterval::day()->minutes(5));
     }
@@ -165,10 +166,9 @@ class RoundTest extends AbstractTestCase
 
     public function testRoundInvalidArgument()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown unit \'foobar\'.'
-        );
+        ));
 
         Carbon::now()->roundUnit('foobar');
     }

--- a/tests/Carbon/SerializationTest.php
+++ b/tests/Carbon/SerializationTest.php
@@ -81,10 +81,9 @@ class SerializationTest extends AbstractTestCase
      */
     public function testFromUnserializedWithInvalidValue($value)
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             "Invalid serialized value: $value"
-        );
+        ));
 
         Carbon::fromSerialized($value);
     }

--- a/tests/Carbon/SettersTest.php
+++ b/tests/Carbon/SettersTest.php
@@ -14,6 +14,7 @@ namespace Tests\Carbon;
 use Carbon\Carbon;
 use DateTimeZone;
 use Exception;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 class SettersTest extends AbstractTestCase
@@ -254,7 +255,9 @@ class SettersTest extends AbstractTestCase
 
     public function testSetTimezoneWithInvalidTimezone()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionObject(new InvalidArgumentException(
+            'Unknown or bad timezone (sdf)'
+        ));
 
         $d = Carbon::now();
         $d->setTimezone('sdf');
@@ -262,10 +265,9 @@ class SettersTest extends AbstractTestCase
 
     public function testTimezoneWithInvalidTimezone()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown or bad timezone (sdf)'
-        );
+        ));
 
         /** @var mixed $d */
         $d = Carbon::now();
@@ -345,10 +347,9 @@ class SettersTest extends AbstractTestCase
 
     public function testTimezoneWithInvalidTimezoneSetter()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown or bad timezone (sdf)'
-        );
+        ));
 
         $d = Carbon::now();
         $d->timezone('sdf');
@@ -356,10 +357,9 @@ class SettersTest extends AbstractTestCase
 
     public function testTzWithInvalidTimezone()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown or bad timezone (sdf)'
-        );
+        ));
 
         /** @var mixed $d */
         $d = Carbon::now();
@@ -368,10 +368,9 @@ class SettersTest extends AbstractTestCase
 
     public function testTzWithInvalidTimezoneSetter()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown or bad timezone (sdf)'
-        );
+        ));
 
         $d = Carbon::now();
         $d->tz('sdf');
@@ -484,7 +483,9 @@ class SettersTest extends AbstractTestCase
 
     public function testInvalidSetter()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionObject(new InvalidArgumentException(
+            "Unknown setter 'doesNotExit'"
+        ));
 
         /** @var mixed $date */
         $date = Carbon::now();
@@ -633,20 +634,18 @@ class SettersTest extends AbstractTestCase
 
     public function testSetUnitNoOverflowInputUnitException()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown unit \'anyUnit\''
-        );
+        ));
 
         Carbon::now()->setUnitNoOverflow('anyUnit', 1, 'year');
     }
 
     public function testSetUnitNoOverflowOverflowUnitException()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown unit \'anyUnit\''
-        );
+        ));
 
         Carbon::now()->setUnitNoOverflow('minute', 1, 'anyUnit');
     }

--- a/tests/Carbon/StartEndOfTest.php
+++ b/tests/Carbon/StartEndOfTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Tests\Carbon;
 
 use Carbon\Carbon;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 class StartEndOfTest extends AbstractTestCase
@@ -570,20 +571,18 @@ class StartEndOfTest extends AbstractTestCase
 
     public function testStartOfInvalidUnit()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown unit \'microsecond\''
-        );
+        ));
 
         Carbon::now()->startOf('microsecond');
     }
 
     public function testEndOfInvalidUnit()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown unit \'microsecond\''
-        );
+        ));
 
         Carbon::now()->endOf('microsecond');
     }

--- a/tests/Carbon/StrictModeTest.php
+++ b/tests/Carbon/StrictModeTest.php
@@ -11,27 +11,27 @@ declare(strict_types=1);
  */
 namespace Tests\Carbon;
 
+use BadMethodCallException;
 use Carbon\Carbon;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 class StrictModeTest extends AbstractTestCase
 {
     public function testSafeCreateDateTimeZoneWithStrictMode1()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown or bad timezone (-15)'
-        );
+        ));
 
         Carbon::createFromDate(2001, 1, 1, -15);
     }
 
     public function testSafeCreateDateTimeZoneWithStrictMode2()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown or bad timezone (foobar)'
-        );
+        ));
 
         Carbon::createFromDate(2001, 1, 1, 'foobar');
     }
@@ -45,10 +45,9 @@ class StrictModeTest extends AbstractTestCase
 
     public function testSetWithStrictMode()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown setter \'foobar\''
-        );
+        ));
 
         /** @var mixed $date */
         $date = Carbon::now();
@@ -57,10 +56,9 @@ class StrictModeTest extends AbstractTestCase
 
     public function testGetWithStrictMode()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown getter \'foobar\''
-        );
+        ));
 
         /** @var mixed $date */
         $date = Carbon::now();
@@ -78,10 +76,9 @@ class StrictModeTest extends AbstractTestCase
 
     public function testIsSameUnitWithStrictMode()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Bad comparison unit: \'foobar\''
-        );
+        ));
 
         Carbon::now()->isSameUnit('foobar');
     }
@@ -94,10 +91,9 @@ class StrictModeTest extends AbstractTestCase
 
     public function testAddRealUnitWithStrictMode()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Invalid unit for real timestamp add/sub: \'foobar\''
-        );
+        ));
 
         Carbon::now()->addRealUnit('foobar');
     }
@@ -111,10 +107,9 @@ class StrictModeTest extends AbstractTestCase
 
     public function testCallWithStrictMode()
     {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new BadMethodCallException(
             'Method foobar does not exist.'
-        );
+        ));
 
         /** @var mixed $date */
         $date = Carbon::now();
@@ -131,10 +126,9 @@ class StrictModeTest extends AbstractTestCase
 
     public function testStaticCallWithStrictMode()
     {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new BadMethodCallException(
             'Method Carbon\Carbon::foobar does not exist.'
-        );
+        ));
 
         Carbon::foobar();
     }

--- a/tests/CarbonImmutable/CreateSafeTest.php
+++ b/tests/CarbonImmutable/CreateSafeTest.php
@@ -26,130 +26,91 @@ class CreateSafeTest extends AbstractTestCase
 
     public function testCreateSafeThrowsExceptionForSecondLowerThanZero()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'second : -1 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('second', -1));
 
         Carbon::createSafe(null, null, null, null, null, -1);
     }
 
     public function testCreateSafeThrowsExceptionForSecondGreaterThan59()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'second : 60 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('second', 60));
 
         Carbon::createSafe(null, null, null, null, null, 60);
     }
 
     public function testCreateSafeThrowsExceptionForMinuteLowerThanZero()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'minute : -1 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('minute', -1));
 
         Carbon::createSafe(null, null, null, null, -1);
     }
 
     public function testCreateSafeThrowsExceptionForMinuteGreaterThan59()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'minute : 60 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('minute', 60));
 
         Carbon::createSafe(null, null, null, null, 60, 25);
     }
 
     public function testCreateSafeThrowsExceptionForHourLowerThanZero()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'hour : -6 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('hour', -6));
 
         Carbon::createSafe(null, null, null, -6);
     }
 
     public function testCreateSafeThrowsExceptionForHourGreaterThan24()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'hour : 25 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('hour', 25));
 
         Carbon::createSafe(null, null, null, 25, 16, 15);
     }
 
     public function testCreateSafeThrowsExceptionForDayLowerThanZero()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'day : -5 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('day', -5));
 
         Carbon::createSafe(null, null, -5);
     }
 
     public function testCreateSafeThrowsExceptionForDayGreaterThan31()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'day : 32 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('day', 32));
 
         Carbon::createSafe(null, null, 32, 17, 16, 15);
     }
 
     public function testCreateSafeThrowsExceptionForMonthLowerThanZero()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'month : -4 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('month', -4));
 
         Carbon::createSafe(null, -4);
     }
 
     public function testCreateSafeThrowsExceptionForMonthGreaterThan12()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'month : 13 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('month', 13));
 
         Carbon::createSafe(null, 13, 5, 17, 16, 15);
     }
 
     public function testCreateSafeThrowsExceptionForYearLowerThanZero()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'year : -5 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('year', -5));
 
         Carbon::createSafe(-5);
     }
 
     public function testCreateSafeThrowsExceptionForYearGreaterThan12()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'year : 10000 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('year', 10000));
 
         Carbon::createSafe(10000, 12, 5, 17, 16, 15);
     }
 
     public function testCreateSafeThrowsExceptionForInvalidDayInShortMonth()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'day : 31 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('day', 31));
 
         // 30 days in April
         Carbon::createSafe(2016, 4, 31, 17, 16, 15);
@@ -157,10 +118,7 @@ class CreateSafeTest extends AbstractTestCase
 
     public function testCreateSafeThrowsExceptionForInvalidDayForFebruaryInLeapYear()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'day : 30 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('day', 30));
 
         // 29 days in February for a leap year
         $this->assertTrue(Carbon::create(2016, 2)->isLeapYear());
@@ -175,10 +133,7 @@ class CreateSafeTest extends AbstractTestCase
 
     public function testCreateSafeThrowsExceptionForInvalidDayForFebruaryInNonLeapYear()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'day : 29 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('day', 29));
 
         // 28 days in February for a non-leap year
         $this->assertFalse(Carbon::create(2015, 2)->isLeapYear());
@@ -209,10 +164,7 @@ class CreateSafeTest extends AbstractTestCase
 
     public function testCreateSafeThrowsExceptionForWithNonIntegerValue()
     {
-        $this->expectException(InvalidDateException::class);
-        $this->expectExceptionMessage(
-            'second : 15.1 is not a valid value.'
-        );
+        $this->expectExceptionObject(new InvalidDateException('second', 15.1));
 
         Carbon::createSafe(2015, 2, 10, 17, 16, 15.1);
     }

--- a/tests/CarbonImmutable/CreateTest.php
+++ b/tests/CarbonImmutable/CreateTest.php
@@ -12,7 +12,9 @@ declare(strict_types=1);
 namespace Tests\CarbonImmutable;
 
 use Carbon\CarbonImmutable as Carbon;
+use DateTime;
 use DateTimeZone;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 class CreateTest extends AbstractTestCase
@@ -73,7 +75,9 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateWithInvalidMonth()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionObject(new InvalidArgumentException(
+            'month must be between 0 and 99, -5 given'
+        ));
 
         Carbon::create(null, -5);
     }
@@ -92,7 +96,9 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateWithInvalidDay()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionObject(new InvalidArgumentException(
+            'day must be between 0 and 99, -4 given'
+        ));
 
         Carbon::create(null, null, -4);
     }
@@ -113,7 +119,9 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateWithInvalidHour()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionObject(new InvalidArgumentException(
+            'hour must be between 0 and 99, -1 given'
+        ));
 
         Carbon::create(null, null, null, -1);
     }
@@ -132,7 +140,9 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateWithInvalidMinute()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionObject(new InvalidArgumentException(
+            'minute must be between 0 and 99, -2 given'
+        ));
 
         Carbon::create(2011, 1, 1, 0, -2, 0);
     }
@@ -151,7 +161,9 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateWithInvalidSecond()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionObject(new InvalidArgumentException(
+            'second must be between 0 and 99, -2 given'
+        ));
 
         Carbon::create(null, null, null, null, null, -2);
     }
@@ -179,14 +191,16 @@ class CreateTest extends AbstractTestCase
     public function testMake()
     {
         $this->assertCarbon(Carbon::make('2017-01-05'), 2017, 1, 5, 0, 0, 0);
-        $this->assertCarbon(Carbon::make(new \DateTime('2017-01-05')), 2017, 1, 5, 0, 0, 0);
+        $this->assertCarbon(Carbon::make(new DateTime('2017-01-05')), 2017, 1, 5, 0, 0, 0);
         $this->assertCarbon(Carbon::make(new Carbon('2017-01-05')), 2017, 1, 5, 0, 0, 0);
         $this->assertNull(Carbon::make(3));
     }
 
     public function testCreateWithInvalidTimezoneOffset()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionObject(new InvalidArgumentException(
+            'Unknown or bad timezone (-28236)'
+        ));
 
         Carbon::createFromDate(2000, 1, 1, -28236);
     }
@@ -258,8 +272,9 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateFromIsoFormatException()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Format wo not supported for creation.');
+        $this->expectExceptionObject(new InvalidArgumentException(
+            'Format wo not supported for creation.'
+        ));
 
         Carbon::createFromIsoFormat('YY D wo', '2019 April 4');
     }

--- a/tests/CarbonImmutable/DiffTest.php
+++ b/tests/CarbonImmutable/DiffTest.php
@@ -14,7 +14,10 @@ namespace Tests\CarbonImmutable;
 use Carbon\CarbonImmutable as Carbon;
 use Carbon\CarbonInterface;
 use Carbon\CarbonInterval;
+use Carbon\Exceptions\InvalidFormatException;
 use Closure;
+use DateTime;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 class DiffTest extends AbstractTestCase
@@ -1195,7 +1198,7 @@ class DiffTest extends AbstractTestCase
 
     public function testDiffForHumansWithDateTimeInstance()
     {
-        $feb15 = new \DateTime('2015-02-15');
+        $feb15 = new DateTime('2015-02-15');
         $mar15 = Carbon::parse('2015-03-15');
         $this->assertSame('1 month after', $mar15->diffForHumans($feb15));
     }
@@ -1222,7 +1225,7 @@ class DiffTest extends AbstractTestCase
     public function testDiffWithDateTime()
     {
         $dt1 = Carbon::createFromDate(2000, 1, 25)->endOfDay();
-        $dt2 = new \DateTime('2000-01-10');
+        $dt2 = new DateTime('2000-01-10');
 
         $this->assertSame(383, $dt1->diffInHours($dt2));
     }
@@ -1505,30 +1508,27 @@ class DiffTest extends AbstractTestCase
 
     public function testDiffWithInvalidType()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Expected null, string, DateTime or DateTimeInterface, integer given'
-        );
+        ));
 
         Carbon::createFromDate(2000, 1, 25)->diffInHours(10);
     }
 
     public function testDiffWithInvalidObject()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Expected null, string, DateTime or DateTimeInterface, Carbon\CarbonInterval given'
-        );
+        ));
 
         Carbon::createFromDate(2000, 1, 25)->diffInHours(new CarbonInterval());
     }
 
     public function testDiffForHumansWithIncorrectDateTimeStringWhichIsNotACarbonInstance()
     {
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage(
-            'Failed to parse time string (2018-04-13-08:00:00) at position 16'
-        );
+        $this->expectExceptionObject(new InvalidFormatException(
+            "Could not parse '2018-04-13-08:00:00': DateTimeImmutable::__construct(): Failed to parse time string (2018-04-13-08:00:00) at position 16 (:): Unexpected character"
+        ));
 
         $mar13 = Carbon::parse('2018-03-13');
         $mar13->diffForHumans('2018-04-13-08:00:00');

--- a/tests/CarbonImmutable/DiffTest.php
+++ b/tests/CarbonImmutable/DiffTest.php
@@ -14,9 +14,9 @@ namespace Tests\CarbonImmutable;
 use Carbon\CarbonImmutable as Carbon;
 use Carbon\CarbonInterface;
 use Carbon\CarbonInterval;
-use Carbon\Exceptions\InvalidFormatException;
 use Closure;
 use DateTime;
+use Exception;
 use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
@@ -1526,9 +1526,10 @@ class DiffTest extends AbstractTestCase
 
     public function testDiffForHumansWithIncorrectDateTimeStringWhichIsNotACarbonInstance()
     {
-        $this->expectExceptionObject(new InvalidFormatException(
-            "Could not parse '2018-04-13-08:00:00': DateTimeImmutable::__construct(): Failed to parse time string (2018-04-13-08:00:00) at position 16 (:): Unexpected character"
-        ));
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(
+            'Failed to parse time string (2018-04-13-08:00:00) at position 16'
+        );
 
         $mar13 = Carbon::parse('2018-03-13');
         $mar13->diffForHumans('2018-04-13-08:00:00');

--- a/tests/CarbonImmutable/GenericMacroTest.php
+++ b/tests/CarbonImmutable/GenericMacroTest.php
@@ -11,8 +11,10 @@ declare(strict_types=1);
  */
 namespace Tests\CarbonImmutable;
 
+use BadMethodCallException;
 use Carbon\CarbonImmutable as Carbon;
 use Tests\AbstractTestCaseWithOldNow;
+use Throwable;
 
 class GenericMacroTest extends AbstractTestCaseWithOldNow
 {
@@ -34,9 +36,9 @@ class GenericMacroTest extends AbstractTestCaseWithOldNow
                 }
 
                 return new static($time);
-            } catch (\Throwable $exception) {
+            } catch (Throwable $exception) {
                 if (stripos($exception->getMessage(), 'Failed to parse') !== false) {
-                    throw new \BadMethodCallException('Try next macro', 0, $exception);
+                    throw new BadMethodCallException('Try next macro', 0, $exception);
                 }
 
                 throw $exception;
@@ -53,7 +55,7 @@ class GenericMacroTest extends AbstractTestCaseWithOldNow
 
         try {
             Carbon::fooBar();
-        } catch (\BadMethodCallException $exception) {
+        } catch (BadMethodCallException $exception) {
             $message = $exception->getMessage();
         }
 
@@ -63,7 +65,7 @@ class GenericMacroTest extends AbstractTestCaseWithOldNow
 
         try {
             $now->barBiz();
-        } catch (\BadMethodCallException $exception) {
+        } catch (BadMethodCallException $exception) {
             $message = $exception->getMessage();
         }
 
@@ -77,9 +79,9 @@ class GenericMacroTest extends AbstractTestCaseWithOldNow
 
             try {
                 return self::this()->modify($time);
-            } catch (\Throwable $exception) {
+            } catch (Throwable $exception) {
                 if (stripos($exception->getMessage(), 'Failed to parse') !== false) {
-                    throw new \BadMethodCallException('Try next macro', 0, $exception);
+                    throw new BadMethodCallException('Try next macro', 0, $exception);
                 }
 
                 throw $exception;
@@ -96,7 +98,7 @@ class GenericMacroTest extends AbstractTestCaseWithOldNow
 
         try {
             Carbon::fooBar();
-        } catch (\BadMethodCallException $exception) {
+        } catch (BadMethodCallException $exception) {
             $message = $exception->getMessage();
         }
 
@@ -106,7 +108,7 @@ class GenericMacroTest extends AbstractTestCaseWithOldNow
 
         try {
             $now->barBiz();
-        } catch (\BadMethodCallException $exception) {
+        } catch (BadMethodCallException $exception) {
             $message = $exception->getMessage();
         }
 
@@ -117,21 +119,21 @@ class GenericMacroTest extends AbstractTestCaseWithOldNow
     {
         Carbon::genericMacro(function ($method) {
             if (!str_starts_with($method, 'myPrefix')) {
-                throw new \BadMethodCallException('Try next macro', 0);
+                throw new BadMethodCallException('Try next macro', 0);
             }
 
             return 'first';
         });
         Carbon::genericMacro(function ($method) {
             if (!str_starts_with($method, 'myPrefix')) {
-                throw new \BadMethodCallException('Try next macro', 0);
+                throw new BadMethodCallException('Try next macro', 0);
             }
 
             return 'second';
         }, 1);
         Carbon::genericMacro(function ($method) {
             if (!str_starts_with($method, 'myPrefix')) {
-                throw new \BadMethodCallException('Try next macro', 0);
+                throw new BadMethodCallException('Try next macro', 0);
             }
 
             return 'third';
@@ -153,21 +155,21 @@ class GenericMacroTest extends AbstractTestCaseWithOldNow
     {
         Carbon::genericMacro(function ($method) {
             if (!str_starts_with($method, 'mlp')) {
-                throw new \BadMethodCallException('Try next macro', 0);
+                throw new BadMethodCallException('Try next macro', 0);
             }
 
             return 'first';
         });
         Carbon::genericMacro(function ($method) {
             if (!str_starts_with($method, 'mlp')) {
-                throw new \BadMethodCallException('Try next macro', 0);
+                throw new BadMethodCallException('Try next macro', 0);
             }
 
             return 'second';
         }, 1);
         Carbon::genericMacro(function ($method) {
             if (!str_starts_with($method, 'mlp')) {
-                throw new \BadMethodCallException('Try next macro', 0);
+                throw new BadMethodCallException('Try next macro', 0);
             }
 
             return 'third';
@@ -181,14 +183,14 @@ class GenericMacroTest extends AbstractTestCaseWithOldNow
             'genericMacros' => [
                 function ($method) {
                     if (!str_starts_with($method, 'mlp')) {
-                        throw new \BadMethodCallException('Try next macro', 0);
+                        throw new BadMethodCallException('Try next macro', 0);
                     }
 
                     return 'local-first';
                 },
                 function ($method) {
                     if (!str_starts_with($method, 'mlp')) {
-                        throw new \BadMethodCallException('Try next macro', 0);
+                        throw new BadMethodCallException('Try next macro', 0);
                     }
 
                     return 'local-second';

--- a/tests/CarbonImmutable/GettersTest.php
+++ b/tests/CarbonImmutable/GettersTest.php
@@ -12,13 +12,16 @@ declare(strict_types=1);
 namespace Tests\CarbonImmutable;
 
 use Carbon\CarbonImmutable as Carbon;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 class GettersTest extends AbstractTestCase
 {
     public function testGettersThrowExceptionOnUnknownGetter()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionObject(new InvalidArgumentException(
+            "Unknown getter 'doesNotExit'"
+        ));
 
         /** @var mixed $d */
         $d = Carbon::create(1234, 5, 6, 7, 8, 9);

--- a/tests/CarbonImmutable/InstanceTest.php
+++ b/tests/CarbonImmutable/InstanceTest.php
@@ -17,6 +17,7 @@ use Carbon\CarbonImmutable as Carbon;
 use Carbon\CarbonInterface;
 use DateTime;
 use DateTimeZone;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 class InstanceTest extends AbstractTestCase
@@ -130,10 +131,9 @@ class InstanceTest extends AbstractTestCase
 
     public function testInvalidCast()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'DateTimeZone has not the instance() method needed to cast the date.'
-        );
+        ));
 
         $carbon = new Carbon('2017-06-27 13:14:15.123456', 'Europe/Paris');
         $carbon->cast(DateTimeZone::class);

--- a/tests/CarbonImmutable/IsTest.php
+++ b/tests/CarbonImmutable/IsTest.php
@@ -13,6 +13,7 @@ namespace Tests\CarbonImmutable;
 
 use \DateTime;
 use Carbon\CarbonImmutable as Carbon;
+use InvalidArgumentException;
 use stdClass;
 use Tests\AbstractTestCase;
 
@@ -279,10 +280,9 @@ class IsTest extends AbstractTestCase
 
     public function testIsSameFoobar()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Bad comparison unit: \'foobar\''
-        );
+        ));
 
         Carbon::now()->isSameUnit('foobar', Carbon::now()->subMillennium());
     }
@@ -673,10 +673,9 @@ class IsTest extends AbstractTestCase
 
     public function testIsSameAsWithInvalidArgument()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Expected null, string, DateTime or DateTimeInterface, stdClass given'
-        );
+        ));
 
         $current = Carbon::createFromDate(2012, 1, 2);
         $current->isSameAs('Y-m-d', new stdClass());

--- a/tests/CarbonImmutable/LocalizationTest.php
+++ b/tests/CarbonImmutable/LocalizationTest.php
@@ -16,6 +16,7 @@ use Carbon\CarbonInterval;
 use Carbon\Exceptions\NotLocaleAwareException;
 use Carbon\Language;
 use Carbon\Translator;
+use InvalidArgumentException;
 use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\MessageCatalogue;
@@ -679,8 +680,7 @@ class LocalizationTest extends AbstractTestCase
 
         Carbon::setTranslator($translator);
 
-        $this->expectException(NotLocaleAwareException::class);
-        $this->expectExceptionMessage(\get_class($translator).' does neither implements Symfony\\Contracts\\Translation\\LocaleAwareInterface nor getLocale() method.');
+        $this->expectExceptionObject(new NotLocaleAwareException($translator));
 
         Carbon::now()->locale();
     }
@@ -719,12 +719,11 @@ class LocalizationTest extends AbstractTestCase
 
     public function testTranslationCustomWithCustomTranslator()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Translator does not implement Symfony\Component\Translation\TranslatorInterface '.
             'and Symfony\Component\Translation\TranslatorBagInterface. '.
             'Symfony\Component\Translation\IdentityTranslator has been given.'
-        );
+        ));
 
         $date = Carbon::create(2018, 1, 1, 0, 0, 0);
         $date->setLocalTranslator(

--- a/tests/CarbonImmutable/MacroTest.php
+++ b/tests/CarbonImmutable/MacroTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  */
 namespace Tests\CarbonImmutable;
 
+use BadMethodCallException;
 use Carbon\CarbonImmutable as Carbon;
 use Tests\AbstractTestCaseWithOldNow;
 use Tests\Carbon\Fixtures\FooBar;
@@ -104,20 +105,18 @@ class MacroTest extends AbstractTestCaseWithOldNow
 
     public function testCarbonRaisesExceptionWhenStaticMacroIsNotFound()
     {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new BadMethodCallException(
             'Method Carbon\CarbonImmutable::nonExistingStaticMacro does not exist.'
-        );
+        ));
 
         Carbon::nonExistingStaticMacro();
     }
 
     public function testCarbonRaisesExceptionWhenMacroIsNotFound()
     {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new BadMethodCallException(
             'Method nonExistingMacro does not exist.'
-        );
+        ));
 
         /** @var mixed $date */
         $date = Carbon::now();

--- a/tests/CarbonImmutable/ObjectsTest.php
+++ b/tests/CarbonImmutable/ObjectsTest.php
@@ -14,6 +14,7 @@ namespace Tests\CarbonImmutable;
 use Carbon\CarbonImmutable as Carbon;
 use DateTime;
 use DateTimeImmutable;
+use stdClass;
 use Tests\AbstractTestCase;
 
 class ObjectsTest extends AbstractTestCase
@@ -23,7 +24,7 @@ class ObjectsTest extends AbstractTestCase
         $dt = Carbon::now();
         $dtToObject = $dt->toObject();
 
-        $this->assertInstanceOf(\stdClass::class, $dtToObject);
+        $this->assertInstanceOf(stdClass::class, $dtToObject);
 
         $this->assertObjectHasAttribute('year', $dtToObject);
         $this->assertSame($dt->year, $dtToObject->year);

--- a/tests/CarbonImmutable/RoundTest.php
+++ b/tests/CarbonImmutable/RoundTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Tests\CarbonImmutable;
 
 use Carbon\CarbonImmutable as Carbon;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 class RoundTest extends AbstractTestCase
@@ -132,10 +133,9 @@ class RoundTest extends AbstractTestCase
 
     public function testRoundInvalidArgument()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown unit \'foobar\'.'
-        );
+        ));
 
         Carbon::now()->roundUnit('foobar');
     }

--- a/tests/CarbonImmutable/SerializationTest.php
+++ b/tests/CarbonImmutable/SerializationTest.php
@@ -77,10 +77,9 @@ class SerializationTest extends AbstractTestCase
      */
     public function testFromUnserializedWithInvalidValue($value)
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             "Invalid serialized value: $value"
-        );
+        ));
 
         Carbon::fromSerialized($value);
     }

--- a/tests/CarbonImmutable/SettersTest.php
+++ b/tests/CarbonImmutable/SettersTest.php
@@ -13,16 +13,17 @@ namespace Tests\CarbonImmutable;
 
 use Carbon\CarbonImmutable as Carbon;
 use DateTimeZone;
+use InvalidArgumentException;
+use RuntimeException;
 use Tests\AbstractTestCase;
 
 class SettersTest extends AbstractTestCase
 {
     public function testYearSetter()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new RuntimeException(
             'Carbon\CarbonImmutable class is immutable.'
-        );
+        ));
 
         $d = Carbon::now();
         $d->year = 1995;
@@ -30,10 +31,9 @@ class SettersTest extends AbstractTestCase
 
     public function testMonthSetter()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new RuntimeException(
             'Carbon\CarbonImmutable class is immutable.'
-        );
+        ));
 
         $d = Carbon::now();
         $d->month = 3;
@@ -41,10 +41,9 @@ class SettersTest extends AbstractTestCase
 
     public function testMonthSetterWithWrap()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new RuntimeException(
             'Carbon\CarbonImmutable class is immutable.'
-        );
+        ));
 
         $d = Carbon::now();
         $d->month = 13;
@@ -52,10 +51,9 @@ class SettersTest extends AbstractTestCase
 
     public function testDaySetter()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new RuntimeException(
             'Carbon\CarbonImmutable class is immutable.'
-        );
+        ));
 
         $d = Carbon::now();
         $d->day = 2;
@@ -63,10 +61,9 @@ class SettersTest extends AbstractTestCase
 
     public function testDaySetterWithWrap()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new RuntimeException(
             'Carbon\CarbonImmutable class is immutable.'
-        );
+        ));
 
         $d = Carbon::createFromDate(2012, 8, 5);
         $d->day = 32;
@@ -74,10 +71,9 @@ class SettersTest extends AbstractTestCase
 
     public function testHourSetter()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new RuntimeException(
             'Carbon\CarbonImmutable class is immutable.'
-        );
+        ));
 
         $d = Carbon::now();
         $d->hour = 2;
@@ -85,10 +81,9 @@ class SettersTest extends AbstractTestCase
 
     public function testHourSetterWithWrap()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new RuntimeException(
             'Carbon\CarbonImmutable class is immutable.'
-        );
+        ));
 
         $d = Carbon::now();
         $d->hour = 25;
@@ -96,10 +91,9 @@ class SettersTest extends AbstractTestCase
 
     public function testMinuteSetter()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new RuntimeException(
             'Carbon\CarbonImmutable class is immutable.'
-        );
+        ));
 
         $d = Carbon::now();
         $d->minute = 2;
@@ -107,10 +101,9 @@ class SettersTest extends AbstractTestCase
 
     public function testMinuteSetterWithWrap()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new RuntimeException(
             'Carbon\CarbonImmutable class is immutable.'
-        );
+        ));
 
         $d = Carbon::now();
         $d->minute = 65;
@@ -118,10 +111,9 @@ class SettersTest extends AbstractTestCase
 
     public function testSecondSetter()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new RuntimeException(
             'Carbon\CarbonImmutable class is immutable.'
-        );
+        ));
 
         $d = Carbon::now();
         $d->second = 2;
@@ -191,10 +183,9 @@ class SettersTest extends AbstractTestCase
 
     public function testSecondSetterWithWrap()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new RuntimeException(
             'Carbon\CarbonImmutable class is immutable.'
-        );
+        ));
 
         $d = Carbon::now();
         $d->second = 65;
@@ -202,10 +193,9 @@ class SettersTest extends AbstractTestCase
 
     public function testTimestampSetter()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new RuntimeException(
             'Carbon\CarbonImmutable class is immutable.'
-        );
+        ));
 
         $d = Carbon::now();
         $d->timestamp = 10;
@@ -213,10 +203,9 @@ class SettersTest extends AbstractTestCase
 
     public function testSetTimezoneWithInvalidTimezone()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown or bad timezone (sdf)'
-        );
+        ));
 
         $d = Carbon::now();
         $d->setTimezone('sdf');
@@ -224,10 +213,9 @@ class SettersTest extends AbstractTestCase
 
     public function testTimezoneWithInvalidTimezone()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new RuntimeException(
             'Carbon\CarbonImmutable class is immutable.'
-        );
+        ));
 
         /** @var mixed $d */
         $d = Carbon::now();
@@ -236,10 +224,9 @@ class SettersTest extends AbstractTestCase
 
     public function testTimezoneWithInvalidTimezoneSetter()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown or bad timezone (sdf)'
-        );
+        ));
 
         $d = Carbon::now();
         $d->timezone('sdf');
@@ -247,10 +234,9 @@ class SettersTest extends AbstractTestCase
 
     public function testTzWithInvalidTimezone()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new RuntimeException(
             'Carbon\CarbonImmutable class is immutable.'
-        );
+        ));
 
         /** @var mixed $d */
         $d = Carbon::now();
@@ -259,10 +245,9 @@ class SettersTest extends AbstractTestCase
 
     public function testTzWithInvalidTimezoneSetter()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown or bad timezone (sdf)'
-        );
+        ));
 
         $d = Carbon::now();
         $d->tz('sdf');
@@ -291,10 +276,9 @@ class SettersTest extends AbstractTestCase
 
     public function testTimezoneUsingString()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new RuntimeException(
             'Carbon\CarbonImmutable class is immutable.'
-        );
+        ));
 
         /** @var mixed $d */
         $d = Carbon::now();
@@ -303,10 +287,9 @@ class SettersTest extends AbstractTestCase
 
     public function testTzUsingString()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new RuntimeException(
             'Carbon\CarbonImmutable class is immutable.'
-        );
+        ));
 
         /** @var mixed $d */
         $d = Carbon::now();
@@ -322,10 +305,9 @@ class SettersTest extends AbstractTestCase
 
     public function testTimezoneUsingDateTimeZone()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new RuntimeException(
             'Carbon\CarbonImmutable class is immutable.'
-        );
+        ));
 
         /** @var mixed $d */
         $d = Carbon::now();
@@ -334,10 +316,9 @@ class SettersTest extends AbstractTestCase
 
     public function testTzUsingDateTimeZone()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new RuntimeException(
             'Carbon\CarbonImmutable class is immutable.'
-        );
+        ));
 
         /** @var mixed $d */
         $d = Carbon::now();
@@ -346,10 +327,9 @@ class SettersTest extends AbstractTestCase
 
     public function testInvalidSetter()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new RuntimeException(
             'Carbon\CarbonImmutable class is immutable.'
-        );
+        ));
 
         /** @var mixed $d */
         $d = Carbon::now();

--- a/tests/CarbonInterval/AddTest.php
+++ b/tests/CarbonInterval/AddTest.php
@@ -16,6 +16,7 @@ use Carbon\CarbonInterval;
 use DateInterval;
 use DateTime;
 use DateTimeImmutable;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 class AddTest extends AbstractTestCase
@@ -143,10 +144,9 @@ class AddTest extends AbstractTestCase
 
     public function testAddWrongFormat()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'This type of data cannot be added/subtracted.'
-        );
+        ));
 
         CarbonInterval::day()->add(Carbon::now());
     }
@@ -182,7 +182,7 @@ class AddTest extends AbstractTestCase
             $this->markTestSkipped('This tests needs PHP 8 named arguments syntax.');
         }
 
-        $interval = eval('return \Carbon\CarbonInterval::days(3)->plus(weeks: 2, hours: 26);');
+        $interval = eval('use Carbon\CarbonInterval;return CarbonInterval::days(3)->plus(weeks: 2, hours: 26);');
 
         $this->assertCarbonInterval($interval, 0, 0, 17, 26, 0, 0);
     }
@@ -198,7 +198,7 @@ class AddTest extends AbstractTestCase
             $this->markTestSkipped('This tests needs PHP 8 named arguments syntax.');
         }
 
-        $interval = eval('return \Carbon\CarbonInterval::days(3)->minus(weeks: 2, hours: 26);');
+        $interval = eval('use Carbon\CarbonInterval;return CarbonInterval::days(3)->minus(weeks: 2, hours: 26);');
 
         $this->assertCarbonInterval($interval, 0, 0, 11, 26, 0, 0, 0, true);
     }

--- a/tests/CarbonInterval/ConstructTest.php
+++ b/tests/CarbonInterval/ConstructTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  */
 namespace Tests\CarbonInterval;
 
+use BadMethodCallException;
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
 use DateInterval;
@@ -314,10 +315,9 @@ class ConstructTest extends AbstractTestCase
 
     public function testCallInvalidStaticMethod()
     {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new BadMethodCallException(
             'Unknown fluent constructor \'anything\''
-        );
+        ));
 
         CarbonInterval::anything();
     }

--- a/tests/CarbonInterval/CreateFromFormatTest.php
+++ b/tests/CarbonInterval/CreateFromFormatTest.php
@@ -19,22 +19,31 @@ class CreateFromFormatTest extends AbstractTestCase
 {
     public function testDefaults()
     {
-        $this->expectException(ParseErrorException::class);
-        $this->expectExceptionMessage('Format expected number but data is missing');
+        $this->expectExceptionObject(new ParseErrorException(
+            'number',
+            ''
+        ));
+
         CarbonInterval::createFromFormat('H:i:s', '');
     }
 
     public function testNulls()
     {
-        $this->expectException(ParseErrorException::class);
-        $this->expectExceptionMessage('Format expected number but data is missing');
+        $this->expectExceptionObject(new ParseErrorException(
+            'number',
+            ''
+        ));
+
         CarbonInterval::createFromFormat('H:i:s', null);
     }
 
     public function testTrailingData()
     {
-        $this->expectException(ParseErrorException::class);
-        $this->expectExceptionMessage("Format expected end of string but get ':25'");
+        $this->expectExceptionObject(new ParseErrorException(
+            'end of string',
+            ':25'
+        ));
+
         CarbonInterval::createFromFormat('H:i', '01:30:25');
     }
 
@@ -46,6 +55,7 @@ class CreateFromFormatTest extends AbstractTestCase
             "Allowed substitutes for interval formats are y, Y, o, m, n, W, d, j, z, h, g, H, G, i, s, u, v\n".
             'See https://php.net/manual/en/function.date.php for their meaning'
         );
+
         CarbonInterval::createFromFormat('N', '4');
     }
 

--- a/tests/CarbonInterval/FromStringTest.php
+++ b/tests/CarbonInterval/FromStringTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Tests\CarbonInterval;
 
 use Carbon\CarbonInterval;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 class FromStringTest extends AbstractTestCase
@@ -109,7 +110,7 @@ class FromStringTest extends AbstractTestCase
 
         try {
             CarbonInterval::fromString($string);
-        } catch (\InvalidArgumentException $exception) {
+        } catch (InvalidArgumentException $exception) {
             $message = $exception->getMessage();
         }
 

--- a/tests/CarbonInterval/GettersTest.php
+++ b/tests/CarbonInterval/GettersTest.php
@@ -13,16 +13,16 @@ namespace Tests\CarbonInterval;
 
 use Carbon\CarbonInterval;
 use Carbon\Translator;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 class GettersTest extends AbstractTestCase
 {
     public function testGettersThrowExceptionOnUnknownGetter()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown getter \'doesNotExit\''
-        );
+        ));
 
         /** @var mixed $interval */
         $interval = CarbonInterval::year();

--- a/tests/CarbonInterval/ParseFromLocaleTest.php
+++ b/tests/CarbonInterval/ParseFromLocaleTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Tests\CarbonInterval;
 
 use Carbon\CarbonInterval;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 class ParseFromLocaleTest extends AbstractTestCase
@@ -114,7 +115,7 @@ class ParseFromLocaleTest extends AbstractTestCase
 
         try {
             CarbonInterval::parseFromLocale($string, $locale);
-        } catch (\InvalidArgumentException $exception) {
+        } catch (InvalidArgumentException $exception) {
             $message = $exception->getMessage();
         }
 

--- a/tests/CarbonInterval/RoundingTest.php
+++ b/tests/CarbonInterval/RoundingTest.php
@@ -11,10 +11,9 @@ class RoundingTest extends AbstractTestCase
 {
     public function testThrowsExceptionForCompositeInterval()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Rounding is only possible with single unit intervals.'
-        );
+        ));
 
         CarbonInterval::days(2)->round('2 hours 50 minutes');
     }

--- a/tests/CarbonInterval/SettersTest.php
+++ b/tests/CarbonInterval/SettersTest.php
@@ -11,7 +11,9 @@ declare(strict_types=1);
  */
 namespace Tests\CarbonInterval;
 
+use BadMethodCallException;
 use Carbon\CarbonInterval;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 class SettersTest extends AbstractTestCase
@@ -178,10 +180,9 @@ class SettersTest extends AbstractTestCase
 
     public function testInvalidSetter()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown setter \'doesNotExit\''
-        );
+        ));
 
         /** @var mixed $ci */
         $ci = new CarbonInterval;
@@ -190,10 +191,9 @@ class SettersTest extends AbstractTestCase
 
     public function testInvalidFluentSetter()
     {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new BadMethodCallException(
             'Unknown fluent setter \'doesNotExit\''
-        );
+        ));
 
         /** @var mixed $ci */
         $ci = new CarbonInterval;
@@ -202,10 +202,9 @@ class SettersTest extends AbstractTestCase
 
     public function testInvalidStaticFluentSetter()
     {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new BadMethodCallException(
             'Unknown fluent constructor \'doesNotExit\''
-        );
+        ));
 
         CarbonInterval::doesNotExit(123);
     }

--- a/tests/CarbonInterval/StrictModeTest.php
+++ b/tests/CarbonInterval/StrictModeTest.php
@@ -11,18 +11,19 @@ declare(strict_types=1);
  */
 namespace Tests\CarbonInterval;
 
+use BadMethodCallException;
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 class StrictModeTest extends AbstractTestCase
 {
     public function testSetWithStrictMode()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown setter \'foobar\''
-        );
+        ));
 
         /** @var mixed $interval */
         $interval = CarbonInterval::day();
@@ -31,10 +32,9 @@ class StrictModeTest extends AbstractTestCase
 
     public function testGetWithStrictMode()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown getter \'foobar\''
-        );
+        ));
 
         /** @var mixed $interval */
         $interval = CarbonInterval::day();
@@ -52,10 +52,9 @@ class StrictModeTest extends AbstractTestCase
 
     public function testStaticCallWithStrictMode()
     {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new BadMethodCallException(
             'Unknown fluent constructor \'foobar\''
-        );
+        ));
 
         CarbonInterval::foobar();
     }

--- a/tests/CarbonInterval/ToDateIntervalTest.php
+++ b/tests/CarbonInterval/ToDateIntervalTest.php
@@ -41,8 +41,10 @@ class ToDateIntervalTest extends AbstractTestCase
 
     public function testBadCast()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('DateTime is not a sub-class of DateInterval.');
+        $this->expectExceptionObject(new InvalidArgumentException(
+            'DateTime is not a sub-class of DateInterval.'
+        ));
+
         CarbonInterval::days(5)->hours(3)->minutes(50)->microseconds(123456)->invert()->cast(DateTime::class);
     }
 }

--- a/tests/CarbonInterval/TotalTest.php
+++ b/tests/CarbonInterval/TotalTest.php
@@ -5,6 +5,7 @@ namespace Tests\CarbonInterval;
 
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 class TotalTest extends AbstractTestCase
@@ -45,10 +46,9 @@ class TotalTest extends AbstractTestCase
 
     public function testThrowsExceptionForInvalidUnits()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown unit \'foo\'.'
-        );
+        ));
 
         CarbonInterval::create()->total('foo');
     }
@@ -139,7 +139,7 @@ class TotalTest extends AbstractTestCase
 
         try {
             $interval->totalMonths;
-        } catch (\InvalidArgumentException $exception) {
+        } catch (InvalidArgumentException $exception) {
             $monthsError = $exception->getMessage();
         }
 
@@ -147,7 +147,7 @@ class TotalTest extends AbstractTestCase
 
         try {
             $interval->totalYears;
-        } catch (\InvalidArgumentException $exception) {
+        } catch (InvalidArgumentException $exception) {
             $yearsError = $exception->getMessage();
         }
 

--- a/tests/CarbonPeriod/AliasTest.php
+++ b/tests/CarbonPeriod/AliasTest.php
@@ -11,9 +11,11 @@ declare(strict_types=1);
  */
 namespace Tests\CarbonPeriod;
 
+use BadMethodCallException;
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
 use Carbon\CarbonPeriod;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 class AliasTest extends AbstractTestCase
@@ -172,10 +174,9 @@ class AliasTest extends AbstractTestCase
 
     public function testCallInvalidAlias()
     {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new BadMethodCallException(
             'Method foobar does not exist.'
-        );
+        ));
 
         CarbonPeriod::foobar();
     }
@@ -194,10 +195,9 @@ class AliasTest extends AbstractTestCase
 
     public function testModifyIntoEmptyDateInterval()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Empty interval is not accepted.'
-        );
+        ));
 
         CarbonPeriod::days(0);
     }

--- a/tests/CarbonPeriod/CreateTest.php
+++ b/tests/CarbonPeriod/CreateTest.php
@@ -21,6 +21,7 @@ use DateInterval;
 use DatePeriod;
 use DateTime;
 use InvalidArgumentException;
+use stdClass;
 use Tests\AbstractTestCase;
 
 class CreateTest extends AbstractTestCase
@@ -109,8 +110,9 @@ class CreateTest extends AbstractTestCase
      */
     public function testCreateFromInvalidIso8601String($iso)
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Invalid ISO 8601 specification: $iso");
+        $this->expectExceptionObject(new InvalidArgumentException(
+            "Invalid ISO 8601 specification: $iso"
+        ));
 
         CarbonPeriod::create($iso);
     }
@@ -330,10 +332,9 @@ class CreateTest extends AbstractTestCase
      */
     public function testCreateFromInvalidParameters(...$arguments)
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Invalid constructor parameters.'
-        );
+        ));
 
         CarbonPeriod::create(...$arguments);
     }
@@ -341,9 +342,9 @@ class CreateTest extends AbstractTestCase
     public function provideInvalidParameters()
     {
         return [
-            [new \stdClass, CarbonInterval::days(1), Carbon::tomorrow()],
-            [Carbon::now(), new \stdClass, Carbon::tomorrow()],
-            [Carbon::now(), CarbonInterval::days(1), new \stdClass],
+            [new stdClass, CarbonInterval::days(1), Carbon::tomorrow()],
+            [Carbon::now(), new stdClass, Carbon::tomorrow()],
+            [Carbon::now(), CarbonInterval::days(1), new stdClass],
             [Carbon::yesterday(), Carbon::now(), Carbon::tomorrow()],
             [CarbonInterval::day(), CarbonInterval::hour()],
             [5, CarbonPeriod::EXCLUDE_START_DATE, CarbonPeriod::EXCLUDE_END_DATE],
@@ -583,8 +584,9 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateFromCarbonInstanceInvalidMethod()
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Method unknownUnitsUntil does not exist.');
+        $this->expectExceptionObject(new BadMethodCallException(
+            'Method unknownUnitsUntil does not exist.'
+        ));
 
         /** @var object $date */
         $date = Carbon::create('2019-01-02');
@@ -657,8 +659,9 @@ class CreateTest extends AbstractTestCase
 
     public function testBadCast()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('DateTime has not the instance() method needed to cast the date.');
+        $this->expectExceptionObject(new InvalidArgumentException(
+            'DateTime has not the instance() method needed to cast the date.'
+        ));
 
         CarbonPeriod::create('2010-08-24', CarbonInterval::weeks(2), '2012-07-19')
             ->cast(DateTime::class);
@@ -695,18 +698,20 @@ class CreateTest extends AbstractTestCase
 
     public function testInstanceInvalidType()
     {
-        $this->expectException(NotAPeriodException::class);
-        $this->expectExceptionMessage('Argument 1 passed to Carbon\CarbonPeriod::Carbon\CarbonPeriod::instance() '.
-            'must be an instance of DatePeriod or Carbon\CarbonPeriod, string given.');
+        $this->expectExceptionObject(new NotAPeriodException(
+            'Argument 1 passed to Carbon\CarbonPeriod::Carbon\CarbonPeriod::instance() '.
+            'must be an instance of DatePeriod or Carbon\CarbonPeriod, string given.'
+        ));
 
         CarbonPeriod::instance('hello');
     }
 
     public function testInstanceInvalidInstance()
     {
-        $this->expectException(NotAPeriodException::class);
-        $this->expectExceptionMessage('Argument 1 passed to Carbon\CarbonPeriod::Carbon\CarbonPeriod::instance() '.
-            'must be an instance of DatePeriod or Carbon\CarbonPeriod, instance of Carbon\Carbon given.');
+        $this->expectExceptionObject(new NotAPeriodException(
+            'Argument 1 passed to Carbon\CarbonPeriod::Carbon\CarbonPeriod::instance() '.
+            'must be an instance of DatePeriod or Carbon\CarbonPeriod, instance of Carbon\Carbon given.'
+        ));
 
         CarbonPeriod::instance(Carbon::now());
     }

--- a/tests/CarbonPeriod/FilterTest.php
+++ b/tests/CarbonPeriod/FilterTest.php
@@ -16,6 +16,7 @@ use Carbon\CarbonInterval;
 use Carbon\CarbonPeriod;
 use DateInterval;
 use DateTime;
+use RuntimeException;
 use Tests\AbstractTestCase;
 use Tests\CarbonPeriod\Fixtures\CarbonPeriodFactory;
 use Tests\CarbonPeriod\Fixtures\FooFilters;
@@ -258,10 +259,9 @@ class FilterTest extends AbstractTestCase
 
     public function testThrowExceptionWhenNextValidDateCannotBeFound()
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new RuntimeException(
             'Could not find next valid date.'
-        );
+        ));
 
         $period = CarbonPeriod::create(
             new Carbon('2000-01-01'),

--- a/tests/CarbonPeriod/GettersTest.php
+++ b/tests/CarbonPeriod/GettersTest.php
@@ -253,21 +253,19 @@ class GettersTest extends AbstractTestCase
 
     public function testOverlapsErrorForNullEnd()
     {
-        $this->expectException(UnreachableException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new UnreachableException(
             "Could not calculate period end without either explicit end or recurrences.\n".
             "If you're looking for a forever-period, use ->setRecurrences(INF)."
-        );
+        ));
 
         CarbonPeriod::create('2019-01-26 10:30:12', null)->overlaps('R2/2019-01-31T10:30:45Z/P2D');
     }
 
     public function testOverlapsErrorForMaxAttempts()
     {
-        $this->expectException(UnreachableException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new UnreachableException(
             'Could not calculate period end after iterating 10000 times.'
-        );
+        ));
 
         $period = CarbonPeriod::create('2019-01-26 10:30:12', CarbonInterval::minute(), 98282828);
         $period->addFilter(function ($date) {
@@ -359,8 +357,7 @@ class GettersTest extends AbstractTestCase
 
     public function testUnknownGetter()
     {
-        $this->expectException(UnknownGetterException::class);
-        $this->expectExceptionMessage("Unknown getter 'middle'");
+        $this->expectExceptionObject(new UnknownGetterException('middle'));
 
         CarbonPeriod::create('2019-08-01', '2019-08-15')->get('middle');
     }

--- a/tests/CarbonPeriod/MacroTest.php
+++ b/tests/CarbonPeriod/MacroTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  */
 namespace Tests\CarbonPeriod;
 
+use BadMethodCallException;
 use Carbon\Carbon;
 use Carbon\CarbonPeriod;
 use ReflectionClass;
@@ -144,10 +145,9 @@ class MacroTest extends AbstractTestCase
 
     public function testCallNonExistingMacro()
     {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new BadMethodCallException(
             'Method nonExistingMacro does not exist.'
-        );
+        ));
 
         /** @var mixed $period */
         $period = CarbonPeriod::create();
@@ -157,10 +157,9 @@ class MacroTest extends AbstractTestCase
 
     public function testCallNonExistingMacroStatically()
     {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new BadMethodCallException(
             'Method nonExistingMacro does not exist.'
-        );
+        ));
 
         CarbonPeriod::nonExistingMacro();
     }

--- a/tests/CarbonPeriod/RoundingTest.php
+++ b/tests/CarbonPeriod/RoundingTest.php
@@ -12,10 +12,9 @@ class RoundingTest extends AbstractTestCase
 {
     public function testThrowsExceptionForCompositeInterval()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Rounding is only possible with single unit intervals.'
-        );
+        ));
 
         CarbonPeriod::days(2)->round('2 hours 50 minutes');
     }

--- a/tests/CarbonPeriod/SettersTest.php
+++ b/tests/CarbonPeriod/SettersTest.php
@@ -17,6 +17,7 @@ use Carbon\CarbonInterval;
 use Carbon\CarbonPeriod;
 use DateInterval;
 use DateTime;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 use Tests\CarbonPeriod\Fixtures\AbstractCarbon;
 
@@ -114,10 +115,9 @@ class SettersTest extends AbstractTestCase
 
     public function testSetDateClassInvalidArgumentException()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Given class does not implement Carbon\CarbonInterface: Carbon\CarbonInterval'
-        );
+        ));
 
         $period = new CarbonPeriod('2001-01-01', '2001-01-02');
 
@@ -126,80 +126,72 @@ class SettersTest extends AbstractTestCase
 
     public function testInvalidInterval()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Invalid interval.'
-        );
+        ));
 
         CarbonPeriod::create()->setDateInterval(new DateTime);
     }
 
     public function testEmptyInterval()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Empty interval is not accepted.'
-        );
+        ));
 
         CarbonPeriod::create()->setDateInterval(new DateInterval('P0D'));
     }
 
     public function testInvalidNumberOfRecurrencesString()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Invalid number of recurrences.'
-        );
+        ));
 
         CarbonPeriod::create()->setRecurrences('foo');
     }
 
     public function testInvalidNegativeNumberOfRecurrences()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Invalid number of recurrences.'
-        );
+        ));
 
         CarbonPeriod::create()->setRecurrences(-4);
     }
 
     public function testInvalidOptions()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Invalid options.'
-        );
+        ));
 
         CarbonPeriod::create()->setOptions('1');
     }
 
     public function testInvalidConstructorParameters()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Invalid constructor parameters.'
-        );
+        ));
 
         CarbonPeriod::create([]);
     }
 
     public function testInvalidStartDate()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Invalid start date.'
-        );
+        ));
 
         CarbonPeriod::create()->setStartDate(new DateInterval('P1D'));
     }
 
     public function testInvalidEndDate()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Invalid end date.'
-        );
+        ));
 
         CarbonPeriod::create()->setEndDate(new DateInterval('P1D'));
     }

--- a/tests/CarbonPeriod/StrictModeTest.php
+++ b/tests/CarbonPeriod/StrictModeTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  */
 namespace Tests\CarbonPeriod;
 
+use BadMethodCallException;
 use Carbon\Carbon;
 use Carbon\CarbonPeriod;
 use Tests\AbstractTestCase;
@@ -19,10 +20,9 @@ class StrictModeTest extends AbstractTestCase
 {
     public function testCallWithStrictMode()
     {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new BadMethodCallException(
             'Method foobar does not exist.'
-        );
+        ));
 
         /** @var mixed $period */
         $period = CarbonPeriod::create();

--- a/tests/CarbonTimeZone/ConversionsTest.php
+++ b/tests/CarbonTimeZone/ConversionsTest.php
@@ -140,8 +140,9 @@ class ConversionsTest extends AbstractTestCaseWithOldNow
 
     public function testCastException()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('stdClass has not the instance() method needed to cast the date.');
+        $this->expectExceptionObject(new InvalidArgumentException(
+            'stdClass has not the instance() method needed to cast the date.'
+        ));
 
         (new CarbonTimeZone('America/Toronto'))->cast(stdClass::class);
     }
@@ -154,10 +155,9 @@ class ConversionsTest extends AbstractTestCaseWithOldNow
 
     public function testInvalidRegionForOffsetInStrictMode()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Unknown timezone for offset -54000 seconds.'
-        );
+        ));
 
         (new CarbonTimeZone(-15))->toRegionTimeZone();
     }

--- a/tests/CarbonTimeZone/CreateTest.php
+++ b/tests/CarbonTimeZone/CreateTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Tests\CarbonTimeZone;
 
 use Carbon\CarbonTimeZone;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 use Tests\CarbonTimeZone\Fixtures\UnknownZone;
 
@@ -44,10 +45,9 @@ class CreateTest extends AbstractTestCase
 
     public function testSafeCreateDateTimeZoneWithoutStrictMode()
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new InvalidArgumentException(
             'Absolute timezone offset cannot be greater than 100.'
-        );
+        ));
 
         new CarbonTimeZone(-15e15);
     }

--- a/tests/Doctrine/CarbonTypesTest.php
+++ b/tests/Doctrine/CarbonTypesTest.php
@@ -129,11 +129,10 @@ class CarbonTypesTest extends AbstractTestCase
      */
     public function testConvertToPHPValueFailure(string $name, string $class)
     {
-        $this->expectException(ConversionException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new ConversionException(
             "Could not convert database value \"2020-0776-23 18:47\" to Doctrine Type $name. ".
             "Expected format: Y-m-d H:i:s.u or any format supported by $class::parse()"
-        );
+        ));
 
         Type::getType($name)->convertToPHPValue('2020-0776-23 18:47', new MySQL57Platform());
     }
@@ -169,11 +168,10 @@ class CarbonTypesTest extends AbstractTestCase
      */
     public function testConvertToDatabaseValueFailure(string $name)
     {
-        $this->expectException(ConversionException::class);
-        $this->expectExceptionMessage(
+        $this->expectExceptionObject(new ConversionException(
             "Could not convert PHP value of type 'array' to type '$name'. ".
             'Expected one of the following types: null, DateTime, Carbon'
-        );
+        ));
 
         Type::getType($name)->convertToDatabaseValue([2020, 06, 23], new MySQL57Platform());
     }

--- a/tests/Laravel/EventDispatcher.php
+++ b/tests/Laravel/EventDispatcher.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Illuminate\Events;
 
-class EventDispatcher extends \Tests\Laravel\EventDispatcherBase
+use Tests\Laravel\EventDispatcherBase;
+
+class EventDispatcher extends EventDispatcherBase
 {
 }

--- a/tests/Laravel/ServiceProviderTest.php
+++ b/tests/Laravel/ServiceProviderTest.php
@@ -138,6 +138,7 @@ class ServiceProviderTest extends TestCase
         }');
 
         eval('namespace Illuminate\Support\Facades;
+        use Exception;
         class Date
         {
             public static $locale;
@@ -152,7 +153,7 @@ class ServiceProviderTest extends TestCase
                 static::$locale = $locale;
 
                 if ($locale === "fr") {
-                    throw new \Exception("stop");
+                    throw new Exception("stop");
                 }
             }
         }');

--- a/tests/Localization/LocalizationTestCase.php
+++ b/tests/Localization/LocalizationTestCase.php
@@ -14,6 +14,7 @@ namespace Tests\Localization;
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterval;
+use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
 abstract class LocalizationTestCase extends AbstractTestCase
@@ -324,15 +325,15 @@ abstract class LocalizationTestCase extends AbstractTestCase
         parent::setUp();
 
         if (!Carbon::setLocale(static::LOCALE) || !$this->areSameLocales(Carbon::getLocale(), static::LOCALE)) {
-            throw new \InvalidArgumentException('Locale '.static::LOCALE.' not found');
+            throw new InvalidArgumentException('Locale '.static::LOCALE.' not found');
         }
 
         if (!CarbonImmutable::setLocale(static::LOCALE) || !$this->areSameLocales(CarbonImmutable::getLocale(), static::LOCALE)) {
-            throw new \InvalidArgumentException('Locale '.static::LOCALE.' not found');
+            throw new InvalidArgumentException('Locale '.static::LOCALE.' not found');
         }
 
         if (!CarbonInterval::setLocale(static::LOCALE) || !$this->areSameLocales(CarbonInterval::getLocale(), static::LOCALE)) {
-            throw new \InvalidArgumentException('Locale '.static::LOCALE.' not found');
+            throw new InvalidArgumentException('Locale '.static::LOCALE.' not found');
         }
     }
 


### PR DESCRIPTION
Add one test class for each exception, where the message and the getters are all tested.
By adding those tests, the coverage surface of the testsuite should improve.

See: `namespace Tests\Carbon\Exceptions;`

---

Also this PR enforces testing expected exception, with `expectExceptionObject` as what should be tested is not the expected type of exception and its message, but with which argument a specific exception type as been called.

