### PR TITLE
Use generators for test data providers 

### DIFF
--- a/tests/Carbon/AddMonthsTest.php
+++ b/tests/Carbon/AddMonthsTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Tests\Carbon;
 
 use Carbon\Carbon;
+use Generator;
 use Tests\AbstractTestCase;
 
 class AddMonthsTest extends AbstractTestCase
@@ -31,15 +32,13 @@ class AddMonthsTest extends AbstractTestCase
         $this->carbon = $date;
     }
 
-    public function providerTestAddMonthNoOverflow()
+    public function providerTestAddMonthNoOverflow(): Generator
     {
-        return [
-            [-2, 2015, 11, 30],
-            [-1, 2015, 12, 31],
-            [0, 2016, 1, 31],
-            [1, 2016, 2, 29],
-            [2, 2016, 3, 31],
-        ];
+        yield [-2, 2015, 11, 30];
+        yield [-1, 2015, 12, 31];
+        yield [0, 2016, 1, 31];
+        yield [1, 2016, 2, 29];
+        yield [2, 2016, 3, 31];
     }
 
     /**
@@ -68,15 +67,13 @@ class AddMonthsTest extends AbstractTestCase
         $this->assertCarbon($this->carbon->addMonthsNoOverflow($months), $y, $m, $d);
     }
 
-    public function providerTestSubMonthNoOverflow()
+    public function providerTestSubMonthNoOverflow(): Generator
     {
-        return [
-            [-2, 2016, 3, 31],
-            [-1, 2016, 2, 29],
-            [0, 2016, 1, 31],
-            [1, 2015, 12, 31],
-            [2, 2015, 11, 30],
-        ];
+        yield [-2, 2016, 3, 31];
+        yield [-1, 2016, 2, 29];
+        yield [0, 2016, 1, 31];
+        yield [1, 2015, 12, 31];
+        yield [2, 2015, 11, 30];
     }
 
     /**
@@ -105,15 +102,13 @@ class AddMonthsTest extends AbstractTestCase
         $this->assertCarbon($this->carbon->subMonthsNoOverflow($months), $y, $m, $d);
     }
 
-    public function providerTestAddMonthWithOverflow()
+    public function providerTestAddMonthWithOverflow(): Generator
     {
-        return [
-            [-2, 2015, 12, 1],
-            [-1, 2015, 12, 31],
-            [0, 2016, 1, 31],
-            [1, 2016, 3, 2],
-            [2, 2016, 3, 31],
-        ];
+        yield [-2, 2015, 12, 1];
+        yield [-1, 2015, 12, 31];
+        yield [0, 2016, 1, 31];
+        yield [1, 2016, 3, 2];
+        yield [2, 2016, 3, 31];
     }
 
     /**
@@ -142,15 +137,13 @@ class AddMonthsTest extends AbstractTestCase
         $this->assertCarbon($this->carbon->addMonthsWithOverflow($months), $y, $m, $d);
     }
 
-    public function providerTestSubMonthWithOverflow()
+    public function providerTestSubMonthWithOverflow(): Generator
     {
-        return [
-            [-2, 2016, 3, 31],
-            [-1, 2016, 3, 2],
-            [0, 2016, 1, 31],
-            [1, 2015, 12, 31],
-            [2, 2015, 12, 1],
-        ];
+        yield [-2, 2016, 3, 31];
+        yield [-1, 2016, 3, 2];
+        yield [0, 2016, 1, 31];
+        yield [1, 2015, 12, 31];
+        yield [2, 2015, 12, 1];
     }
 
     /**

--- a/tests/Carbon/CreateTest.php
+++ b/tests/Carbon/CreateTest.php
@@ -15,6 +15,7 @@ use Carbon\Carbon;
 use Carbon\Exceptions\OutOfRangeException;
 use DateTime;
 use DateTimeZone;
+use Generator;
 use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
@@ -381,722 +382,718 @@ class CreateTest extends AbstractTestCase
         $this->assertSame('2018-07-24 08:34', $date->format('Y-m-d H:i'));
     }
 
-    public function getLocales()
+    public function getLocales(): Generator
     {
-        return array_map(function ($locale) {
-            return [$locale];
-        }, [
-            'aa_ER',
-            'aa_ER@saaho',
-            'aa_ET',
-            'af',
-            'af_NA',
-            'af_ZA',
-            'agq',
-            'agr',
-            'agr_PE',
-            'ak',
-            'ak_GH',
-            'am',
-            'am_ET',
-            'an',
-            'an_ES',
-            'anp',
-            'anp_IN',
-            'ar',
-            'ar_AE',
-            'ar_BH',
-            'ar_DJ',
-            'ar_DZ',
-            'ar_EG',
-            'ar_EH',
-            'ar_ER',
-            'ar_IL',
-            'ar_IN',
-            'ar_IQ',
-            'ar_JO',
-            'ar_KM',
-            'ar_KW',
-            'ar_LB',
-            'ar_LY',
-            'ar_MA',
-            'ar_MR',
-            'ar_OM',
-            'ar_PS',
-            'ar_QA',
-            'ar_SA',
-            'ar_SD',
-            'ar_SO',
-            'ar_SS',
-            'ar_SY',
-            'ar_Shakl',
-            'ar_TD',
-            'ar_TN',
-            'ar_YE',
-            'as',
-            'as_IN',
-            'asa',
-            'ast',
-            'ast_ES',
-            'ayc',
-            'ayc_PE',
-            'az',
-            'az_AZ',
-            'az_Cyrl',
-            'az_Latn',
-            'bas',
-            'be',
-            'be_BY',
-            'bem',
-            'bem_ZM',
-            'ber',
-            'ber_DZ',
-            'ber_MA',
-            'bez',
-            'bg',
-            'bg_BG',
-            'bhb',
-            'bhb_IN',
-            'bho',
-            'bho_IN',
-            'bi',
-            'bi_VU',
-            'bm',
-            'bo_IN',
-            'br',
-            'br_FR',
-            'brx',
-            'brx_IN',
-            'bs',
-            'bs_BA',
-            'bs_Cyrl',
-            'bs_Latn',
-            'ca',
-            'ca_AD',
-            'ca_ES',
-            'ca_ES_Valencia',
-            'ca_FR',
-            'ca_IT',
-            'ccp',
-            'ccp_IN',
-            'ce',
-            'ce_RU',
-            'cgg',
-            'chr',
-            'chr_US',
-            'cmn',
-            'cmn_TW',
-            'crh',
-            'crh_UA',
-            'cu',
-            'cy',
-            'cy_GB',
-            'da',
-            'da_DK',
-            'da_GL',
-            'dav',
-            'dje',
-            'doi',
-            'doi_IN',
-            'dsb',
-            'dsb_DE',
-            'dua',
-            'dv',
-            'dv_MV',
-            'dyo',
-            'dz',
-            'dz_BT',
-            'ebu',
-            'ee_TG',
-            'el',
-            'el_CY',
-            'el_GR',
-            'en',
-            'en_001',
-            'en_150',
-            'en_AG',
-            'en_AI',
-            'en_AS',
-            'en_AT',
-            'en_AU',
-            'en_BB',
-            'en_BE',
-            'en_BI',
-            'en_BM',
-            'en_BS',
-            'en_BW',
-            'en_BZ',
-            'en_CA',
-            'en_CC',
-            'en_CH',
-            'en_CK',
-            'en_CM',
-            'en_CX',
-            'en_CY',
-            'en_DE',
-            'en_DG',
-            'en_DK',
-            'en_DM',
-            'en_ER',
-            'en_FI',
-            'en_FJ',
-            'en_FK',
-            'en_FM',
-            'en_GB',
-            'en_GD',
-            'en_GG',
-            'en_GH',
-            'en_GI',
-            'en_GM',
-            'en_GU',
-            'en_GY',
-            'en_HK',
-            'en_IE',
-            'en_IL',
-            'en_IM',
-            'en_IN',
-            'en_IO',
-            'en_ISO',
-            'en_JE',
-            'en_JM',
-            'en_KE',
-            'en_KI',
-            'en_KN',
-            'en_KY',
-            'en_LC',
-            'en_LR',
-            'en_LS',
-            'en_MG',
-            'en_MH',
-            'en_MO',
-            'en_MP',
-            'en_MS',
-            'en_MT',
-            'en_MU',
-            'en_MW',
-            'en_MY',
-            'en_NA',
-            'en_NF',
-            'en_NG',
-            'en_NL',
-            'en_NR',
-            'en_NU',
-            'en_NZ',
-            'en_PG',
-            'en_PH',
-            'en_PK',
-            'en_PN',
-            'en_PR',
-            'en_PW',
-            'en_RW',
-            'en_SB',
-            'en_SC',
-            'en_SD',
-            'en_SE',
-            'en_SG',
-            'en_SH',
-            'en_SI',
-            'en_SL',
-            'en_SS',
-            'en_SX',
-            'en_SZ',
-            'en_TC',
-            'en_TK',
-            'en_TO',
-            'en_TT',
-            'en_TV',
-            'en_TZ',
-            'en_UG',
-            'en_UM',
-            'en_US',
-            'en_US_Posix',
-            'en_VC',
-            'en_VG',
-            'en_VI',
-            'en_VU',
-            'en_WS',
-            'en_ZA',
-            'en_ZM',
-            'en_ZW',
-            'eo',
-            'es',
-            'es_419',
-            'es_AR',
-            'es_BO',
-            'es_BR',
-            'es_BZ',
-            'es_CL',
-            'es_CO',
-            'es_CR',
-            'es_CU',
-            'es_DO',
-            'es_EA',
-            'es_EC',
-            'es_ES',
-            'es_GQ',
-            'es_GT',
-            'es_HN',
-            'es_IC',
-            'es_MX',
-            'es_NI',
-            'es_PA',
-            'es_PE',
-            'es_PH',
-            'es_PR',
-            'es_PY',
-            'es_SV',
-            'es_US',
-            'es_UY',
-            'es_VE',
-            'et',
-            'et_EE',
-            'ewo',
-            'ff',
-            'ff_CM',
-            'ff_GN',
-            'ff_MR',
-            'ff_SN',
-            'fil',
-            'fil_PH',
-            'fo',
-            'fo_DK',
-            'fo_FO',
-            'fr',
-            'fr_BE',
-            'fr_BF',
-            'fr_BI',
-            'fr_BJ',
-            'fr_BL',
-            'fr_CA',
-            'fr_CD',
-            'fr_CF',
-            'fr_CG',
-            'fr_CH',
-            'fr_CI',
-            'fr_CM',
-            'fr_DJ',
-            'fr_DZ',
-            'fr_FR',
-            'fr_GA',
-            'fr_GF',
-            'fr_GN',
-            'fr_GP',
-            'fr_GQ',
-            'fr_HT',
-            'fr_KM',
-            'fr_LU',
-            'fr_MA',
-            'fr_MC',
-            'fr_MF',
-            'fr_MG',
-            'fr_ML',
-            'fr_MQ',
-            'fr_MR',
-            'fr_MU',
-            'fr_NC',
-            'fr_NE',
-            'fr_PF',
-            'fr_PM',
-            'fr_RE',
-            'fr_RW',
-            'fr_SC',
-            'fr_SN',
-            'fr_SY',
-            'fr_TD',
-            'fr_TG',
-            'fr_TN',
-            'fr_VU',
-            'fr_WF',
-            'fr_YT',
-            'fy',
-            'fy_NL',
-            'ga',
-            'ga_IE',
-            'gd',
-            'gd_GB',
-            'gez',
-            'gez_ER',
-            'gez_ET',
-            'gl',
-            'gl_ES',
-            'guz',
-            'gv',
-            'gv_GB',
-            'ha',
-            'ha_GH',
-            'ha_NE',
-            'ha_NG',
-            'hak',
-            'hak_TW',
-            'haw',
-            'he',
-            'he_IL',
-            'hif',
-            'hif_FJ',
-            'hne',
-            'hne_IN',
-            'hr',
-            'hr_BA',
-            'hr_HR',
-            'hsb',
-            'hsb_DE',
-            'ht',
-            'ht_HT',
-            'hy',
-            'hy_AM',
-            'ia',
-            'ia_FR',
-            'id',
-            'id_ID',
-            'ig',
-            'ig_NG',
-            'ii',
-            'ik',
-            'ik_CA',
-            'in',
-            'it',
-            'it_CH',
-            'it_IT',
-            'it_SM',
-            'it_VA',
-            'iu',
-            'iu_CA',
-            'iw',
-            'ja',
-            'ja_JP',
-            'jgo',
-            'jmc',
-            'jv',
-            'kab',
-            'kab_DZ',
-            'kam',
-            'kde',
-            'kea',
-            'khq',
-            'ki',
-            'kk',
-            'kk_KZ',
-            'kkj',
-            'kl',
-            'kl_GL',
-            'kln',
-            'km',
-            'km_KH',
-            'kok',
-            'kok_IN',
-            'ks',
-            'ks_IN',
-            'ks_IN@devanagari',
-            'ksb',
-            'ksf',
-            'ksh',
-            'kw',
-            'kw_GB',
-            'ky',
-            'ky_KG',
-            'lag',
-            'lg',
-            'lg_UG',
-            'li',
-            'li_NL',
-            'lij',
-            'lij_IT',
-            'lkt',
-            'ln',
-            'ln_AO',
-            'ln_CD',
-            'ln_CF',
-            'ln_CG',
-            'lo',
-            'lo_LA',
-            'lrc',
-            'lrc_IQ',
-            'lt',
-            'lt_LT',
-            'lu',
-            'luo',
-            'luy',
-            'lzh',
-            'lzh_TW',
-            'mag',
-            'mag_IN',
-            'mai',
-            'mai_IN',
-            'mas',
-            'mas_TZ',
-            'mer',
-            'mfe',
-            'mfe_MU',
-            'mg',
-            'mg_MG',
-            'mgh',
-            'mgo',
-            'mhr',
-            'mhr_RU',
-            'mi',
-            'mi_NZ',
-            'miq',
-            'miq_NI',
-            'mjw',
-            'mjw_IN',
-            'mk',
-            'mk_MK',
-            'mni',
-            'mni_IN',
-            'mo',
-            'ms',
-            'ms_BN',
-            'ms_MY',
-            'ms_SG',
-            'mt',
-            'mt_MT',
-            'mua',
-            'mzn',
-            'nan',
-            'nan_TW',
-            'nan_TW@latin',
-            'naq',
-            'nb',
-            'nb_NO',
-            'nb_SJ',
-            'nd',
-            'nds',
-            'nds_DE',
-            'nds_NL',
-            'ne_IN',
-            'nhn',
-            'nhn_MX',
-            'niu',
-            'niu_NU',
-            'nl',
-            'nl_AW',
-            'nl_BE',
-            'nl_BQ',
-            'nl_CW',
-            'nl_NL',
-            'nl_SR',
-            'nl_SX',
-            'nmg',
-            'nn',
-            'nn_NO',
-            'nnh',
-            'no',
-            'nr',
-            'nr_ZA',
-            'nso',
-            'nso_ZA',
-            'nus',
-            'nyn',
-            'oc',
-            'oc_FR',
-            'om',
-            'om_ET',
-            'om_KE',
-            'os',
-            'os_RU',
-            'pa_Arab',
-            'pa_Guru',
-            'pl',
-            'pl_PL',
-            'prg',
-            'pt',
-            'pt_AO',
-            'pt_BR',
-            'pt_CH',
-            'pt_CV',
-            'pt_GQ',
-            'pt_GW',
-            'pt_LU',
-            'pt_MO',
-            'pt_MZ',
-            'pt_PT',
-            'pt_ST',
-            'pt_TL',
-            'qu',
-            'qu_BO',
-            'qu_EC',
-            'quz',
-            'quz_PE',
-            'raj',
-            'raj_IN',
-            'rm',
-            'rn',
-            'ro',
-            'ro_MD',
-            'ro_RO',
-            'rof',
-            'ru',
-            'ru_BY',
-            'ru_KG',
-            'ru_KZ',
-            'ru_MD',
-            'ru_RU',
-            'ru_UA',
-            'rw',
-            'rw_RW',
-            'rwk',
-            'sa',
-            'sa_IN',
-            'sah',
-            'sah_RU',
-            'saq',
-            'sat',
-            'sat_IN',
-            'sbp',
-            'sd',
-            'sd_IN',
-            'sd_IN@devanagari',
-            'se',
-            'se_FI',
-            'se_NO',
-            'se_SE',
-            'seh',
-            'ses',
-            'sg',
-            'sgs',
-            'sgs_LT',
-            'shi',
-            'shi_Latn',
-            'shi_Tfng',
-            'shn',
-            'shn_MM',
-            'shs',
-            'shs_CA',
-            'sid',
-            'sid_ET',
-            'sl',
-            'sl_SI',
-            'sm',
-            'sm_WS',
-            'smn',
-            'sn',
-            'so',
-            'so_DJ',
-            'so_ET',
-            'so_KE',
-            'so_SO',
-            'sq',
-            'sq_AL',
-            'sq_MK',
-            'sq_XK',
-            'sr',
-            'sr_Cyrl',
-            'sr_Cyrl_BA',
-            'sr_Cyrl_ME',
-            'sr_Cyrl_XK',
-            'sr_Latn',
-            'sr_Latn_BA',
-            'sr_Latn_ME',
-            'sr_Latn_XK',
-            'sr_ME',
-            'sr_RS',
-            'sr_RS@latin',
-            'ss',
-            'ss_ZA',
-            'st',
-            'st_ZA',
-            'sv',
-            'sv_AX',
-            'sv_FI',
-            'sv_SE',
-            'sw',
-            'sw_CD',
-            'sw_KE',
-            'sw_TZ',
-            'sw_UG',
-            'szl',
-            'szl_PL',
-            'ta',
-            'ta_IN',
-            'ta_LK',
-            'tcy',
-            'tcy_IN',
-            'teo',
-            'teo_KE',
-            'tet',
-            'tg',
-            'tg_TJ',
-            'th',
-            'th_TH',
-            'the',
-            'the_NP',
-            'ti',
-            'ti_ER',
-            'ti_ET',
-            'tk',
-            'tk_TM',
-            'tlh',
-            'tn',
-            'tn_ZA',
-            'to',
-            'to_TO',
-            'tpi',
-            'tpi_PG',
-            'tr',
-            'tr_TR',
-            'ts',
-            'ts_ZA',
-            'tt_RU@iqtelif',
-            'twq',
-            'tzl',
-            'tzm',
-            'tzm_Latn',
-            'ug',
-            'ug_CN',
-            'uk',
-            'uk_UA',
-            'unm',
-            'unm_US',
-            'ur',
-            'ur_IN',
-            'ur_PK',
-            'uz_Arab',
-            'vai',
-            'vai_Vaii',
-            've',
-            've_ZA',
-            'vi',
-            'vi_VN',
-            'vo',
-            'vun',
-            'wa',
-            'wa_BE',
-            'wae',
-            'wae_CH',
-            'wal',
-            'wal_ET',
-            'xh',
-            'xh_ZA',
-            'xog',
-            'yav',
-            'yi',
-            'yi_US',
-            'yo',
-            'yo_BJ',
-            'yo_NG',
-            'yue',
-            'yue_HK',
-            'yue_Hans',
-            'yue_Hant',
-            'yuw',
-            'yuw_PG',
-            'zh',
-            'zh_CN',
-            'zh_HK',
-            'zh_Hans',
-            'zh_Hans_HK',
-            'zh_Hans_MO',
-            'zh_Hans_SG',
-            'zh_Hant',
-            'zh_Hant_HK',
-            'zh_Hant_MO',
-            'zh_Hant_TW',
-            'zh_MO',
-            'zh_SG',
-            'zh_TW',
-            'zh_YUE',
-            'zu',
-            'zu_ZA',
-        ]);
+        yield ['aa_ER'];
+        yield ['aa_ER@saaho'];
+        yield ['aa_ET'];
+        yield ['af'];
+        yield ['af_NA'];
+        yield ['af_ZA'];
+        yield ['agq'];
+        yield ['agr'];
+        yield ['agr_PE'];
+        yield ['ak'];
+        yield ['ak_GH'];
+        yield ['am'];
+        yield ['am_ET'];
+        yield ['an'];
+        yield ['an_ES'];
+        yield ['anp'];
+        yield ['anp_IN'];
+        yield ['ar'];
+        yield ['ar_AE'];
+        yield ['ar_BH'];
+        yield ['ar_DJ'];
+        yield ['ar_DZ'];
+        yield ['ar_EG'];
+        yield ['ar_EH'];
+        yield ['ar_ER'];
+        yield ['ar_IL'];
+        yield ['ar_IN'];
+        yield ['ar_IQ'];
+        yield ['ar_JO'];
+        yield ['ar_KM'];
+        yield ['ar_KW'];
+        yield ['ar_LB'];
+        yield ['ar_LY'];
+        yield ['ar_MA'];
+        yield ['ar_MR'];
+        yield ['ar_OM'];
+        yield ['ar_PS'];
+        yield ['ar_QA'];
+        yield ['ar_SA'];
+        yield ['ar_SD'];
+        yield ['ar_SO'];
+        yield ['ar_SS'];
+        yield ['ar_SY'];
+        yield ['ar_Shakl'];
+        yield ['ar_TD'];
+        yield ['ar_TN'];
+        yield ['ar_YE'];
+        yield ['as'];
+        yield ['as_IN'];
+        yield ['asa'];
+        yield ['ast'];
+        yield ['ast_ES'];
+        yield ['ayc'];
+        yield ['ayc_PE'];
+        yield ['az'];
+        yield ['az_AZ'];
+        yield ['az_Cyrl'];
+        yield ['az_Latn'];
+        yield ['bas'];
+        yield ['be'];
+        yield ['be_BY'];
+        yield ['bem'];
+        yield ['bem_ZM'];
+        yield ['ber'];
+        yield ['ber_DZ'];
+        yield ['ber_MA'];
+        yield ['bez'];
+        yield ['bg'];
+        yield ['bg_BG'];
+        yield ['bhb'];
+        yield ['bhb_IN'];
+        yield ['bho'];
+        yield ['bho_IN'];
+        yield ['bi'];
+        yield ['bi_VU'];
+        yield ['bm'];
+        yield ['bo_IN'];
+        yield ['br'];
+        yield ['br_FR'];
+        yield ['brx'];
+        yield ['brx_IN'];
+        yield ['bs'];
+        yield ['bs_BA'];
+        yield ['bs_Cyrl'];
+        yield ['bs_Latn'];
+        yield ['ca'];
+        yield ['ca_AD'];
+        yield ['ca_ES'];
+        yield ['ca_ES_Valencia'];
+        yield ['ca_FR'];
+        yield ['ca_IT'];
+        yield ['ccp'];
+        yield ['ccp_IN'];
+        yield ['ce'];
+        yield ['ce_RU'];
+        yield ['cgg'];
+        yield ['chr'];
+        yield ['chr_US'];
+        yield ['cmn'];
+        yield ['cmn_TW'];
+        yield ['crh'];
+        yield ['crh_UA'];
+        yield ['cu'];
+        yield ['cy'];
+        yield ['cy_GB'];
+        yield ['da'];
+        yield ['da_DK'];
+        yield ['da_GL'];
+        yield ['dav'];
+        yield ['dje'];
+        yield ['doi'];
+        yield ['doi_IN'];
+        yield ['dsb'];
+        yield ['dsb_DE'];
+        yield ['dua'];
+        yield ['dv'];
+        yield ['dv_MV'];
+        yield ['dyo'];
+        yield ['dz'];
+        yield ['dz_BT'];
+        yield ['ebu'];
+        yield ['ee_TG'];
+        yield ['el'];
+        yield ['el_CY'];
+        yield ['el_GR'];
+        yield ['en'];
+        yield ['en_001'];
+        yield ['en_150'];
+        yield ['en_AG'];
+        yield ['en_AI'];
+        yield ['en_AS'];
+        yield ['en_AT'];
+        yield ['en_AU'];
+        yield ['en_BB'];
+        yield ['en_BE'];
+        yield ['en_BI'];
+        yield ['en_BM'];
+        yield ['en_BS'];
+        yield ['en_BW'];
+        yield ['en_BZ'];
+        yield ['en_CA'];
+        yield ['en_CC'];
+        yield ['en_CH'];
+        yield ['en_CK'];
+        yield ['en_CM'];
+        yield ['en_CX'];
+        yield ['en_CY'];
+        yield ['en_DE'];
+        yield ['en_DG'];
+        yield ['en_DK'];
+        yield ['en_DM'];
+        yield ['en_ER'];
+        yield ['en_FI'];
+        yield ['en_FJ'];
+        yield ['en_FK'];
+        yield ['en_FM'];
+        yield ['en_GB'];
+        yield ['en_GD'];
+        yield ['en_GG'];
+        yield ['en_GH'];
+        yield ['en_GI'];
+        yield ['en_GM'];
+        yield ['en_GU'];
+        yield ['en_GY'];
+        yield ['en_HK'];
+        yield ['en_IE'];
+        yield ['en_IL'];
+        yield ['en_IM'];
+        yield ['en_IN'];
+        yield ['en_IO'];
+        yield ['en_ISO'];
+        yield ['en_JE'];
+        yield ['en_JM'];
+        yield ['en_KE'];
+        yield ['en_KI'];
+        yield ['en_KN'];
+        yield ['en_KY'];
+        yield ['en_LC'];
+        yield ['en_LR'];
+        yield ['en_LS'];
+        yield ['en_MG'];
+        yield ['en_MH'];
+        yield ['en_MO'];
+        yield ['en_MP'];
+        yield ['en_MS'];
+        yield ['en_MT'];
+        yield ['en_MU'];
+        yield ['en_MW'];
+        yield ['en_MY'];
+        yield ['en_NA'];
+        yield ['en_NF'];
+        yield ['en_NG'];
+        yield ['en_NL'];
+        yield ['en_NR'];
+        yield ['en_NU'];
+        yield ['en_NZ'];
+        yield ['en_PG'];
+        yield ['en_PH'];
+        yield ['en_PK'];
+        yield ['en_PN'];
+        yield ['en_PR'];
+        yield ['en_PW'];
+        yield ['en_RW'];
+        yield ['en_SB'];
+        yield ['en_SC'];
+        yield ['en_SD'];
+        yield ['en_SE'];
+        yield ['en_SG'];
+        yield ['en_SH'];
+        yield ['en_SI'];
+        yield ['en_SL'];
+        yield ['en_SS'];
+        yield ['en_SX'];
+        yield ['en_SZ'];
+        yield ['en_TC'];
+        yield ['en_TK'];
+        yield ['en_TO'];
+        yield ['en_TT'];
+        yield ['en_TV'];
+        yield ['en_TZ'];
+        yield ['en_UG'];
+        yield ['en_UM'];
+        yield ['en_US'];
+        yield ['en_US_Posix'];
+        yield ['en_VC'];
+        yield ['en_VG'];
+        yield ['en_VI'];
+        yield ['en_VU'];
+        yield ['en_WS'];
+        yield ['en_ZA'];
+        yield ['en_ZM'];
+        yield ['en_ZW'];
+        yield ['eo'];
+        yield ['es'];
+        yield ['es_419'];
+        yield ['es_AR'];
+        yield ['es_BO'];
+        yield ['es_BR'];
+        yield ['es_BZ'];
+        yield ['es_CL'];
+        yield ['es_CO'];
+        yield ['es_CR'];
+        yield ['es_CU'];
+        yield ['es_DO'];
+        yield ['es_EA'];
+        yield ['es_EC'];
+        yield ['es_ES'];
+        yield ['es_GQ'];
+        yield ['es_GT'];
+        yield ['es_HN'];
+        yield ['es_IC'];
+        yield ['es_MX'];
+        yield ['es_NI'];
+        yield ['es_PA'];
+        yield ['es_PE'];
+        yield ['es_PH'];
+        yield ['es_PR'];
+        yield ['es_PY'];
+        yield ['es_SV'];
+        yield ['es_US'];
+        yield ['es_UY'];
+        yield ['es_VE'];
+        yield ['et'];
+        yield ['et_EE'];
+        yield ['ewo'];
+        yield ['ff'];
+        yield ['ff_CM'];
+        yield ['ff_GN'];
+        yield ['ff_MR'];
+        yield ['ff_SN'];
+        yield ['fil'];
+        yield ['fil_PH'];
+        yield ['fo'];
+        yield ['fo_DK'];
+        yield ['fo_FO'];
+        yield ['fr'];
+        yield ['fr_BE'];
+        yield ['fr_BF'];
+        yield ['fr_BI'];
+        yield ['fr_BJ'];
+        yield ['fr_BL'];
+        yield ['fr_CA'];
+        yield ['fr_CD'];
+        yield ['fr_CF'];
+        yield ['fr_CG'];
+        yield ['fr_CH'];
+        yield ['fr_CI'];
+        yield ['fr_CM'];
+        yield ['fr_DJ'];
+        yield ['fr_DZ'];
+        yield ['fr_FR'];
+        yield ['fr_GA'];
+        yield ['fr_GF'];
+        yield ['fr_GN'];
+        yield ['fr_GP'];
+        yield ['fr_GQ'];
+        yield ['fr_HT'];
+        yield ['fr_KM'];
+        yield ['fr_LU'];
+        yield ['fr_MA'];
+        yield ['fr_MC'];
+        yield ['fr_MF'];
+        yield ['fr_MG'];
+        yield ['fr_ML'];
+        yield ['fr_MQ'];
+        yield ['fr_MR'];
+        yield ['fr_MU'];
+        yield ['fr_NC'];
+        yield ['fr_NE'];
+        yield ['fr_PF'];
+        yield ['fr_PM'];
+        yield ['fr_RE'];
+        yield ['fr_RW'];
+        yield ['fr_SC'];
+        yield ['fr_SN'];
+        yield ['fr_SY'];
+        yield ['fr_TD'];
+        yield ['fr_TG'];
+        yield ['fr_TN'];
+        yield ['fr_VU'];
+        yield ['fr_WF'];
+        yield ['fr_YT'];
+        yield ['fy'];
+        yield ['fy_NL'];
+        yield ['ga'];
+        yield ['ga_IE'];
+        yield ['gd'];
+        yield ['gd_GB'];
+        yield ['gez'];
+        yield ['gez_ER'];
+        yield ['gez_ET'];
+        yield ['gl'];
+        yield ['gl_ES'];
+        yield ['guz'];
+        yield ['gv'];
+        yield ['gv_GB'];
+        yield ['ha'];
+        yield ['ha_GH'];
+        yield ['ha_NE'];
+        yield ['ha_NG'];
+        yield ['hak'];
+        yield ['hak_TW'];
+        yield ['haw'];
+        yield ['he'];
+        yield ['he_IL'];
+        yield ['hif'];
+        yield ['hif_FJ'];
+        yield ['hne'];
+        yield ['hne_IN'];
+        yield ['hr'];
+        yield ['hr_BA'];
+        yield ['hr_HR'];
+        yield ['hsb'];
+        yield ['hsb_DE'];
+        yield ['ht'];
+        yield ['ht_HT'];
+        yield ['hy'];
+        yield ['hy_AM'];
+        yield ['ia'];
+        yield ['ia_FR'];
+        yield ['id'];
+        yield ['id_ID'];
+        yield ['ig'];
+        yield ['ig_NG'];
+        yield ['ii'];
+        yield ['ik'];
+        yield ['ik_CA'];
+        yield ['in'];
+        yield ['it'];
+        yield ['it_CH'];
+        yield ['it_IT'];
+        yield ['it_SM'];
+        yield ['it_VA'];
+        yield ['iu'];
+        yield ['iu_CA'];
+        yield ['iw'];
+        yield ['ja'];
+        yield ['ja_JP'];
+        yield ['jgo'];
+        yield ['jmc'];
+        yield ['jv'];
+        yield ['kab'];
+        yield ['kab_DZ'];
+        yield ['kam'];
+        yield ['kde'];
+        yield ['kea'];
+        yield ['khq'];
+        yield ['ki'];
+        yield ['kk'];
+        yield ['kk_KZ'];
+        yield ['kkj'];
+        yield ['kl'];
+        yield ['kl_GL'];
+        yield ['kln'];
+        yield ['km'];
+        yield ['km_KH'];
+        yield ['kok'];
+        yield ['kok_IN'];
+        yield ['ks'];
+        yield ['ks_IN'];
+        yield ['ks_IN@devanagari'];
+        yield ['ksb'];
+        yield ['ksf'];
+        yield ['ksh'];
+        yield ['kw'];
+        yield ['kw_GB'];
+        yield ['ky'];
+        yield ['ky_KG'];
+        yield ['lag'];
+        yield ['lg'];
+        yield ['lg_UG'];
+        yield ['li'];
+        yield ['li_NL'];
+        yield ['lij'];
+        yield ['lij_IT'];
+        yield ['lkt'];
+        yield ['ln'];
+        yield ['ln_AO'];
+        yield ['ln_CD'];
+        yield ['ln_CF'];
+        yield ['ln_CG'];
+        yield ['lo'];
+        yield ['lo_LA'];
+        yield ['lrc'];
+        yield ['lrc_IQ'];
+        yield ['lt'];
+        yield ['lt_LT'];
+        yield ['lu'];
+        yield ['luo'];
+        yield ['luy'];
+        yield ['lzh'];
+        yield ['lzh_TW'];
+        yield ['mag'];
+        yield ['mag_IN'];
+        yield ['mai'];
+        yield ['mai_IN'];
+        yield ['mas'];
+        yield ['mas_TZ'];
+        yield ['mer'];
+        yield ['mfe'];
+        yield ['mfe_MU'];
+        yield ['mg'];
+        yield ['mg_MG'];
+        yield ['mgh'];
+        yield ['mgo'];
+        yield ['mhr'];
+        yield ['mhr_RU'];
+        yield ['mi'];
+        yield ['mi_NZ'];
+        yield ['miq'];
+        yield ['miq_NI'];
+        yield ['mjw'];
+        yield ['mjw_IN'];
+        yield ['mk'];
+        yield ['mk_MK'];
+        yield ['mni'];
+        yield ['mni_IN'];
+        yield ['mo'];
+        yield ['ms'];
+        yield ['ms_BN'];
+        yield ['ms_MY'];
+        yield ['ms_SG'];
+        yield ['mt'];
+        yield ['mt_MT'];
+        yield ['mua'];
+        yield ['mzn'];
+        yield ['nan'];
+        yield ['nan_TW'];
+        yield ['nan_TW@latin'];
+        yield ['naq'];
+        yield ['nb'];
+        yield ['nb_NO'];
+        yield ['nb_SJ'];
+        yield ['nd'];
+        yield ['nds'];
+        yield ['nds_DE'];
+        yield ['nds_NL'];
+        yield ['ne_IN'];
+        yield ['nhn'];
+        yield ['nhn_MX'];
+        yield ['niu'];
+        yield ['niu_NU'];
+        yield ['nl'];
+        yield ['nl_AW'];
+        yield ['nl_BE'];
+        yield ['nl_BQ'];
+        yield ['nl_CW'];
+        yield ['nl_NL'];
+        yield ['nl_SR'];
+        yield ['nl_SX'];
+        yield ['nmg'];
+        yield ['nn'];
+        yield ['nn_NO'];
+        yield ['nnh'];
+        yield ['no'];
+        yield ['nr'];
+        yield ['nr_ZA'];
+        yield ['nso'];
+        yield ['nso_ZA'];
+        yield ['nus'];
+        yield ['nyn'];
+        yield ['oc'];
+        yield ['oc_FR'];
+        yield ['om'];
+        yield ['om_ET'];
+        yield ['om_KE'];
+        yield ['os'];
+        yield ['os_RU'];
+        yield ['pa_Arab'];
+        yield ['pa_Guru'];
+        yield ['pl'];
+        yield ['pl_PL'];
+        yield ['prg'];
+        yield ['pt'];
+        yield ['pt_AO'];
+        yield ['pt_BR'];
+        yield ['pt_CH'];
+        yield ['pt_CV'];
+        yield ['pt_GQ'];
+        yield ['pt_GW'];
+        yield ['pt_LU'];
+        yield ['pt_MO'];
+        yield ['pt_MZ'];
+        yield ['pt_PT'];
+        yield ['pt_ST'];
+        yield ['pt_TL'];
+        yield ['qu'];
+        yield ['qu_BO'];
+        yield ['qu_EC'];
+        yield ['quz'];
+        yield ['quz_PE'];
+        yield ['raj'];
+        yield ['raj_IN'];
+        yield ['rm'];
+        yield ['rn'];
+        yield ['ro'];
+        yield ['ro_MD'];
+        yield ['ro_RO'];
+        yield ['rof'];
+        yield ['ru'];
+        yield ['ru_BY'];
+        yield ['ru_KG'];
+        yield ['ru_KZ'];
+        yield ['ru_MD'];
+        yield ['ru_RU'];
+        yield ['ru_UA'];
+        yield ['rw'];
+        yield ['rw_RW'];
+        yield ['rwk'];
+        yield ['sa'];
+        yield ['sa_IN'];
+        yield ['sah'];
+        yield ['sah_RU'];
+        yield ['saq'];
+        yield ['sat'];
+        yield ['sat_IN'];
+        yield ['sbp'];
+        yield ['sd'];
+        yield ['sd_IN'];
+        yield ['sd_IN@devanagari'];
+        yield ['se'];
+        yield ['se_FI'];
+        yield ['se_NO'];
+        yield ['se_SE'];
+        yield ['seh'];
+        yield ['ses'];
+        yield ['sg'];
+        yield ['sgs'];
+        yield ['sgs_LT'];
+        yield ['shi'];
+        yield ['shi_Latn'];
+        yield ['shi_Tfng'];
+        yield ['shn'];
+        yield ['shn_MM'];
+        yield ['shs'];
+        yield ['shs_CA'];
+        yield ['sid'];
+        yield ['sid_ET'];
+        yield ['sl'];
+        yield ['sl_SI'];
+        yield ['sm'];
+        yield ['sm_WS'];
+        yield ['smn'];
+        yield ['sn'];
+        yield ['so'];
+        yield ['so_DJ'];
+        yield ['so_ET'];
+        yield ['so_KE'];
+        yield ['so_SO'];
+        yield ['sq'];
+        yield ['sq_AL'];
+        yield ['sq_MK'];
+        yield ['sq_XK'];
+        yield ['sr'];
+        yield ['sr_Cyrl'];
+        yield ['sr_Cyrl_BA'];
+        yield ['sr_Cyrl_ME'];
+        yield ['sr_Cyrl_XK'];
+        yield ['sr_Latn'];
+        yield ['sr_Latn_BA'];
+        yield ['sr_Latn_ME'];
+        yield ['sr_Latn_XK'];
+        yield ['sr_ME'];
+        yield ['sr_RS'];
+        yield ['sr_RS@latin'];
+        yield ['ss'];
+        yield ['ss_ZA'];
+        yield ['st'];
+        yield ['st_ZA'];
+        yield ['sv'];
+        yield ['sv_AX'];
+        yield ['sv_FI'];
+        yield ['sv_SE'];
+        yield ['sw'];
+        yield ['sw_CD'];
+        yield ['sw_KE'];
+        yield ['sw_TZ'];
+        yield ['sw_UG'];
+        yield ['szl'];
+        yield ['szl_PL'];
+        yield ['ta'];
+        yield ['ta_IN'];
+        yield ['ta_LK'];
+        yield ['tcy'];
+        yield ['tcy_IN'];
+        yield ['teo'];
+        yield ['teo_KE'];
+        yield ['tet'];
+        yield ['tg'];
+        yield ['tg_TJ'];
+        yield ['th'];
+        yield ['th_TH'];
+        yield ['the'];
+        yield ['the_NP'];
+        yield ['ti'];
+        yield ['ti_ER'];
+        yield ['ti_ET'];
+        yield ['tk'];
+        yield ['tk_TM'];
+        yield ['tlh'];
+        yield ['tn'];
+        yield ['tn_ZA'];
+        yield ['to'];
+        yield ['to_TO'];
+        yield ['tpi'];
+        yield ['tpi_PG'];
+        yield ['tr'];
+        yield ['tr_TR'];
+        yield ['ts'];
+        yield ['ts_ZA'];
+        yield ['tt_RU@iqtelif'];
+        yield ['twq'];
+        yield ['tzl'];
+        yield ['tzm'];
+        yield ['tzm_Latn'];
+        yield ['ug'];
+        yield ['ug_CN'];
+        yield ['uk'];
+        yield ['uk_UA'];
+        yield ['unm'];
+        yield ['unm_US'];
+        yield ['ur'];
+        yield ['ur_IN'];
+        yield ['ur_PK'];
+        yield ['uz_Arab'];
+        yield ['vai'];
+        yield ['vai_Vaii'];
+        yield ['ve'];
+        yield ['ve_ZA'];
+        yield ['vi'];
+        yield ['vi_VN'];
+        yield ['vo'];
+        yield ['vun'];
+        yield ['wa'];
+        yield ['wa_BE'];
+        yield ['wae'];
+        yield ['wae_CH'];
+        yield ['wal'];
+        yield ['wal_ET'];
+        yield ['xh'];
+        yield ['xh_ZA'];
+        yield ['xog'];
+        yield ['yav'];
+        yield ['yi'];
+        yield ['yi_US'];
+        yield ['yo'];
+        yield ['yo_BJ'];
+        yield ['yo_NG'];
+        yield ['yue'];
+        yield ['yue_HK'];
+        yield ['yue_Hans'];
+        yield ['yue_Hant'];
+        yield ['yuw'];
+        yield ['yuw_PG'];
+        yield ['zh'];
+        yield ['zh_CN'];
+        yield ['zh_HK'];
+        yield ['zh_Hans'];
+        yield ['zh_Hans_HK'];
+        yield ['zh_Hans_MO'];
+        yield ['zh_Hans_SG'];
+        yield ['zh_Hant'];
+        yield ['zh_Hant_HK'];
+        yield ['zh_Hant_MO'];
+        yield ['zh_Hant_TW'];
+        yield ['zh_MO'];
+        yield ['zh_SG'];
+        yield ['zh_TW'];
+        yield ['zh_YUE'];
+        yield ['zu'];
+        yield ['zu_ZA'];
     }
 }

--- a/tests/Carbon/GettersTest.php
+++ b/tests/Carbon/GettersTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Tests\Carbon;
 
 use Carbon\Carbon;
+use Generator;
 use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
@@ -239,22 +240,20 @@ class GettersTest extends AbstractTestCase
         $this->assertSame($age, $d->age);
     }
 
-    public function dataProviderTestQuarter()
+    public function dataProviderTestQuarter(): Generator
     {
-        return [
-            [1, 1],
-            [2, 1],
-            [3, 1],
-            [4, 2],
-            [5, 2],
-            [6, 2],
-            [7, 3],
-            [8, 3],
-            [9, 3],
-            [10, 4],
-            [11, 4],
-            [12, 4],
-        ];
+        yield [1, 1];
+        yield [2, 1];
+        yield [3, 1];
+        yield [4, 2];
+        yield [5, 2];
+        yield [6, 2];
+        yield [7, 3];
+        yield [8, 3];
+        yield [9, 3];
+        yield [10, 4];
+        yield [11, 4];
+        yield [12, 4];
     }
 
     /**

--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -14,6 +14,7 @@ namespace Tests\Carbon;
 use \DateTime;
 use BadMethodCallException;
 use Carbon\Carbon;
+use Generator;
 use InvalidArgumentException;
 use stdClass;
 use Tests\AbstractTestCase;
@@ -925,50 +926,46 @@ class IsTest extends AbstractTestCase
         $this->assertFalse(Carbon::hasFormatWithModifiers('1975705-01', 'Y#m#d'));
     }
 
-    public function getFormatLetters()
+    public function getFormatLetters(): Generator
     {
-        return array_map(static function ($letter) {
-            return [$letter];
-        }, [
-            'd',
-            'D',
-            'j',
-            'l',
-            'N',
-            'S',
-            'w',
-            'z',
-            'W',
-            'F',
-            'm',
-            'M',
-            'n',
-            't',
-            'L',
-            'o',
-            'Y',
-            'y',
-            'a',
-            'A',
-            'B',
-            'g',
-            'G',
-            'h',
-            'H',
-            'i',
-            's',
-            'u',
-            'v',
-            'e',
-            'I',
-            'O',
-            'P',
-            'T',
-            'Z',
-            'U',
-            'c',
-            'r',
-        ]);
+        yield ['d'];
+        yield ['D'];
+        yield ['j'];
+        yield ['l'];
+        yield ['N'];
+        yield ['S'];
+        yield ['w'];
+        yield ['z'];
+        yield ['W'];
+        yield ['F'];
+        yield ['m'];
+        yield ['M'];
+        yield ['n'];
+        yield ['t'];
+        yield ['L'];
+        yield ['o'];
+        yield ['Y'];
+        yield ['y'];
+        yield ['a'];
+        yield ['A'];
+        yield ['B'];
+        yield ['g'];
+        yield ['G'];
+        yield ['h'];
+        yield ['H'];
+        yield ['i'];
+        yield ['s'];
+        yield ['u'];
+        yield ['v'];
+        yield ['e'];
+        yield ['I'];
+        yield ['O'];
+        yield ['P'];
+        yield ['T'];
+        yield ['Z'];
+        yield ['U'];
+        yield ['c'];
+        yield ['r'];
     }
 
     /**

--- a/tests/Carbon/IssetTest.php
+++ b/tests/Carbon/IssetTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Tests\Carbon;
 
 use Carbon\Carbon;
+use Generator;
 use Tests\AbstractTestCase;
 
 class IssetTest extends AbstractTestCase
@@ -21,34 +22,32 @@ class IssetTest extends AbstractTestCase
         $this->assertFalse(isset(Carbon::create(1234, 5, 6, 7, 8, 9)->sdfsdfss));
     }
 
-    public function providerTestIssetReturnTrueForProperties()
+    public function providerTestIssetReturnTrueForProperties(): Generator
     {
-        return [
-            ['age'],
-            ['day'],
-            ['dayOfWeek'],
-            ['dayOfYear'],
-            ['daysInMonth'],
-            ['dst'],
-            ['hour'],
-            ['local'],
-            ['micro'],
-            ['minute'],
-            ['month'],
-            ['offset'],
-            ['offsetHours'],
-            ['quarter'],
-            ['second'],
-            ['timestamp'],
-            ['timezone'],
-            ['timezoneName'],
-            ['tz'],
-            ['tzName'],
-            ['utc'],
-            ['weekOfMonth'],
-            ['weekOfYear'],
-            ['year'],
-        ];
+        yield ['age'];
+        yield ['day'];
+        yield ['dayOfWeek'];
+        yield ['dayOfYear'];
+        yield ['daysInMonth'];
+        yield ['dst'];
+        yield ['hour'];
+        yield ['local'];
+        yield ['micro'];
+        yield ['minute'];
+        yield ['month'];
+        yield ['offset'];
+        yield ['offsetHours'];
+        yield ['quarter'];
+        yield ['second'];
+        yield ['timestamp'];
+        yield ['timezone'];
+        yield ['timezoneName'];
+        yield ['tz'];
+        yield ['tzName'];
+        yield ['utc'];
+        yield ['weekOfMonth'];
+        yield ['weekOfYear'];
+        yield ['year'];
     }
 
     /**

--- a/tests/Carbon/LocalizationTest.php
+++ b/tests/Carbon/LocalizationTest.php
@@ -16,6 +16,7 @@ use Carbon\CarbonInterval;
 use Carbon\Exceptions\NotLocaleAwareException;
 use Carbon\Language;
 use Carbon\Translator;
+use Generator;
 use InvalidArgumentException;
 use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Component\Translation\Loader\ArrayLoader;
@@ -169,148 +170,146 @@ class LocalizationTest extends AbstractTestCase
      * @see \Tests\Carbon\LocalizationTest::testSetLocale
      * @see \Tests\Carbon\LocalizationTest::testSetTranslator
      *
-     * @return array
+     * @return \Generator
      */
