### PR TITLE
Add unit test for PHP bug 80974

### DIFF
--- a/src/Carbon/Traits/Difference.php
+++ b/src/Carbon/Traits/Difference.php
@@ -121,7 +121,19 @@ trait Difference
     #[ReturnTypeWillChange]
     public function diff($date = null, $absolute = false)
     {
-        return parent::diff($this->resolveCarbon($date), (bool) $absolute);
+        $other = $this->resolveCarbon($date);
+
+        // Can be removed if https://github.com/derickr/timelib/pull/110
+        // is merged
+        // https://bugs.php.net/bug.php?id=80998 was announced fixed in PHP 8.1.0beta3
+        // but created a reverse-regression when using UTC, so we still need this hack
+        // @codeCoverageIgnoreStart
+        if (version_compare(PHP_VERSION, '8.1.0-dev', '>=') && $other->tz !== $this->tz) {
+            $other = $other->avoidMutation()->tz($this->tz);
+        }
+        // @codeCoverageIgnoreEnd
+
+        return parent::diff($other, (bool) $absolute);
     }
 
     /**

--- a/tests/Carbon/DiffTest.php
+++ b/tests/Carbon/DiffTest.php
@@ -1703,6 +1703,14 @@ class DiffTest extends AbstractTestCase
         $this->assertSame(0, $startDate->diffInSeconds($endDate));
     }
 
+    public function testPHPBug80974()
+    {
+        $this->assertSame(3, Carbon::parse('2018-07-01 America/Toronto')->diff('2018-07-02 America/Vancouver')->h);
+        $this->assertSame(0, Carbon::parse('2018-07-01')->utc()->diff('2018-07-02')->days);
+        $this->assertSame(1, Carbon::parse('2018-07-01')->utc()->diff(Carbon::parse('2018-07-02'))->days);
+        $this->assertSame(1, Carbon::parse('2018-07-01')->diff(Carbon::parse('2018-07-02')->utc())->days);
+    }
+
     public function testDiffWithZeroAndNonZeroMicroseconds()
     {
         $requestTime = new Carbon('2018-11-14 18:23:12.0 +00:00');

--- a/tests/CarbonImmutable/DiffTest.php
+++ b/tests/CarbonImmutable/DiffTest.php
@@ -1669,6 +1669,14 @@ class DiffTest extends AbstractTestCase
         $this->assertSame(0, $startDate->diffInSeconds($endDate));
     }
 
+    public function testPHPBug80974()
+    {
+        $this->assertSame(3, Carbon::parse('2018-07-01 America/Toronto')->diff('2018-07-02 America/Vancouver')->h);
+        $this->assertSame(0, Carbon::parse('2018-07-01')->utc()->diff('2018-07-02')->days);
+        $this->assertSame(1, Carbon::parse('2018-07-01')->utc()->diff(Carbon::parse('2018-07-02'))->days);
+        $this->assertSame(1, Carbon::parse('2018-07-01')->diff(Carbon::parse('2018-07-02')->utc())->days);
+    }
+
     public function testDiffWithZeroAndNonZeroMicroseconds()
     {
         $requestTime = new Carbon('2018-11-14 18:23:12.0 +00:00');


### PR DESCRIPTION
- Add unit test for PHP bug 80974 to prove the work-around is still needed in Carbon 2.x
- Restore the work-around