### PR TITLE
Use ob_get_clean

### DIFF
--- a/tests/Carbon/Fixtures/DumpCarbon.php
+++ b/tests/Carbon/Fixtures/DumpCarbon.php
@@ -25,8 +25,7 @@ final class DumpCarbon extends Carbon
     {
         ob_start();
         var_dump($this);
-        $this->dump = ob_get_contents() ?: '';
-        ob_end_clean();
+        $this->dump = ob_get_clean() ?: '';
 
         parent::__construct($time, $tz);
     }

--- a/tests/Cli/Cli.php
+++ b/tests/Cli/Cli.php
@@ -6,7 +6,7 @@ class Cli
 {
     public static $lastParameters = [];
 
-    public function __invoke(...$parameters)
+    public function __invoke(...$parameters): bool
     {
         static::$lastParameters = $parameters;
 

--- a/tests/Cli/InvokerTest.php
+++ b/tests/Cli/InvokerTest.php
@@ -17,7 +17,7 @@ use Tests\AbstractTestCase;
 
 class InvokerTest extends AbstractTestCase
 {
-    public function testInvoke()
+    public function testInvoke(): void
     {
         $invoker = new Invoker();
         $lastCommand = null;
@@ -27,8 +27,7 @@ class InvokerTest extends AbstractTestCase
 
         ob_start();
         $return = $invoker('file', 'install', $exec);
-        $contents = ob_get_contents();
-        ob_end_clean();
+        $contents = ob_get_clean();
 
         $this->assertSame('composer require carbon-cli/carbon-cli --no-interaction', $lastCommand);
         $this->assertSame('Installation succeeded.', $contents);
@@ -41,8 +40,7 @@ class InvokerTest extends AbstractTestCase
 
         ob_start();
         $return = $invoker('file', 'install', $exec);
-        $contents = ob_get_contents();
-        ob_end_clean();
+        $contents = ob_get_clean();
 
         $this->assertNull($lastCommand);
         $this->assertSame('', $contents);


### PR DESCRIPTION
No need to use `ob_get_contents` and then `ob_end_clean`

We can directly use `ob_get_clean` instead  