-    public function providerLocales()
+    public function providerLocales(): Generator
     {
-        return [
-            ['af'],
-            ['ar'],
-            ['ar_DZ'],
-            ['ar_KW'],
-            ['ar_LY'],
-            ['ar_MA'],
-            ['ar_SA'],
-            ['ar_Shakl'],
-            ['ar_TN'],
-            ['az'],
-            ['be'],
-            ['bg'],
-            ['bm'],
-            ['bn'],
-            ['bo'],
-            ['br'],
-            ['bs'],
-            ['bs_BA'],
-            ['ca'],
-            ['cs'],
-            ['cv'],
-            ['cy'],
-            ['da'],
-            ['de'],
-            ['de_AT'],
-            ['de_CH'],
-            ['dv'],
-            ['dv_MV'],
-            ['el'],
-            ['en'],
-            ['en_AU'],
-            ['en_CA'],
-            ['en_GB'],
-            ['en_IE'],
-            ['en_IL'],
-            ['en_NZ'],
-            ['eo'],
-            ['es'],
-            ['es_DO'],
-            ['es_US'],
-            ['et'],
-            ['eu'],
-            ['fa'],
-            ['fi'],
-            ['fo'],
-            ['fr'],
-            ['fr_CA'],
-            ['fr_CH'],
-            ['fy'],
-            ['gd'],
-            ['gl'],
-            ['gom_Latn'],
-            ['gu'],
-            ['he'],
-            ['hi'],
-            ['hr'],
-            ['hu'],
-            ['hy'],
-            ['hy_AM'],
-            ['id'],
-            ['is'],
-            ['it'],
-            ['ja'],
-            ['jv'],
-            ['ka'],
-            ['kk'],
-            ['km'],
-            ['kn'],
-            ['ko'],
-            ['ku'],
-            ['ky'],
-            ['lb'],
-            ['lo'],
-            ['lt'],
-            ['lv'],
-            ['me'],
-            ['mi'],
-            ['mk'],
-            ['ml'],
-            ['mn'],
-            ['mr'],
-            ['ms'],
-            ['ms_MY'],
-            ['mt'],
-            ['my'],
-            ['nb'],
-            ['ne'],
-            ['nl'],
-            ['nl_BE'],
-            ['nn'],
-            ['no'],
-            ['oc'],
-            ['pa_IN'],
-            ['pl'],
-            ['ps'],
-            ['pt'],
-            ['pt_BR'],
-            ['ro'],
-            ['ru'],
-            ['sd'],
-            ['se'],
-            ['sh'],
-            ['si'],
-            ['sk'],
-            ['sl'],
-            ['sq'],
-            ['sr'],
-            ['sr_Cyrl'],
-            ['sr_Cyrl_ME'],
-            ['sr_Latn_ME'],
-            ['sr_ME'],
-            ['ss'],
-            ['sv'],
-            ['sw'],
-            ['ta'],
-            ['te'],
-            ['tet'],
-            ['tg'],
-            ['th'],
-            ['tl_PH'],
-            ['tlh'],
-            ['tr'],
-            ['tzl'],
-            ['tzm'],
-            ['tzm_Latn'],
-            ['ug_CN'],
-            ['uk'],
-            ['ur'],
-            ['uz'],
-            ['uz_Latn'],
-            ['vi'],
-            ['yo'],
-            ['zh'],
-            ['zh_CN'],
-            ['zh_HK'],
-            ['zh_TW'],
-        ];
+        yield ['af'];
+        yield ['ar'];
+        yield ['ar_DZ'];
+        yield ['ar_KW'];
+        yield ['ar_LY'];
+        yield ['ar_MA'];
+        yield ['ar_SA'];
+        yield ['ar_Shakl'];
+        yield ['ar_TN'];
+        yield ['az'];
+        yield ['be'];
+        yield ['bg'];
+        yield ['bm'];
+        yield ['bn'];
+        yield ['bo'];
+        yield ['br'];
+        yield ['bs'];
+        yield ['bs_BA'];
+        yield ['ca'];
+        yield ['cs'];
+        yield ['cv'];
+        yield ['cy'];
+        yield ['da'];
+        yield ['de'];
+        yield ['de_AT'];
+        yield ['de_CH'];
+        yield ['dv'];
+        yield ['dv_MV'];
+        yield ['el'];
+        yield ['en'];
+        yield ['en_AU'];
+        yield ['en_CA'];
+        yield ['en_GB'];
+        yield ['en_IE'];
+        yield ['en_IL'];
+        yield ['en_NZ'];
+        yield ['eo'];
+        yield ['es'];
+        yield ['es_DO'];
+        yield ['es_US'];
+        yield ['et'];
+        yield ['eu'];
+        yield ['fa'];
+        yield ['fi'];
+        yield ['fo'];
+        yield ['fr'];
+        yield ['fr_CA'];
+        yield ['fr_CH'];
+        yield ['fy'];
+        yield ['gd'];
+        yield ['gl'];
+        yield ['gom_Latn'];
+        yield ['gu'];
+        yield ['he'];
+        yield ['hi'];
+        yield ['hr'];
+        yield ['hu'];
+        yield ['hy'];
+        yield ['hy_AM'];
+        yield ['id'];
+        yield ['is'];
+        yield ['it'];
+        yield ['ja'];
+        yield ['jv'];
+        yield ['ka'];
+        yield ['kk'];
+        yield ['km'];
+        yield ['kn'];
+        yield ['ko'];
+        yield ['ku'];
+        yield ['ky'];
+        yield ['lb'];
+        yield ['lo'];
+        yield ['lt'];
+        yield ['lv'];
+        yield ['me'];
+        yield ['mi'];
+        yield ['mk'];
+        yield ['ml'];
+        yield ['mn'];
+        yield ['mr'];
+        yield ['ms'];
+        yield ['ms_MY'];
+        yield ['mt'];
+        yield ['my'];
+        yield ['nb'];
+        yield ['ne'];
+        yield ['nl'];
+        yield ['nl_BE'];
+        yield ['nn'];
+        yield ['no'];
+        yield ['oc'];
+        yield ['pa_IN'];
+        yield ['pl'];
+        yield ['ps'];
+        yield ['pt'];
+        yield ['pt_BR'];
+        yield ['ro'];
+        yield ['ru'];
+        yield ['sd'];
+        yield ['se'];
+        yield ['sh'];
+        yield ['si'];
+        yield ['sk'];
+        yield ['sl'];
+        yield ['sq'];
+        yield ['sr'];
+        yield ['sr_Cyrl'];
+        yield ['sr_Cyrl_ME'];
+        yield ['sr_Latn_ME'];
+        yield ['sr_ME'];
+        yield ['ss'];
+        yield ['sv'];
+        yield ['sw'];
+        yield ['ta'];
+        yield ['te'];
+        yield ['tet'];
+        yield ['tg'];
+        yield ['th'];
+        yield ['tl_PH'];
+        yield ['tlh'];
+        yield ['tr'];
+        yield ['tzl'];
+        yield ['tzm'];
+        yield ['tzm_Latn'];
+        yield ['ug_CN'];
+        yield ['uk'];
+        yield ['ur'];
+        yield ['uz'];
+        yield ['uz_Latn'];
+        yield ['vi'];
+        yield ['yo'];
+        yield ['zh'];
+        yield ['zh_CN'];
+        yield ['zh_HK'];
+        yield ['zh_TW'];
     }
 
     /**
@@ -352,20 +351,18 @@ class LocalizationTest extends AbstractTestCase
     /**
      * @see \Tests\Carbon\LocalizationTest::testSetLocaleWithMalformedLocale
      *
-     * @return array
+     * @return \Generator
      */
