### PR TITLE
Add `@return` PHPdoc to `{@inheritdoc}` blocks from vendors

### DIFF
--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -2149,6 +2149,8 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
 
     /**
      * {@inheritdoc}
+     *
+     * @return array
      */
     #[ReturnTypeWillChange]
     public static function getLastErrors();
@@ -3333,6 +3335,8 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
      * Calls \DateTime::modify if mutable or \DateTimeImmutable::modify else.
      *
      * @see https://php.net/manual/en/datetime.modify.php
+     *
+     * @return static|false
      */
     #[ReturnTypeWillChange]
     public function modify($modify);

--- a/src/Carbon/Doctrine/CarbonImmutableType.php
+++ b/src/Carbon/Doctrine/CarbonImmutableType.php
@@ -12,6 +12,8 @@ class CarbonImmutableType extends DateTimeImmutableType implements CarbonDoctrin
 {
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getName()
     {
@@ -20,6 +22,8 @@ class CarbonImmutableType extends DateTimeImmutableType implements CarbonDoctrin
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {

--- a/src/Carbon/Doctrine/CarbonType.php
+++ b/src/Carbon/Doctrine/CarbonType.php
@@ -12,6 +12,8 @@ class CarbonType extends DateTimeType implements CarbonDoctrineType
 {
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getName()
     {
@@ -20,6 +22,8 @@ class CarbonType extends DateTimeType implements CarbonDoctrineType
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function requiresSQLCommentHint(AbstractPlatform $platform)
     {

--- a/src/Carbon/Doctrine/CarbonTypeConverter.php
+++ b/src/Carbon/Doctrine/CarbonTypeConverter.php
@@ -26,6 +26,9 @@ trait CarbonTypeConverter
         return Carbon::class;
     }
 
+    /**
+     * @return string
+     */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {
         $precision = ($fieldDeclaration['precision'] ?: 10) === 10

--- a/src/Carbon/PHPStan/Macro.php
+++ b/src/Carbon/PHPStan/Macro.php
@@ -148,6 +148,8 @@ final class Macro implements BuiltinMethodReflection
 
     /**
      * {@inheritdoc}
+     *
+     * @return string|false
      */
     public function getFileName()
     {
@@ -180,6 +182,8 @@ final class Macro implements BuiltinMethodReflection
 
     /**
      * {@inheritdoc}
+     *
+     * @return int|false
      */
     public function getStartLine()
     {
@@ -188,6 +192,8 @@ final class Macro implements BuiltinMethodReflection
 
     /**
      * {@inheritdoc}
+     *
+     * @return int|false
      */
     public function getEndLine()
     {

--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -931,6 +931,8 @@ trait Creator
 
     /**
      * {@inheritdoc}
+     *
+     * @return array
      */
     #[ReturnTypeWillChange]
     public static function getLastErrors()

--- a/src/Carbon/Traits/Modifiers.php
+++ b/src/Carbon/Traits/Modifiers.php
@@ -429,6 +429,8 @@ trait Modifiers
      * Calls \DateTime::modify if mutable or \DateTimeImmutable::modify else.
      *
      * @see https://php.net/manual/en/datetime.modify.php
+     *
+     * @return static|false
      */
     #[ReturnTypeWillChange]
     public function modify($modify)

--- a/src/Carbon/Traits/Serialization.php
+++ b/src/Carbon/Traits/Serialization.php
@@ -135,6 +135,8 @@ trait Serialization
 
     /**
      * Set locale if specified on unserialize() called.
+     *
+     * @return void
      */
     #[ReturnTypeWillChange]
     public function __wakeup()


### PR DESCRIPTION
This package included almost all `@return` PHPdoc except from a few. Some of these have comments that were `{@inheritdoc}`, but given the "inheritdoc" are from PHP's `DateTimeInterface`, one could argue that they are "unknown".

Besides fixing the PHPdoc, these return annotations will also suppress type deprecations when Carbon is used in a Symfony application. Since Symfony 5.4, developers are warned when a child class does not yet have a return type (PHP native or PHPdoc) while the parent has. See also [the Symfony docs](https://symfony.com/doc/5.4/setup/upgrade_major.html#upgrading-to-symfony-6-add-native-return-types) for more info on this topic.

I'm not sure about the plans of Carbon to add PHP typing (I saw that 7.1 compat is still maintained, so I expect it'll take a while), but I hope you'll accept these PHPdocs. It'll make the life of all your Symfony users better, and I think it's also more explicit for all your Laravel/PHP users :)