### PR TITLE
Enforce docblock alignment consistancy with phpdoc_align rule

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -40,7 +40,16 @@ $rules = [
     'php_unit_test_case_static_method_calls' => [
         'call_type' => 'this',
     ],
-    'phpdoc_align' => false,
+    'phpdoc_align' => [
+        'align' => 'vertical',
+        'tags' => [
+            'param',
+            'return',
+            'throws',
+            'type',
+            'var',
+        ],
+    ],
     'phpdoc_indent' => true,
     'phpdoc_inline_tag_normalizer' => true,
     'phpdoc_no_access' => true,

--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -5012,8 +5012,8 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
      *
      * /!\ Use this method for unit tests only.
      *
-     * @param Closure|static|string|false|null $testNow real or mock Carbon instance
-     * @param Closure|null $callback
+     * @param Closure|static|string|false|null $testNow  real or mock Carbon instance
+     * @param Closure|null                     $callback
      *
      * @return mixed
      */

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -1905,8 +1905,8 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
     /**
      * Add given parameters to the current interval.
      *
-     * @param int $years
-     * @param int $months
+     * @param int       $years
+     * @param int       $months
      * @param int|float $weeks
      * @param int|float $days
      * @param int|float $hours
@@ -1935,8 +1935,8 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
     /**
      * Add given parameters to the current interval.
      *
-     * @param int $years
-     * @param int $months
+     * @param int       $years
+     * @param int       $months
      * @param int|float $weeks
      * @param int|float $days
      * @param int|float $hours

--- a/src/Carbon/Traits/Test.php
+++ b/src/Carbon/Traits/Test.php
@@ -61,8 +61,8 @@ trait Test
      *
      * /!\ Use this method for unit tests only.
      *
-     * @param Closure|static|string|false|null $testNow real or mock Carbon instance
-     * @param Closure|null $callback
+     * @param Closure|static|string|false|null $testNow  real or mock Carbon instance
+     * @param Closure|null                     $callback
      *
      * @return mixed
      */

--- a/tests/Carbon/Exceptions/NotLocaleAwareExceptionTest.php
+++ b/tests/Carbon/Exceptions/NotLocaleAwareExceptionTest.php
@@ -32,8 +32,8 @@ class NotLocaleAwareExceptionTest extends AbstractTestCase
     /**
      * @dataProvider dataProviderTestNotAPeriodException
      *
-     * @param  mixed  $object
-     * @param  string  $message
+     * @param mixed  $object
+     * @param string $message
      *
      * @return void
      */


### PR DESCRIPTION
This PR enforces docblock alignment consistancy with `phpdoc_align` rule.