-    public function dataProviderTestSetLocaleWithMalformedLocale()
+    public function dataProviderTestSetLocaleWithMalformedLocale(): Generator
     {
-        return [
-            ['DE'],
-            ['pt-BR'],
-            ['pt-br'],
-            ['PT-br'],
-            ['PT-BR'],
-            ['pt_br'],
-            ['PT_br'],
-            ['PT_BR'],
-        ];
+        yield ['DE'];
+        yield ['pt-BR'];
+        yield ['pt-br'];
+        yield ['PT-br'];
+        yield ['PT-BR'];
+        yield ['pt_br'];
+        yield ['PT_br'];
+        yield ['PT_BR'];
     }
 
     /**

--- a/tests/Carbon/ModifyNearDSTChangeTest.php
+++ b/tests/Carbon/ModifyNearDSTChangeTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Tests\Carbon;
 
 use Carbon\Carbon;
+use Generator;
 use Tests\AbstractTestCase;
 
 class ModifyNearDSTChangeTest extends AbstractTestCase
@@ -48,25 +49,21 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
         $this->assertSame($expected, $date->format('c'));
     }
 
-    public function getTransitionTests()
+    public function getTransitionTests(): Generator
     {
-
         // arguments:
         // - Date string to Carbon::parse in America/New_York.
         // - Hours to add
         // - Resulting string in 'c' format
-        $tests = [
-            // testForwardTransition
-            // When standard time was about to reach 2010-03-14T02:00:00-05:00 clocks were turned forward 1 hour to
-            // 2010-03-14T03:00:00-04:00 local daylight time instead
-            ['2010-03-14T00:00:00', 24, '2010-03-15T00:00:00-04:00'],
 
-            // testBackwardTransition
-            // When local daylight time was about to reach 2010-11-07T02:00:00-04:00 clocks were turned backward 1 hour
-            // to 2010-11-07T01:00:00-05:00 local standard time instead
-            ['2010-11-07T00:00:00', 24, '2010-11-08T00:00:00-05:00'],
-        ];
+        // testForwardTransition
+        // When standard time was about to reach 2010-03-14T02:00:00-05:00 clocks were turned forward 1 hour to
+        // 2010-03-14T03:00:00-04:00 local daylight time instead
+        yield ['2010-03-14T00:00:00', 24, '2010-03-15T00:00:00-04:00'];
 
-        return $tests;
+        // testBackwardTransition
+        // When local daylight time was about to reach 2010-11-07T02:00:00-04:00 clocks were turned backward 1 hour
+        // to 2010-11-07T01:00:00-05:00 local standard time instead
+        yield ['2010-11-07T00:00:00', 24, '2010-11-08T00:00:00-05:00'];
     }
 }

--- a/tests/Carbon/SerializationTest.php
+++ b/tests/Carbon/SerializationTest.php
@@ -13,6 +13,7 @@ namespace Tests\Carbon;
 
 use Carbon\Carbon;
 use DateTime;
+use Generator;
 use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionObject;
@@ -63,15 +64,13 @@ class SerializationTest extends AbstractTestCase
         $this->assertSame('mercredi 18:30:11.654321', $copy->tz('Europe/Paris')->isoFormat('dddd HH:mm:ss.SSSSSS'));
     }
 
-    public function providerTestFromUnserializedWithInvalidValue()
+    public function providerTestFromUnserializedWithInvalidValue(): Generator
     {
-        return [
-            [null],
-            [true],
-            [false],
-            [123],
-            ['foobar'],
-        ];
+        yield [null];
+        yield [true];
+        yield [false];
+        yield [123];
+        yield ['foobar'];
     }
 
     /**

--- a/tests/Carbon/SettersTest.php
+++ b/tests/Carbon/SettersTest.php
@@ -14,6 +14,7 @@ namespace Tests\Carbon;
 use Carbon\Carbon;
 use DateTimeZone;
 use Exception;
+use Generator;
 use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
@@ -507,16 +508,14 @@ class SettersTest extends AbstractTestCase
         $this->assertCarbon($d, 2016, 2, 12, $hour, $minute, $second);
     }
 
-    public function dataProviderTestSetTimeFromTimeString()
+    public function dataProviderTestSetTimeFromTimeString(): Generator
     {
-        return [
-            [9, 15, 30, '09:15:30'],
-            [9, 15, 0, '09:15'],
-            [9, 0, 0, '09'],
-            [9, 5, 3, '9:5:3'],
-            [9, 5, 0, '9:5'],
-            [9, 0, 0, '9'],
-        ];
+        yield [9, 15, 30, '09:15:30'];
+        yield [9, 15, 0, '09:15'];
+        yield [9, 0, 0, '09'];
+        yield [9, 5, 3, '9:5:3'];
+        yield [9, 5, 0, '9:5'];
+        yield [9, 0, 0, '9'];
     }
 
     public function testWeekendDaysSetter()

--- a/tests/Carbon/StartEndOfTest.php
+++ b/tests/Carbon/StartEndOfTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Tests\Carbon;
 
 use Carbon\Carbon;
+use Generator;
 use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
@@ -439,22 +440,20 @@ class StartEndOfTest extends AbstractTestCase
         $this->assertInstanceOfCarbon($dt->startOfQuarter());
     }
 
-    public function dataProviderTestStartOfQuarter()
+    public function dataProviderTestStartOfQuarter(): Generator
     {
-        return [
-            [1, 1],
-            [2, 1],
-            [3, 1],
-            [4, 4],
-            [5, 4],
-            [6, 4],
-            [7, 7],
-            [8, 7],
-            [9, 7],
-            [10, 10],
-            [11, 10],
-            [12, 10],
-        ];
+        yield [1, 1];
+        yield [2, 1];
+        yield [3, 1];
+        yield [4, 4];
+        yield [5, 4];
+        yield [6, 4];
+        yield [7, 7];
+        yield [8, 7];
+        yield [9, 7];
+        yield [10, 10];
+        yield [11, 10];
+        yield [12, 10];
     }
 
     /**
@@ -475,22 +474,20 @@ class StartEndOfTest extends AbstractTestCase
         $this->assertInstanceOfCarbon($dt->endOfQuarter());
     }
 
-    public function dataProviderTestEndOfQuarter()
+    public function dataProviderTestEndOfQuarter(): Generator
     {
-        return [
-            [1, 3, 31],
-            [2, 3, 31],
-            [3, 3, 31],
-            [4, 6, 30],
-            [5, 6, 30],
-            [6, 6, 30],
-            [7, 9, 30],
-            [8, 9, 30],
-            [9, 9, 30],
-            [10, 12, 31],
-            [11, 12, 31],
-            [12, 12, 31],
-        ];
+        yield [1, 3, 31];
+        yield [2, 3, 31];
+        yield [3, 3, 31];
+        yield [4, 6, 30];
+        yield [5, 6, 30];
+        yield [6, 6, 30];
+        yield [7, 9, 30];
+        yield [8, 9, 30];
+        yield [9, 9, 30];
+        yield [10, 12, 31];
+        yield [11, 12, 31];
+        yield [12, 12, 31];
     }
 
     /**

--- a/tests/CarbonImmutable/IsTest.php
+++ b/tests/CarbonImmutable/IsTest.php
@@ -13,6 +13,7 @@ namespace Tests\CarbonImmutable;
 
 use \DateTime;
 use Carbon\CarbonImmutable as Carbon;
+use Generator;
 use InvalidArgumentException;
 use stdClass;
 use Tests\AbstractTestCase;
@@ -912,50 +913,46 @@ class IsTest extends AbstractTestCase
         $this->assertFalse(Carbon::hasFormat('12/30/2019', 'd/m/Y'));
     }
 
-    public function getFormatLetters()
+    public function getFormatLetters(): Generator
     {
-        return array_map(static function ($letter) {
-            return [$letter];
-        }, [
-            'd',
-            'D',
-            'j',
-            'l',
-            'N',
-            'S',
-            'w',
-            'z',
-            'W',
-            'F',
-            'm',
-            'M',
-            'n',
-            't',
-            'L',
-            'o',
-            'Y',
-            'y',
-            'a',
-            'A',
-            'B',
-            'g',
-            'G',
-            'h',
-            'H',
-            'i',
-            's',
-            'u',
-            'v',
-            'e',
-            'I',
-            'O',
-            'P',
-            'T',
-            'Z',
-            'U',
-            'c',
-            'r',
-        ]);
+        yield ['d'];
+        yield ['D'];
+        yield ['j'];
+        yield ['l'];
+        yield ['N'];
+        yield ['S'];
+        yield ['w'];
+        yield ['z'];
+        yield ['W'];
+        yield ['F'];
+        yield ['m'];
+        yield ['M'];
+        yield ['n'];
+        yield ['t'];
+        yield ['L'];
+        yield ['o'];
+        yield ['Y'];
+        yield ['y'];
+        yield ['a'];
+        yield ['A'];
+        yield ['B'];
+        yield ['g'];
+        yield ['G'];
+        yield ['h'];
+        yield ['H'];
+        yield ['i'];
+        yield ['s'];
+        yield ['u'];
+        yield ['v'];
+        yield ['e'];
+        yield ['I'];
+        yield ['O'];
+        yield ['P'];
+        yield ['T'];
+        yield ['Z'];
+        yield ['U'];
+        yield ['c'];
+        yield ['r'];
     }
 
     /**

--- a/tests/CarbonImmutable/ModifyNearDSTChangeTest.php
+++ b/tests/CarbonImmutable/ModifyNearDSTChangeTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Tests\CarbonImmutable;
 
 use Carbon\CarbonImmutable as Carbon;
+use Generator;
 use Tests\AbstractTestCase;
 
 class ModifyNearDSTChangeTest extends AbstractTestCase
@@ -48,25 +49,21 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
         $this->assertSame($expected, $date->format('c'));
     }
 
-    public function getTransitionTests()
+    public function getTransitionTests(): Generator
     {
-
         // arguments:
         // - Date string to Carbon::parse in America/New_York.
         // - Hours to add
         // - Resulting string in 'c' format
-        $tests = [
-            // testForwardTransition
-            // When standard time was about to reach 2010-03-14T02:00:00-05:00 clocks were turned forward 1 hour to
-            // 2010-03-14T03:00:00-04:00 local daylight time instead
-            ['2010-03-14T00:00:00', 24, '2010-03-15T00:00:00-04:00'],
 
-            // testBackwardTransition
-            // When local daylight time was about to reach 2010-11-07T02:00:00-04:00 clocks were turned backward 1 hour
-            // to 2010-11-07T01:00:00-05:00 local standard time instead
-            ['2010-11-07T00:00:00', 24, '2010-11-08T00:00:00-05:00'],
-        ];
+        // testForwardTransition
+        // When standard time was about to reach 2010-03-14T02:00:00-05:00 clocks were turned forward 1 hour to
+        // 2010-03-14T03:00:00-04:00 local daylight time instead
+        yield ['2010-03-14T00:00:00', 24, '2010-03-15T00:00:00-04:00'];
 
-        return $tests;
+        // testBackwardTransition
+        // When local daylight time was about to reach 2010-11-07T02:00:00-04:00 clocks were turned backward 1 hour
+        // to 2010-11-07T01:00:00-05:00 local standard time instead
+        yield ['2010-11-07T00:00:00', 24, '2010-11-08T00:00:00-05:00'];
     }
 }

--- a/tests/CarbonInterval/AddTest.php
+++ b/tests/CarbonInterval/AddTest.php
@@ -16,6 +16,7 @@ use Carbon\CarbonInterval;
 use DateInterval;
 use DateTime;
 use DateTimeImmutable;
+use Generator;
 use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
@@ -82,18 +83,16 @@ class AddTest extends AbstractTestCase
         $this->assertCarbonInterval($ci, 4, 3, 28, 8, 10, 11);
     }
 
-    public function provideAddsResults()
+    public function provideAddsResults(): Generator
     {
-        return [
-            [5, 2, 7],
-            [-5, -2, -7],
-            [-5, 2, -3],
-            [5, -2, 3],
-            [2, 5, 7],
-            [-2, -5, -7],
-            [-2, 5, 3],
-            [2, -5, -3],
-        ];
+        yield [5, 2, 7];
+        yield [-5, -2, -7];
+        yield [-5, 2, -3];
+        yield [5, -2, 3];
+        yield [2, 5, 7];
+        yield [-2, -5, -7];
+        yield [-2, 5, 3];
+        yield [2, -5, -3];
     }
 
     /**

--- a/tests/CarbonInterval/CascadeTest.php
+++ b/tests/CarbonInterval/CascadeTest.php
@@ -5,6 +5,7 @@ namespace Tests\CarbonInterval;
 
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
+use Generator;
 use Tests\AbstractTestCase;
 
 class CascadeTest extends AbstractTestCase
@@ -34,15 +35,13 @@ class CascadeTest extends AbstractTestCase
         $this->assertIntervalSpec($interval, $expected, true);
     }
 
-    public function provideIntervalSpecs()
+    public function provideIntervalSpecs(): Generator
     {
-        return [
-            ['3600s',                        'PT1H'],
-            ['10000s',                       'PT2H46M40S'],
-            ['1276d',                        'P3Y9M16D'],
-            ['47d 14h',                      'P1M19DT14H'],
-            ['2y 123mo 5w 6d 47h 160m 217s', 'P12Y4M15DT1H43M37S'],
-        ];
+        yield ['3600s', 'PT1H'];
+        yield ['10000s', 'PT2H46M40S'];
+        yield ['1276d', 'P3Y9M16D'];
+        yield ['47d 14h', 'P1M19DT14H'];
+        yield ['2y 123mo 5w 6d 47h 160m 217s', 'P12Y4M15DT1H43M37S'];
     }
 
     /**
@@ -67,138 +66,136 @@ class CascadeTest extends AbstractTestCase
         $this->assertIntervalSpec($interval, $expected, 1 - $expectingInversion);
     }
 
-    public function provideMixedSignsIntervalSpecs()
+    public function provideMixedSignsIntervalSpecs(): Generator
     {
-        return [
+        yield [
             [
-                [
-                    'hours' => 1,
-                    'minutes' => -30,
-                ],
-                'PT30M',
-                0,
+                'hours' => 1,
+                'minutes' => -30,
             ],
+            'PT30M',
+            0,
+        ];
+        yield [
             [
-                [
-                    'hours' => 1,
-                    'minutes' => -90,
-                ],
-                'PT30M',
-                1,
+                'hours' => 1,
+                'minutes' => -90,
             ],
+            'PT30M',
+            1,
+        ];
+        yield [
             [
-                [
-                    'hours' => 1,
-                    'minutes' => -90,
-                    'seconds' => 3660,
-                ],
-                'PT31M',
-                0,
+                'hours' => 1,
+                'minutes' => -90,
+                'seconds' => 3660,
             ],
+            'PT31M',
+            0,
+        ];
+        yield [
             [
-                [
-                    'hours' => 1,
-                    'minutes' => -90,
-                    'seconds' => 3540,
-                ],
-                'PT29M',
-                0,
+                'hours' => 1,
+                'minutes' => -90,
+                'seconds' => 3540,
             ],
+            'PT29M',
+            0,
+        ];
+        yield [
             [
-                [
-                    'hours' => 1,
-                    'minutes' => 90,
-                    'seconds' => -3540,
-                ],
-                'PT1H31M',
-                0,
+                'hours' => 1,
+                'minutes' => 90,
+                'seconds' => -3540,
             ],
+            'PT1H31M',
+            0,
+        ];
+        yield [
             [
-                [
-                    'hours' => 1,
-                    'minutes' => 90,
-                    'seconds' => -3660,
-                ],
-                'PT1H29M',
-                0,
+                'hours' => 1,
+                'minutes' => 90,
+                'seconds' => -3660,
             ],
+            'PT1H29M',
+            0,
+        ];
+        yield [
             [
-                [
-                    'hours' => -1,
-                    'minutes' => 90,
-                    'seconds' => -3660,
-                ],
-                'PT31M',
-                1,
+                'hours' => -1,
+                'minutes' => 90,
+                'seconds' => -3660,
             ],
+            'PT31M',
+            1,
+        ];
+        yield [
             [
-                [
-                    'hours' => -1,
-                    'minutes' => 61,
-                    'seconds' => -120,
-                ],
-                'PT1M',
-                1,
+                'hours' => -1,
+                'minutes' => 61,
+                'seconds' => -120,
             ],
+            'PT1M',
+            1,
+        ];
+        yield [
             [
-                [
-                    'days' => 48,
-                    'hours' => -8,
-                ],
-                'P1M19DT16H',
-                0,
+                'days' => 48,
+                'hours' => -8,
             ],
+            'P1M19DT16H',
+            0,
+        ];
+        yield [
             [
-                [
-                    'days' => 48,
-                    'hours' => -28,
-                ],
-                'P1M18DT20H',
-                0,
+                'days' => 48,
+                'hours' => -28,
             ],
+            'P1M18DT20H',
+            0,
+        ];
+        yield [
             [
-                [
-                    'hours' => 1,
-                    'seconds' => -3615,
-                ],
-                'PT15S',
-                1,
+                'hours' => 1,
+                'seconds' => -3615,
             ],
+            'PT15S',
+            1,
+        ];
+        yield [
             [
-                [
-                    'hours' => -1,
-                    'seconds' => 3615,
-                ],
-                'PT15S',
-                0,
+                'hours' => -1,
+                'seconds' => 3615,
             ],
+            'PT15S',
+            0,
+        ];
+        yield [
             [
-                [
-                    'hours' => 1,
-                    'seconds' => -59,
-                ],
-                'PT59M1S',
-                0,
+                'hours' => 1,
+                'seconds' => -59,
             ],
+            'PT59M1S',
+            0,
+        ];
+        yield [
             [
-                [
-                    'hours' => -1,
-                    'seconds' => 59,
-                ],
-                'PT59M1S',
-                1,
+                'hours' => -1,
+                'seconds' => 59,
             ],
+            'PT59M1S',
+            1,
+        ];
+        yield [
             [
-                [
-                    'years' => 94,
-                    'months' => 11,
-                    'days' => 24,
-                    'hours' => 3848,
-                    'microseconds' => 7991,
-                ],
-                'P95Y5M16DT8H',
-                0,
+                'years' => 94,
+                'months' => 11,
+                'days' => 24,
+                'hours' => 3848,
+                'microseconds' => 7991,
             ],
+            'P95Y5M16DT8H',
+            0,
         ];
     }
 
@@ -229,15 +226,13 @@ class CascadeTest extends AbstractTestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function provideCustomIntervalSpecs()
+    public function provideCustomIntervalSpecs(): Generator
     {
-        return [
-            ['3600s',                        '1h'],
-            ['10000s',                       '2h 46m 40s'],
-            ['1276d',                        '255w 1d'],
-            ['47d 14h',                      '9w 3d 6h'],
-            ['2y 123mo 5w 6d 47h 160m 217s', '2yrs 123mos 7w 2d 1h 43m 37s'],
-        ];
+        yield ['3600s', '1h'];
+        yield ['10000s', '2h 46m 40s'];
+        yield ['1276d', '255w 1d'];
+        yield ['47d 14h', '9w 3d 6h'];
+        yield ['2y 123mo 5w 6d 47h 160m 217s', '2yrs 123mos 7w 2d 1h 43m 37s'];
     }
 
     /**

--- a/tests/CarbonInterval/FromStringTest.php
+++ b/tests/CarbonInterval/FromStringTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Tests\CarbonInterval;
 
 use Carbon\CarbonInterval;
+use Generator;
 use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
@@ -22,80 +23,78 @@ class FromStringTest extends AbstractTestCase
         $this->assertEquals($expected, $result, "'$string' does not return expected interval.");
     }
 
-    public function provideValidStrings()
+    public function provideValidStrings(): Generator
     {
-        return [
-            // zero interval
-            ['', new CarbonInterval(0)],
+        // zero interval
+        yield ['', new CarbonInterval(0)];
 
-            // single values
-            ['1y', new CarbonInterval(1)],
-            ['1mo', new CarbonInterval(0, 1)],
-            ['1w', new CarbonInterval(0, 0, 1)],
-            ['1d', new CarbonInterval(0, 0, 0, 1)],
-            ['1h', new CarbonInterval(0, 0, 0, 0, 1)],
-            ['1m', new CarbonInterval(0, 0, 0, 0, 0, 1)],
-            ['1s', new CarbonInterval(0, 0, 0, 0, 0, 0, 1)],
-            ['1ms', new CarbonInterval(0, 0, 0, 0, 0, 0, 0, 1000)],
-            ['1µs', new CarbonInterval(0, 0, 0, 0, 0, 0, 0, 1)],
+        // single values
+        yield ['1y', new CarbonInterval(1)];
+        yield ['1mo', new CarbonInterval(0, 1)];
+        yield ['1w', new CarbonInterval(0, 0, 1)];
+        yield ['1d', new CarbonInterval(0, 0, 0, 1)];
+        yield ['1h', new CarbonInterval(0, 0, 0, 0, 1)];
+        yield ['1m', new CarbonInterval(0, 0, 0, 0, 0, 1)];
+        yield ['1s', new CarbonInterval(0, 0, 0, 0, 0, 0, 1)];
+        yield ['1ms', new CarbonInterval(0, 0, 0, 0, 0, 0, 0, 1000)];
+        yield ['1µs', new CarbonInterval(0, 0, 0, 0, 0, 0, 0, 1)];
 
-            // single values with space
-            ['1 y', new CarbonInterval(1)],
-            ['1 mo', new CarbonInterval(0, 1)],
-            ['1 w', new CarbonInterval(0, 0, 1)],
+        // single values with space
+        yield ['1 y', new CarbonInterval(1)];
+        yield ['1 mo', new CarbonInterval(0, 1)];
+        yield ['1 w', new CarbonInterval(0, 0, 1)];
 
-            // fractions with integer result
-            ['0.571428571429w', new CarbonInterval(0, 0, 0, 4)],
-            ['0.5d', new CarbonInterval(0, 0, 0, 0, 12)],
-            ['0.5h', new CarbonInterval(0, 0, 0, 0, 0, 30)],
-            ['0.5m', new CarbonInterval(0, 0, 0, 0, 0, 0, 30)],
+        // fractions with integer result
+        yield ['0.571428571429w', new CarbonInterval(0, 0, 0, 4)];
+        yield ['0.5d', new CarbonInterval(0, 0, 0, 0, 12)];
+        yield ['0.5h', new CarbonInterval(0, 0, 0, 0, 0, 30)];
+        yield ['0.5m', new CarbonInterval(0, 0, 0, 0, 0, 0, 30)];
 
-            // fractions with float result
-            ['1.5w', new CarbonInterval(0, 0, 1, 3, 12)],
-            ['2.34d', new CarbonInterval(0, 0, 0, 2, 8, 9, 36)],
-            ['3.12h', new CarbonInterval(0, 0, 0, 0, 3, 7, 12)],
-            ['3.129h', new CarbonInterval(0, 0, 0, 0, 3, 7, 44, 400000)],
-            ['4.24m', new CarbonInterval(0, 0, 0, 0, 0, 4, 14, 400000)],
-            ['3.56s', new CarbonInterval(0, 0, 0, 0, 0, 0, 3, 560000)],
-            ['3.56ms', new CarbonInterval(0, 0, 0, 0, 0, 0, 0, 3560)],
+        // fractions with float result
+        yield ['1.5w', new CarbonInterval(0, 0, 1, 3, 12)];
+        yield ['2.34d', new CarbonInterval(0, 0, 0, 2, 8, 9, 36)];
+        yield ['3.12h', new CarbonInterval(0, 0, 0, 0, 3, 7, 12)];
+        yield ['3.129h', new CarbonInterval(0, 0, 0, 0, 3, 7, 44, 400000)];
+        yield ['4.24m', new CarbonInterval(0, 0, 0, 0, 0, 4, 14, 400000)];
+        yield ['3.56s', new CarbonInterval(0, 0, 0, 0, 0, 0, 3, 560000)];
+        yield ['3.56ms', new CarbonInterval(0, 0, 0, 0, 0, 0, 0, 3560)];
 
-            // combinations
-            ['2w 3d', new CarbonInterval(0, 0, 0, 17)],
-            ['1y 2mo 1.5w 3d', new CarbonInterval(1, 2, 1, 6, 12)],
+        // combinations
+        yield ['2w 3d', new CarbonInterval(0, 0, 0, 17)];
+        yield ['1y 2mo 1.5w 3d', new CarbonInterval(1, 2, 1, 6, 12)];
 
-            // multi same values
-            ['1y 2y', new CarbonInterval(3)],
-            ['1mo 20mo', new CarbonInterval(0, 21)],
-            ['1w 2w 3w', new CarbonInterval(0, 0, 6)],
-            ['10d 20d 30d', new CarbonInterval(0, 0, 0, 60)],
-            ['5h 15h 25h', new CarbonInterval(0, 0, 0, 0, 45)],
-            ['3m 3m 3m 1m', new CarbonInterval(0, 0, 0, 0, 0, 10)],
-            ['55s 45s 1s 2s 3s 4s', new CarbonInterval(0, 0, 0, 0, 0, 0, 110)],
-            ['1500ms 1623555µs', new CarbonInterval(0, 0, 0, 0, 0, 0, 0, 3123555)],
-            ['430 milli', new CarbonInterval(0, 0, 0, 0, 0, 0, 0, 430000)],
+        // multi same values
+        yield ['1y 2y', new CarbonInterval(3)];
+        yield ['1mo 20mo', new CarbonInterval(0, 21)];
+        yield ['1w 2w 3w', new CarbonInterval(0, 0, 6)];
+        yield ['10d 20d 30d', new CarbonInterval(0, 0, 0, 60)];
+        yield ['5h 15h 25h', new CarbonInterval(0, 0, 0, 0, 45)];
+        yield ['3m 3m 3m 1m', new CarbonInterval(0, 0, 0, 0, 0, 10)];
+        yield ['55s 45s 1s 2s 3s 4s', new CarbonInterval(0, 0, 0, 0, 0, 0, 110)];
+        yield ['1500ms 1623555µs', new CarbonInterval(0, 0, 0, 0, 0, 0, 0, 3123555)];
+        yield ['430 milli', new CarbonInterval(0, 0, 0, 0, 0, 0, 0, 430000)];
 
-            // multi same values with space
-            ['1 y 2 y', new CarbonInterval(3)],
-            ['1 mo 20 mo', new CarbonInterval(0, 21)],
-            ['1 w      2  w       3    w', new CarbonInterval(0, 0, 6)],
+        // multi same values with space
+        yield ['1 y 2 y', new CarbonInterval(3)];
+        yield ['1 mo 20 mo', new CarbonInterval(0, 21)];
+        yield ['1 w      2  w       3    w', new CarbonInterval(0, 0, 6)];
 
-            // no-space values
-            ['2w3d', new CarbonInterval(0, 0, 0, 17)],
-            ['1y2mo3w4d5h6m7s', new CarbonInterval(1, 2, 3, 4, 5, 6, 7)],
+        // no-space values
+        yield ['2w3d', new CarbonInterval(0, 0, 0, 17)];
+        yield ['1y2mo3w4d5h6m7s', new CarbonInterval(1, 2, 3, 4, 5, 6, 7)];
 
-            // written-out units
-            ['1year 2month 3week 4day 5hour 6minute 7second', new CarbonInterval(1, 2, 3, 4, 5, 6, 7)],
-            ['1 year 2 month 3 week', new CarbonInterval(1, 2, 3)],
-            ['2 Years 3 Months 4 Weeks', new CarbonInterval(2, 3, 4)],
-            ['5 Days 6 Hours 7 Minutes 8 Seconds', new CarbonInterval(0, 0, 0, 5, 6, 7, 8)],
+        // written-out units
+        yield ['1year 2month 3week 4day 5hour 6minute 7second', new CarbonInterval(1, 2, 3, 4, 5, 6, 7)];
+        yield ['1 year 2 month 3 week', new CarbonInterval(1, 2, 3)];
+        yield ['2 Years 3 Months 4 Weeks', new CarbonInterval(2, 3, 4)];
+        yield ['5 Days 6 Hours 7 Minutes 8 Seconds', new CarbonInterval(0, 0, 0, 5, 6, 7, 8)];
 
-            // ignore invalid format; parse only [num][char-format] or [num] [char-format]
-            ['Hello! Please add 1y2w to ...', new CarbonInterval(1, 0, 2)],
-            ['nothing to parse :(', new CarbonInterval(0)],
+        // ignore invalid format; parse only [num][char-format] or [num] [char-format]
+        yield ['Hello! Please add 1y2w to ...', new CarbonInterval(1, 0, 2)];
+        yield ['nothing to parse :(', new CarbonInterval(0)];
 
-            // case insensitive
-            ['1Y 3MO 1W 3D 12H 23M 42S', new CarbonInterval(1, 3, 1, 3, 12, 23, 42)],
-        ];
+        // case insensitive
+        yield ['1Y 3MO 1W 3D 12H 23M 42S', new CarbonInterval(1, 3, 1, 3, 12, 23, 42)];
     }
 
     /**
@@ -117,12 +116,10 @@ class FromStringTest extends AbstractTestCase
         $this->assertStringContainsString($part, $message);
     }
 
-    public function provideInvalidStrings()
+    public function provideInvalidStrings(): Generator
     {
-        return [
-            ['1q', '1q'],
-            ['about 12..14m', '12..'],
-            ['4h 13', '13'],
-        ];
+        yield ['1q', '1q'];
+        yield ['about 12..14m', '12..'];
+        yield ['4h 13', '13'];
     }
 }

--- a/tests/CarbonInterval/ParseFromLocaleTest.php
+++ b/tests/CarbonInterval/ParseFromLocaleTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Tests\CarbonInterval;
 
 use Carbon\CarbonInterval;
+use Generator;
 use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
@@ -23,83 +24,81 @@ class ParseFromLocaleTest extends AbstractTestCase
         $this->assertEquals($expected, $result, "'{$string}' does not return expected interval.");
     }
 
-    public function provideValidStrings()
+    public function provideValidStrings(): Generator
     {
-        return [
-            // zero interval
-            ['', 'en', new CarbonInterval(0)],
+        // zero interval
+        yield ['', 'en', new CarbonInterval(0)];
 
-            // single values
-            ['1y', 'en', new CarbonInterval(1)],
-            ['1mo', 'en', new CarbonInterval(0, 1)],
-            ['1w', 'en', new CarbonInterval(0, 0, 1)],
-            ['1d', 'en', new CarbonInterval(0, 0, 0, 1)],
-            ['1h', 'en', new CarbonInterval(0, 0, 0, 0, 1)],
-            ['1m', 'en', new CarbonInterval(0, 0, 0, 0, 0, 1)],
-            ['1s', 'en', new CarbonInterval(0, 0, 0, 0, 0, 0, 1)],
-            ['1ms', 'en', new CarbonInterval(0, 0, 0, 0, 0, 0, 0, 1000)],
-            ['1µs', 'en', new CarbonInterval(0, 0, 0, 0, 0, 0, 0, 1)],
+        // single values
+        yield ['1y', 'en', new CarbonInterval(1)];
+        yield ['1mo', 'en', new CarbonInterval(0, 1)];
+        yield ['1w', 'en', new CarbonInterval(0, 0, 1)];
+        yield ['1d', 'en', new CarbonInterval(0, 0, 0, 1)];
+        yield ['1h', 'en', new CarbonInterval(0, 0, 0, 0, 1)];
+        yield ['1m', 'en', new CarbonInterval(0, 0, 0, 0, 0, 1)];
+        yield ['1s', 'en', new CarbonInterval(0, 0, 0, 0, 0, 0, 1)];
+        yield ['1ms', 'en', new CarbonInterval(0, 0, 0, 0, 0, 0, 0, 1000)];
+        yield ['1µs', 'en', new CarbonInterval(0, 0, 0, 0, 0, 0, 0, 1)];
 
-            // single values with space
-            ['1 y', 'en', new CarbonInterval(1)],
-            ['1 mo', 'en', new CarbonInterval(0, 1)],
-            ['1 w', 'en', new CarbonInterval(0, 0, 1)],
+        // single values with space
+        yield ['1 y', 'en', new CarbonInterval(1)];
+        yield ['1 mo', 'en', new CarbonInterval(0, 1)];
+        yield ['1 w', 'en', new CarbonInterval(0, 0, 1)];
 
-            // fractions with integer result
-            ['0.571428571429w', 'en', new CarbonInterval(0, 0, 0, 4)],
-            ['0.5d', 'en', new CarbonInterval(0, 0, 0, 0, 12)],
-            ['0.5h', 'en', new CarbonInterval(0, 0, 0, 0, 0, 30)],
-            ['0.5m', 'en', new CarbonInterval(0, 0, 0, 0, 0, 0, 30)],
+        // fractions with integer result
+        yield ['0.571428571429w', 'en', new CarbonInterval(0, 0, 0, 4)];
+        yield ['0.5d', 'en', new CarbonInterval(0, 0, 0, 0, 12)];
+        yield ['0.5h', 'en', new CarbonInterval(0, 0, 0, 0, 0, 30)];
+        yield ['0.5m', 'en', new CarbonInterval(0, 0, 0, 0, 0, 0, 30)];
 
-            // fractions with float result
-            ['1.5w', 'en', new CarbonInterval(0, 0, 1, 3, 12)],
-            ['2.34d', 'en', new CarbonInterval(0, 0, 0, 2, 8, 9, 36)],
-            ['3.12h', 'en', new CarbonInterval(0, 0, 0, 0, 3, 7, 12)],
-            ['3.129h', 'en', new CarbonInterval(0, 0, 0, 0, 3, 7, 44, 400000)],
-            ['4.24m', 'en', new CarbonInterval(0, 0, 0, 0, 0, 4, 14, 400000)],
-            ['3.56s', 'en', new CarbonInterval(0, 0, 0, 0, 0, 0, 3, 560000)],
-            ['3.56ms', 'en', new CarbonInterval(0, 0, 0, 0, 0, 0, 0, 3560)],
+        // fractions with float result
+        yield ['1.5w', 'en', new CarbonInterval(0, 0, 1, 3, 12)];
+        yield ['2.34d', 'en', new CarbonInterval(0, 0, 0, 2, 8, 9, 36)];
+        yield ['3.12h', 'en', new CarbonInterval(0, 0, 0, 0, 3, 7, 12)];
+        yield ['3.129h', 'en', new CarbonInterval(0, 0, 0, 0, 3, 7, 44, 400000)];
+        yield ['4.24m', 'en', new CarbonInterval(0, 0, 0, 0, 0, 4, 14, 400000)];
+        yield ['3.56s', 'en', new CarbonInterval(0, 0, 0, 0, 0, 0, 3, 560000)];
+        yield ['3.56ms', 'en', new CarbonInterval(0, 0, 0, 0, 0, 0, 0, 3560)];
 
-            // combinations
-            ['2w 3d', 'en', new CarbonInterval(0, 0, 0, 17)],
-            ['1y 2mo 1.5w 3d', 'en', new CarbonInterval(1, 2, 1, 6, 12)],
+        // combinations
+        yield ['2w 3d', 'en', new CarbonInterval(0, 0, 0, 17)];
+        yield ['1y 2mo 1.5w 3d', 'en', new CarbonInterval(1, 2, 1, 6, 12)];
 
-            // multi same values
-            ['1y 2y', 'en', new CarbonInterval(3)],
-            ['1mo 20mo', 'en', new CarbonInterval(0, 21)],
-            ['1w 2w 3w', 'en', new CarbonInterval(0, 0, 6)],
-            ['10d 20d 30d', 'en', new CarbonInterval(0, 0, 0, 60)],
-            ['5h 15h 25h', 'en', new CarbonInterval(0, 0, 0, 0, 45)],
-            ['3m 3m 3m 1m', 'en', new CarbonInterval(0, 0, 0, 0, 0, 10)],
-            ['55s 45s 1s 2s 3s 4s', 'en', new CarbonInterval(0, 0, 0, 0, 0, 0, 110)],
-            ['1500ms 1623555µs', 'en', new CarbonInterval(0, 0, 0, 0, 0, 0, 0, 3123555)],
-            ['430 milli', 'en', new CarbonInterval(0, 0, 0, 0, 0, 0, 0, 430000)],
+        // multi same values
+        yield ['1y 2y', 'en', new CarbonInterval(3)];
+        yield ['1mo 20mo', 'en', new CarbonInterval(0, 21)];
+        yield ['1w 2w 3w', 'en', new CarbonInterval(0, 0, 6)];
+        yield ['10d 20d 30d', 'en', new CarbonInterval(0, 0, 0, 60)];
+        yield ['5h 15h 25h', 'en', new CarbonInterval(0, 0, 0, 0, 45)];
+        yield ['3m 3m 3m 1m', 'en', new CarbonInterval(0, 0, 0, 0, 0, 10)];
+        yield ['55s 45s 1s 2s 3s 4s', 'en', new CarbonInterval(0, 0, 0, 0, 0, 0, 110)];
+        yield ['1500ms 1623555µs', 'en', new CarbonInterval(0, 0, 0, 0, 0, 0, 0, 3123555)];
+        yield ['430 milli', 'en', new CarbonInterval(0, 0, 0, 0, 0, 0, 0, 430000)];
 
-            // multi same values with space
-            ['1 y 2 y', 'en', new CarbonInterval(3)],
-            ['1 mo 20 mo', 'en', new CarbonInterval(0, 21)],
-            ['1 w      2  w       3    w', 'en', new CarbonInterval(0, 0, 6)],
+        // multi same values with space
+        yield ['1 y 2 y', 'en', new CarbonInterval(3)];
+        yield ['1 mo 20 mo', 'en', new CarbonInterval(0, 21)];
+        yield ['1 w      2  w       3    w', 'en', new CarbonInterval(0, 0, 6)];
 
-            // no-space values
-            ['2w3d', 'en', new CarbonInterval(0, 0, 0, 17)],
-            ['1y2mo3w4d5h6m7s', 'en', new CarbonInterval(1, 2, 3, 4, 5, 6, 7)],
+        // no-space values
+        yield ['2w3d', 'en', new CarbonInterval(0, 0, 0, 17)];
+        yield ['1y2mo3w4d5h6m7s', 'en', new CarbonInterval(1, 2, 3, 4, 5, 6, 7)];
 
-            // written-out units
-            ['1year 2month 3week 4day 5hour 6minute 7second', 'en', new CarbonInterval(1, 2, 3, 4, 5, 6, 7)],
-            ['1 year 2 month 3 week', 'en', new CarbonInterval(1, 2, 3)],
-            ['2 Years 3 Months 4 Weeks', 'en', new CarbonInterval(2, 3, 4)],
-            ['5 Days 6 Hours 7 Minutes 8 Seconds', 'en', new CarbonInterval(0, 0, 0, 5, 6, 7, 8)],
+        // written-out units
+        yield ['1year 2month 3week 4day 5hour 6minute 7second', 'en', new CarbonInterval(1, 2, 3, 4, 5, 6, 7)];
+        yield ['1 year 2 month 3 week', 'en', new CarbonInterval(1, 2, 3)];
+        yield ['2 Years 3 Months 4 Weeks', 'en', new CarbonInterval(2, 3, 4)];
+        yield ['5 Days 6 Hours 7 Minutes 8 Seconds', 'en', new CarbonInterval(0, 0, 0, 5, 6, 7, 8)];
 
-            // ignore invalid format; parse only [num][char-format] or [num] [char-format]
-            ['Hello! Please add 1y2w to ...', 'en', new CarbonInterval(1, 0, 2)],
-            ['nothing to parse :(', 'en', new CarbonInterval(0)],
+        // ignore invalid format; parse only [num][char-format] or [num] [char-format]
+        yield ['Hello! Please add 1y2w to ...', 'en', new CarbonInterval(1, 0, 2)];
+        yield ['nothing to parse :(', 'en', new CarbonInterval(0)];
 
-            // case insensitive
-            ['1Y 3MO 1W 3D 12H 23M 42S', 'en', new CarbonInterval(1, 3, 1, 3, 12, 23, 42)],
+        // case insensitive
+        yield ['1Y 3MO 1W 3D 12H 23M 42S', 'en', new CarbonInterval(1, 3, 1, 3, 12, 23, 42)];
 
-            // Example for the ticket (#1756)
-            ['2 jours 3 heures', 'fr', new CarbonInterval(0, 0, 0, 2, 3, 0, 0)],
-        ];
+        // Example for the ticket (#1756)
+        yield ['2 jours 3 heures', 'fr', new CarbonInterval(0, 0, 0, 2, 3, 0, 0)];
     }
 
     /**
@@ -122,12 +121,10 @@ class ParseFromLocaleTest extends AbstractTestCase
         $this->assertStringContainsString($part, $message);
     }
 
-    public function provideInvalidStrings()
+    public function provideInvalidStrings(): Generator
     {
-        return [
-            ['1q', '1q', 'en'],
-            ['about 12..14m', '12..', 'en'],
-            ['4h 13', '13', 'en'],
-        ];
+        yield ['1q', '1q', 'en'];
+        yield ['about 12..14m', '12..', 'en'];
+        yield ['4h 13', '13', 'en'];
     }
 }

--- a/tests/CarbonInterval/ToPeriodTest.php
+++ b/tests/CarbonInterval/ToPeriodTest.php
@@ -6,6 +6,7 @@ namespace Tests\CarbonInterval;
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
 use Carbon\CarbonPeriod;
+use Generator;
 use Tests\AbstractTestCase;
 
 class ToPeriodTest extends AbstractTestCase
@@ -22,29 +23,27 @@ class ToPeriodTest extends AbstractTestCase
         $this->assertSame($expected, $period->spec());
     }
 
-    public function provideToPeriodParameters()
+    public function provideToPeriodParameters(): Generator
     {
-        return [
-            [
+        yield [
                 CarbonInterval::days(3),
                 ['2017-10-15', 4],
                 'R4/2017-10-15T00:00:00-04:00/P3D',
-            ],
-            [
+            ];
+        yield [
                 CarbonInterval::hours(7),
                 ['2017-10-15', '2017-10-17'],
                 '2017-10-15T00:00:00-04:00/PT7H/2017-10-17T00:00:00-04:00',
-            ],
-            [
+            ];
+        yield [
                 CarbonInterval::months(3)->days(2)->hours(10)->minutes(20),
                 ['2017-10-15'],
                 '2017-10-15T00:00:00-04:00/P3M2DT10H20M',
-            ],
-            [
+            ];
+        yield [
                 CarbonInterval::minutes(30),
                 [new Carbon('2018-05-14 17:30 UTC'), new Carbon('2018-05-14 18:00 Europe/Oslo')],
                 '2018-05-14T17:30:00+00:00/PT30M/2018-05-14T18:00:00+02:00',
-            ],
-        ];
+            ];
     }
 }

--- a/tests/CarbonInterval/TotalTest.php
+++ b/tests/CarbonInterval/TotalTest.php
@@ -5,6 +5,7 @@ namespace Tests\CarbonInterval;
 
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
+use Generator;
 use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
@@ -22,26 +23,24 @@ class TotalTest extends AbstractTestCase
         );
     }
 
-    public function provideIntervalSpecs()
+    public function provideIntervalSpecs(): Generator
     {
-        return [
-            ['10s',                'seconds', 10],
-            ['100s',               'seconds', 100],
-            ['2d 4h 17m 35s',      'seconds', ((2 * 24 + 4) * 60 + 17) * 60 + 35],
-            ['1y',                 'Seconds', 12 * 4 * 7 * 24 * 60 * 60],
-            ['1000y',              'SECONDS', 1000 * 12 * 4 * 7 * 24 * 60 * 60],
-            ['235s',               'minutes', 235 / 60],
-            ['3h 14m 235s',        'minutes', 3 * 60 + 14 + 235 / 60],
-            ['27h 150m 4960s',     'hours',   27 + (150 + 4960 / 60) / 60],
-            ['1w',                 'days',    7],
-            ['2w 15d',             'weeks',   29 / 7],
-            ['5mo 54d 185h 7680m', 'days',    5 * 4 * 7 + 54 + (185 + 7680 / 60) / 24],
-            ['4y 2mo',             'days',    (4 * 12 + 2) * 4 * 7],
-            ['165d',               'weeks',   165 / 7],
-            ['5mo',                'weeks',   5 * 4],
-            ['6897d',              'months',  6897 / 7 / 4],
-            ['35mo',               'years',   35 / 12],
-        ];
+        yield ['10s',                'seconds', 10];
+        yield ['100s',               'seconds', 100];
+        yield ['2d 4h 17m 35s',      'seconds', ((2 * 24 + 4) * 60 + 17) * 60 + 35];
+        yield ['1y',                 'Seconds', 12 * 4 * 7 * 24 * 60 * 60];
+        yield ['1000y',              'SECONDS', 1000 * 12 * 4 * 7 * 24 * 60 * 60];
+        yield ['235s',               'minutes', 235 / 60];
+        yield ['3h 14m 235s',        'minutes', 3 * 60 + 14 + 235 / 60];
+        yield ['27h 150m 4960s',     'hours',   27 + (150 + 4960 / 60) / 60];
+        yield ['1w',                 'days',    7];
+        yield ['2w 15d',             'weeks',   29 / 7];
+        yield ['5mo 54d 185h 7680m', 'days',    5 * 4 * 7 + 54 + (185 + 7680 / 60) / 24];
+        yield ['4y 2mo',             'days',    (4 * 12 + 2) * 4 * 7];
+        yield ['165d',               'weeks',   165 / 7];
+        yield ['5mo',                'weeks',   5 * 4];
+        yield ['6897d',              'months',  6897 / 7 / 4];
+        yield ['35mo',               'years',   35 / 12];
     }
 
     public function testThrowsExceptionForInvalidUnits()
@@ -78,13 +77,11 @@ class TotalTest extends AbstractTestCase
         $this->assertSame(-12312, $interval->totalMilliseconds);
     }
 
-    public function getNegativeIntervals()
+    public function getNegativeIntervals(): Generator
     {
-        return [
-            [-1, CarbonInterval::hours(0)->hours(-150)],
-            [-1, CarbonInterval::hours(150)->invert()],
-            [1, CarbonInterval::hours(0)->hours(-150)->invert()],
-        ];
+        yield [-1, CarbonInterval::hours(0)->hours(-150)];
+        yield [-1, CarbonInterval::hours(150)->invert()];
+        yield [1, CarbonInterval::hours(0)->hours(-150)->invert()];
     }
 
     /**

--- a/tests/CarbonPeriod/CreateTest.php
+++ b/tests/CarbonPeriod/CreateTest.php
@@ -20,6 +20,7 @@ use Carbon\Exceptions\NotAPeriodException;
 use DateInterval;
 use DatePeriod;
 use DateTime;
+use Generator;
 use InvalidArgumentException;
 use stdClass;
 use Tests\AbstractTestCase;
@@ -41,29 +42,27 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function provideIso8601String()
+    public function provideIso8601String(): Generator
     {
-        return [
-            [
-                ['R4/2012-07-01T00:00:00/P7D'],
-                ['2012-07-01', '2012-07-08', '2012-07-15', '2012-07-22'],
-            ],
-            [
-                ['R4/2012-07-01T00:00:00/P7D', CarbonPeriod::EXCLUDE_START_DATE],
-                ['2012-07-08', '2012-07-15', '2012-07-22', '2012-07-29'],
-            ],
-            [
-                ['2012-07-01/P2D/2012-07-07'],
-                ['2012-07-01', '2012-07-03', '2012-07-05', '2012-07-07'],
-            ],
-            [
-                ['2012-07-01/2012-07-04', CarbonPeriod::EXCLUDE_END_DATE],
-                ['2012-07-01', '2012-07-02', '2012-07-03'],
-            ],
-            [
-                ['R2/2012-07-01T10:30:45Z/P2D'],
-                ['2012-07-01 10:30:45 UTC', '2012-07-03 10:30:45 UTC'],
-            ],
+        yield [
+            ['R4/2012-07-01T00:00:00/P7D'],
+            ['2012-07-01', '2012-07-08', '2012-07-15', '2012-07-22'],
+        ];
+        yield [
+            ['R4/2012-07-01T00:00:00/P7D', CarbonPeriod::EXCLUDE_START_DATE],
+            ['2012-07-08', '2012-07-15', '2012-07-22', '2012-07-29'],
+        ];
+        yield [
+            ['2012-07-01/P2D/2012-07-07'],
+            ['2012-07-01', '2012-07-03', '2012-07-05', '2012-07-07'],
+        ];
+        yield [
+            ['2012-07-01/2012-07-04', CarbonPeriod::EXCLUDE_END_DATE],
+            ['2012-07-01', '2012-07-02', '2012-07-03'],
+        ];
+        yield [
+            ['R2/2012-07-01T10:30:45Z/P2D'],
+            ['2012-07-01 10:30:45 UTC', '2012-07-03 10:30:45 UTC'],
         ];
     }
 
@@ -97,12 +96,10 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function providePartialIso8601String()
+    public function providePartialIso8601String(): Generator
     {
-        return [
-            ['2008-02-15/03-14', '2008-02-15', '2008-03-14'],
-            ['2007-12-14T13:30/15:30', '2007-12-14 13:30', '2007-12-14 15:30'],
-        ];
+        yield ['2008-02-15/03-14', '2008-02-15', '2008-03-14'];
+        yield ['2007-12-14T13:30/15:30', '2007-12-14 13:30', '2007-12-14 15:30'];
     }
 
     /**
@@ -117,16 +114,14 @@ class CreateTest extends AbstractTestCase
         CarbonPeriod::create($iso);
     }
 
-    public function provideInvalidIso8601String()
+    public function provideInvalidIso8601String(): Generator
     {
-        return [
-            ['R2/R4'],
-            ['2008-02-15/2008-02-16/2008-02-17'],
-            ['P1D/2008-02-15/P2D'],
-            ['2008-02-15/R5'],
-            ['P2D/R2'],
-            ['/'],
-        ];
+        yield ['R2/R4'];
+        yield ['2008-02-15/2008-02-16/2008-02-17'];
+        yield ['P1D/2008-02-15/P2D'];
+        yield ['2008-02-15/R5'];
+        yield ['P2D/R2'];
+        yield ['/'];
     }
 
     /**
@@ -147,42 +142,40 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function provideStartDateAndEndDate()
+    public function provideStartDateAndEndDate(): Generator
     {
-        return [
-            [
+        yield [
                 ['2015-09-30', '2015-10-03'],
                 ['2015-09-30', '2015-10-01', '2015-10-02', '2015-10-03'],
-            ],
-            [
+            ];
+        yield [
                 ['2015-09-30', '2015-10-03', CarbonPeriod::EXCLUDE_START_DATE],
                 ['2015-10-01', '2015-10-02', '2015-10-03'],
-            ],
-            [
+            ];
+        yield [
                 ['2015-09-30', '2015-10-03', CarbonPeriod::EXCLUDE_END_DATE],
                 ['2015-09-30', '2015-10-01', '2015-10-02'],
-            ],
-            [
+            ];
+        yield [
                 ['2015-09-30', '2015-10-03', CarbonPeriod::EXCLUDE_START_DATE | CarbonPeriod::EXCLUDE_END_DATE],
                 ['2015-10-01', '2015-10-02'],
-            ],
-            [
+            ];
+        yield [
                 ['2015-10-02', '2015-10-03', CarbonPeriod::EXCLUDE_START_DATE | CarbonPeriod::EXCLUDE_END_DATE],
                 [],
-            ],
-            [
+            ];
+        yield [
                 ['2015-10-02', '2015-10-02'],
                 ['2015-10-02'],
-            ],
-            [
+            ];
+        yield [
                 ['2015-10-02', '2015-10-02', CarbonPeriod::EXCLUDE_START_DATE],
                 [],
-            ],
-            [
+            ];
+        yield [
                 ['2015-10-02', '2015-10-02', CarbonPeriod::EXCLUDE_END_DATE],
                 [],
-            ],
-        ];
+            ];
     }
 
     /**
@@ -204,41 +197,44 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function provideStartDateAndIntervalAndEndDate()
+    public function provideStartDateAndIntervalAndEndDate(): Generator
     {
-        return [
+        yield [
+            ['2018-04-21', 'P3D', '2018-04-26'],
+            ['2018-04-21', '2018-04-24'],
+        ];
+        yield [
+            ['2018-04-21 16:15', 'PT15M', '2018-04-21 16:59:59'],
+            ['2018-04-21 16:15', '2018-04-21 16:30', '2018-04-21 16:45'],
+        ];
+        yield [
+            ['2018-04-21 16:15', 'PT15M', '2018-04-21 17:00'],
+            ['2018-04-21 16:15', '2018-04-21 16:30', '2018-04-21 16:45', '2018-04-21 17:00'],
+        ];
+        yield [
+            ['2018-04-21 17:00', 'PT45S', '2018-04-21 17:02', CarbonPeriod::EXCLUDE_START_DATE],
+            ['2018-04-21 17:00:45', '2018-04-21 17:01:30'],
+        ];
+        yield [
+            ['2017-12-31 22:00', 'PT2H', '2018-01-01 4:00', CarbonPeriod::EXCLUDE_END_DATE],
+            ['2017-12-31 22:00', '2018-01-01 0:00', '2018-01-01 2:00'],
+        ];
+        yield [
             [
-                ['2018-04-21', 'P3D', '2018-04-26'],
-                ['2018-04-21', '2018-04-24'],
+                '2017-12-31 23:59',
+                'PT30S',
+                '2018-01-01 0:01',
+                CarbonPeriod::EXCLUDE_START_DATE | CarbonPeriod::EXCLUDE_END_DATE,
             ],
-            [
-                ['2018-04-21 16:15', 'PT15M', '2018-04-21 16:59:59'],
-                ['2018-04-21 16:15', '2018-04-21 16:30', '2018-04-21 16:45'],
-            ],
-            [
-                ['2018-04-21 16:15', 'PT15M', '2018-04-21 17:00'],
-                ['2018-04-21 16:15', '2018-04-21 16:30', '2018-04-21 16:45', '2018-04-21 17:00'],
-            ],
-            [
-                ['2018-04-21 17:00', 'PT45S', '2018-04-21 17:02', CarbonPeriod::EXCLUDE_START_DATE],
-                ['2018-04-21 17:00:45', '2018-04-21 17:01:30'],
-            ],
-            [
-                ['2017-12-31 22:00', 'PT2H', '2018-01-01 4:00', CarbonPeriod::EXCLUDE_END_DATE],
-                ['2017-12-31 22:00', '2018-01-01 0:00', '2018-01-01 2:00'],
-            ],
-            [
-                ['2017-12-31 23:59', 'PT30S', '2018-01-01 0:01', CarbonPeriod::EXCLUDE_START_DATE | CarbonPeriod::EXCLUDE_END_DATE],
-                ['2017-12-31 23:59:30', '2018-01-01 0:00', '2018-01-01 0:00:30'],
-            ],
-            [
-                ['2018-04-21', 'P1D', '2018-04-21'],
-                ['2018-04-21'],
-            ],
-            [
-                ['2018-04-21', 'P1D', '2018-04-20 23:59:59'],
-                [],
-            ],
+            ['2017-12-31 23:59:30', '2018-01-01 0:00', '2018-01-01 0:00:30'],
+        ];
+        yield [
+            ['2018-04-21', 'P1D', '2018-04-21'],
+            ['2018-04-21'],
+        ];
+        yield [
+            ['2018-04-21', 'P1D', '2018-04-20 23:59:59'],
+            [],
         ];
     }
 
@@ -260,17 +256,15 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function provideStartDateAndIntervalAndRecurrences()
+    public function provideStartDateAndIntervalAndRecurrences(): Generator
     {
-        return [
-            [
-                ['2018-04-16', 'P2D', 3],
-                ['2018-04-16', '2018-04-18', '2018-04-20'],
-            ],
-            [
-                ['2018-04-30', 'P2M', 2, CarbonPeriod::EXCLUDE_START_DATE],
-                ['2018-06-30', '2018-08-30'],
-            ],
+        yield [
+            ['2018-04-16', 'P2D', 3],
+            ['2018-04-16', '2018-04-18', '2018-04-20'],
+        ];
+        yield [
+            ['2018-04-30', 'P2M', 2, CarbonPeriod::EXCLUDE_START_DATE],
+            ['2018-06-30', '2018-08-30'],
         ];
     }
 
@@ -291,26 +285,24 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function provideStartDateAndRecurrences()
+    public function provideStartDateAndRecurrences(): Generator
     {
-        return [
-            [
+        yield [
                 ['2018-04-16', 2],
                 ['2018-04-16', '2018-04-17'],
-            ],
-            [
+            ];
+        yield [
                 ['2018-04-30', 1],
                 ['2018-04-30'],
-            ],
-            [
+            ];
+        yield [
                 ['2018-04-30', 1, CarbonPeriod::EXCLUDE_START_DATE],
                 ['2018-05-01'],
-            ],
-            [
+            ];
+        yield [
                 ['2018-05-17', 0],
                 [],
-            ],
-        ];
+            ];
     }
 
     public function testCreateFromBaseClasses()
@@ -339,17 +331,15 @@ class CreateTest extends AbstractTestCase
         CarbonPeriod::create(...$arguments);
     }
 
-    public function provideInvalidParameters()
+    public function provideInvalidParameters(): Generator
     {
-        return [
-            [new stdClass, CarbonInterval::days(1), Carbon::tomorrow()],
-            [Carbon::now(), new stdClass, Carbon::tomorrow()],
-            [Carbon::now(), CarbonInterval::days(1), new stdClass],
-            [Carbon::yesterday(), Carbon::now(), Carbon::tomorrow()],
-            [CarbonInterval::day(), CarbonInterval::hour()],
-            [5, CarbonPeriod::EXCLUDE_START_DATE, CarbonPeriod::EXCLUDE_END_DATE],
-            ['2017-10-15/P3D', CarbonInterval::hour()],
-        ];
+        yield [new stdClass, CarbonInterval::days(1), Carbon::tomorrow()];
+        yield [Carbon::now(), new stdClass, Carbon::tomorrow()];
+        yield [Carbon::now(), CarbonInterval::days(1), new stdClass];
+        yield [Carbon::yesterday(), Carbon::now(), Carbon::tomorrow()];
+        yield [CarbonInterval::day(), CarbonInterval::hour()];
+        yield [5, CarbonPeriod::EXCLUDE_START_DATE, CarbonPeriod::EXCLUDE_END_DATE];
+        yield ['2017-10-15/P3D', CarbonInterval::hour()];
     }
 
     public function testCreateOnDstForwardChange()

--- a/tests/CarbonPeriod/IteratorTest.php
+++ b/tests/CarbonPeriod/IteratorTest.php
@@ -14,6 +14,7 @@ namespace Tests\CarbonPeriod;
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
 use Carbon\CarbonPeriod;
+use Generator;
 use Tests\AbstractTestCase;
 use Tests\CarbonPeriod\Fixtures\CarbonPeriodFactory;
 
@@ -126,29 +127,27 @@ class IteratorTest extends AbstractTestCase
         );
     }
 
-    public function provideIterateBackwardsArguments()
+    public function provideIterateBackwardsArguments(): Generator
     {
-        return [
-            [
-                ['2015-10-15', '2015-10-06'],
-                ['2015-10-15', '2015-10-12', '2015-10-09', '2015-10-06'],
-            ],
-            [
-                ['2015-10-15', '2015-10-06', CarbonPeriod::EXCLUDE_START_DATE],
-                ['2015-10-12', '2015-10-09', '2015-10-06'],
-            ],
-            [
-                ['2015-10-15', '2015-10-06', CarbonPeriod::EXCLUDE_END_DATE],
-                ['2015-10-15', '2015-10-12', '2015-10-09'],
-            ],
-            [
-                ['2015-10-15', '2015-10-06', CarbonPeriod::EXCLUDE_START_DATE | CarbonPeriod::EXCLUDE_END_DATE],
-                ['2015-10-12', '2015-10-09'],
-            ],
-            [
-                ['2015-10-15', 3],
-                ['2015-10-15', '2015-10-12', '2015-10-09'],
-            ],
+        yield [
+            ['2015-10-15', '2015-10-06'],
+            ['2015-10-15', '2015-10-12', '2015-10-09', '2015-10-06'],
+        ];
+        yield [
+            ['2015-10-15', '2015-10-06', CarbonPeriod::EXCLUDE_START_DATE],
+            ['2015-10-12', '2015-10-09', '2015-10-06'],
+        ];
+        yield [
+            ['2015-10-15', '2015-10-06', CarbonPeriod::EXCLUDE_END_DATE],
+            ['2015-10-15', '2015-10-12', '2015-10-09'],
+        ];
+        yield [
+            ['2015-10-15', '2015-10-06', CarbonPeriod::EXCLUDE_START_DATE | CarbonPeriod::EXCLUDE_END_DATE],
+            ['2015-10-12', '2015-10-09'],
+        ];
+        yield [
+            ['2015-10-15', 3],
+            ['2015-10-15', '2015-10-12', '2015-10-09'],
         ];
     }
 

--- a/tests/CarbonPeriod/ToStringTest.php
+++ b/tests/CarbonPeriod/ToStringTest.php
@@ -15,6 +15,7 @@ use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterval;
 use Carbon\CarbonPeriod;
+use Generator;
 use Tests\AbstractTestCase;
 
 class ToStringTest extends AbstractTestCase
@@ -30,47 +31,45 @@ class ToStringTest extends AbstractTestCase
         );
     }
 
-    public function provideToString()
+    public function provideToString(): Generator
     {
         Carbon::setTestNow(new Carbon('2015-09-01', 'America/Toronto'));
 
-        return [
-            [
+        yield [
                 CarbonPeriod::create('R4/2012-07-01T12:00:00/P7D'),
                 '4 times every 1 week from 2012-07-01 12:00:00',
-            ],
-            [
+            ];
+        yield [
                 CarbonPeriod::create(
                     Carbon::parse('2015-09-30'),
                     Carbon::parse('2015-10-03')
                 ),
                 'Every 1 day from 2015-09-30 to 2015-10-03',
-            ],
-            [
+            ];
+        yield [
                 CarbonPeriod::create(
                     Carbon::parse('2015-09-30 12:50'),
                     CarbonInterval::days(3)->hours(5),
                     Carbon::parse('2015-10-03 19:00')
                 ),
                 'Every 3 days and 5 hours from 2015-09-30 12:50:00 to 2015-10-03 19:00:00',
-            ],
-            [
+            ];
+        yield [
                 CarbonPeriod::create('2015-09-30 17:30'),
                 'Every 1 day from 2015-09-30 17:30:00',
-            ],
-            [
+            ];
+        yield [
                 CarbonPeriod::create('P1M14D'),
                 'Every 1 month and 2 weeks from 2015-09-01',
-            ],
-            [
+            ];
+        yield [
                 CarbonPeriod::create('2015-09-30 13:30', 'P17D')->setRecurrences(1),
                 'Once every 2 weeks and 3 days from 2015-09-30 13:30:00',
-            ],
-            [
+            ];
+        yield [
                 CarbonPeriod::create('2015-10-01', '2015-10-05', 'PT30M'),
                 'Every 30 minutes from 2015-10-01 to 2015-10-05',
-            ],
-        ];
+            ];
     }
 
     public function testMagicToString()
@@ -98,42 +97,40 @@ class ToStringTest extends AbstractTestCase
         );
     }
 
-    public function provideToIso8601String()
+    public function provideToIso8601String(): Generator
     {
         Carbon::setTestNow(new Carbon('2015-09-01', 'America/Toronto'));
 
-        return [
-            [
+        yield [
                 CarbonPeriod::create('R4/2012-07-01T00:00:00-04:00/P7D'),
                 'R4/2012-07-01T00:00:00-04:00/P7D',
-            ],
-            [
+            ];
+        yield [
                 CarbonPeriod::create(
                     Carbon::parse('2015-09-30', 'America/Toronto'),
                     Carbon::parse('2015-10-03', 'America/Toronto')
                 ),
                 '2015-09-30T00:00:00-04:00/P1D/2015-10-03T00:00:00-04:00',
-            ],
-            [
+            ];
+        yield [
                 CarbonPeriod::create(
                     Carbon::parse('2015-09-30 12:50', 'America/Toronto'),
                     CarbonInterval::days(3)->hours(5),
                     Carbon::parse('2015-10-03 19:00', 'America/Toronto')
                 ),
                 '2015-09-30T12:50:00-04:00/P3DT5H/2015-10-03T19:00:00-04:00',
-            ],
-            [
+            ];
+        yield [
                 CarbonPeriod::create(
                     Carbon::parse('2015-09-30 12:50', 'America/Toronto'),
                     CarbonInterval::days(3)
                 ),
                 '2015-09-30T12:50:00-04:00/P3D',
-            ],
-            [
+            ];
+        yield [
                 CarbonPeriod::create(),
                 '2015-09-01T00:00:00-04:00/P1D',
-            ],
-        ];
+            ];
     }
 
     public function testSpec()

--- a/tests/CarbonTimeZone/ConversionsTest.php
+++ b/tests/CarbonTimeZone/ConversionsTest.php
@@ -15,6 +15,7 @@ namespace Tests\CarbonTimeZone;
 use Carbon\Carbon;
 use Carbon\CarbonTimeZone;
 use DateTimeZone;
+use Generator;
 use InvalidArgumentException;
 use stdClass;
 use Tests\AbstractTestCaseWithOldNow;
@@ -48,34 +49,32 @@ class ConversionsTest extends AbstractTestCaseWithOldNow
         $this->assertSame('America/Chicago', (new CarbonTimeZone('America/Toronto'))->toOffsetTimeZone($date)->toRegionTimeZone($date)->getName());
     }
 
-    public function dataProviderToOffsetName()
+    public function dataProviderToOffsetName(): Generator
     {
-        return [
-            // timezone - number
-            ['2018-12-20', '-05:00', -5],
-            ['2018-06-20', '-05:00', -5],
-            // timezone - use offset
-            ['2018-12-20', '-05:00', '-05:00'],
-            ['2018-06-20', '-05:00', '-05:00'],
-            // timezone - by name - with daylight time
-            ['2018-12-20', '-05:00', 'America/Toronto'],
-            ['2018-06-20', '-04:00', 'America/Toronto'],
-            // timezone - by name - without daylight time
-            ['2018-12-20', '+03:00', 'Asia/Baghdad'],
-            ['2018-06-20', '+03:00', 'Asia/Baghdad'],
-            // timezone - no full hour - the same time
-            ['2018-12-20', '-09:30', 'Pacific/Marquesas'],
-            ['2018-06-20', '-09:30', 'Pacific/Marquesas'],
-            // timezone - no full hour -
-            ['2018-12-20', '-03:30', 'America/St_Johns'],
-            ['2018-06-20', '-02:30', 'America/St_Johns'],
-            // timezone - no full hour +
-            ['2018-12-20', '+13:45', 'Pacific/Chatham'],
-            ['2018-06-20', '+12:45', 'Pacific/Chatham'],
-            // timezone - UTC
-            ['2018-12-20', '+00:00', 'UTC'],
-            ['2018-06-20', '+00:00', 'UTC'],
-        ];
+        // timezone - number
+        yield ['2018-12-20', '-05:00', -5];
+        yield ['2018-06-20', '-05:00', -5];
+        // timezone - use offset
+        yield ['2018-12-20', '-05:00', '-05:00'];
+        yield ['2018-06-20', '-05:00', '-05:00'];
+        // timezone - by name - with daylight time
+        yield ['2018-12-20', '-05:00', 'America/Toronto'];
+        yield ['2018-06-20', '-04:00', 'America/Toronto'];
+        // timezone - by name - without daylight time
+        yield ['2018-12-20', '+03:00', 'Asia/Baghdad'];
+        yield ['2018-06-20', '+03:00', 'Asia/Baghdad'];
+        // timezone - no full hour - the same time
+        yield ['2018-12-20', '-09:30', 'Pacific/Marquesas'];
+        yield ['2018-06-20', '-09:30', 'Pacific/Marquesas'];
+        // timezone - no full hour -
+        yield ['2018-12-20', '-03:30', 'America/St_Johns'];
+        yield ['2018-06-20', '-02:30', 'America/St_Johns'];
+        // timezone - no full hour +
+        yield ['2018-12-20', '+13:45', 'Pacific/Chatham'];
+        yield ['2018-06-20', '+12:45', 'Pacific/Chatham'];
+        // timezone - UTC
+        yield ['2018-12-20', '+00:00', 'UTC'];
+        yield ['2018-06-20', '+00:00', 'UTC'];
     }
 
     /**

--- a/tests/CommonTraits/MacroContextNestingTest.php
+++ b/tests/CommonTraits/MacroContextNestingTest.php
@@ -15,18 +15,17 @@ use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterval;
 use Carbon\CarbonPeriod;
+use Generator;
 use Tests\AbstractTestCaseWithOldNow;
 
 class MacroContextNestingTest extends AbstractTestCaseWithOldNow
 {
-    public function getMacroableClasses()
+    public function getMacroableClasses(): Generator
     {
-        return [
-            [Carbon::class, Carbon::parse('2010-05-23'), null],
-            [CarbonImmutable::class, CarbonImmutable::parse('2010-05-23'), null],
-            [CarbonInterval::class, CarbonInterval::make('P1M6D'), (string) (CarbonInterval::second())],
-            [CarbonPeriod::class, CarbonPeriod::create('2010-08-23', '2010-10-02'), null],
-        ];
+        yield [Carbon::class, Carbon::parse('2010-05-23'), null];
+        yield [CarbonImmutable::class, CarbonImmutable::parse('2010-05-23'), null];
+        yield [CarbonInterval::class, CarbonInterval::make('P1M6D'), (string) (CarbonInterval::second())];
+        yield [CarbonPeriod::class, CarbonPeriod::create('2010-08-23', '2010-10-02'), null];
     }
 
     /**

--- a/tests/Doctrine/CarbonTypesTest.php
+++ b/tests/Doctrine/CarbonTypesTest.php
@@ -24,6 +24,7 @@ use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\Type;
+use Generator;
 use Tests\AbstractTestCase;
 
 class CarbonTypesTest extends AbstractTestCase
@@ -37,14 +38,12 @@ class CarbonTypesTest extends AbstractTestCase
         }
     }
 
-    public static function getTypes()
+    public static function getTypes(): Generator
     {
-        return [
-            ['datetime', Carbon::class, DateTimeType::class, false],
-            ['datetime_immutable', CarbonImmutable::class, DateTimeImmutableType::class, true],
-            ['carbon', Carbon::class, CarbonType::class, true],
-            ['carbon_immutable', CarbonImmutable::class, CarbonImmutableType::class, true],
-        ];
+        yield ['datetime', Carbon::class, DateTimeType::class, false];
+        yield ['datetime_immutable', CarbonImmutable::class, DateTimeImmutableType::class, true];
+        yield ['carbon', Carbon::class, CarbonType::class, true];
+        yield ['carbon_immutable', CarbonImmutable::class, CarbonImmutableType::class, true];
     }
 
     /**

--- a/tests/Laravel/ServiceProviderTest.php
+++ b/tests/Laravel/ServiceProviderTest.php
@@ -8,6 +8,7 @@ use Carbon\CarbonImmutable;
 use Carbon\CarbonInterval;
 use Carbon\CarbonPeriod;
 use Carbon\Laravel\ServiceProvider;
+use Generator;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Events\EventDispatcher;
 use Illuminate\Support\Carbon as SupportCarbon;
@@ -17,7 +18,7 @@ use stdClass;
 
 class ServiceProviderTest extends TestCase
 {
-    public function getDispatchers()
+    public function getDispatchers(): Generator
     {
         if (!class_exists(Dispatcher::class)) {
             include_once __DIR__.'/Dispatcher.php';
@@ -27,10 +28,8 @@ class ServiceProviderTest extends TestCase
             include_once __DIR__.'/EventDispatcher.php';
         }
 
-        return [
-            [new Dispatcher()],
-            [new EventDispatcher()],
-        ];
+        yield [new Dispatcher()];
+        yield [new EventDispatcher()];
     }
 
     /**


### PR DESCRIPTION
Use generators for dataProviders.
This is especially way more memory-efficient when dealing with large arrays.