### PR TITLE
Fix phpunit syntax warning

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-    xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
     colors="true"
 >


### PR DESCRIPTION
This PR fixes `phpunit` syntax warning:

```
> php -d memory_limit=-1 -d zend.enable_gc=0 vendor/bin/phpunit
PHPUnit 8.5.20 by Sebastian Bergmann and contributors.

  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 6:
  - Element 'phpunit', attribute '{https://www.w3.org/2001/XMLSchema-instance}noNamespaceSchemaLocation': The attribute '{https://www.w3.org/2001/XMLSchema-instance}noNamespaceSchemaLocation' is not allowed.

  Test results may not be as expected.
```