### PR TITLE
LV month short names from legislation

### DIFF
--- a/src/Carbon/Lang/lv.php
+++ b/src/Carbon/Lang/lv.php
@@ -177,6 +177,6 @@ return [
     'weekdays_short' => ['Sv.', 'P.', 'O.', 'T.', 'C.', 'Pk.', 'S.'],
     'weekdays_min' => ['Sv.', 'P.', 'O.', 'T.', 'C.', 'Pk.', 'S.'],
     'months' => ['janvārī', 'februārī', 'martā', 'aprīlī', 'maijā', 'jūnijā', 'jūlijā', 'augustā', 'septembrī', 'oktobrī', 'novembrī', 'decembrī'],
-    'months_short' => ['Janv', 'Feb', 'Mar', 'Apr', 'Mai', 'Jūn', 'Jūl', 'Aug', 'Sept', 'Okt', 'Nov', 'Dec'],
+    'months_short' => ['Janv', 'Febr', 'Martā', 'Apr', 'Maijā', 'Jūn', 'Jūl', 'Aug', 'Sept', 'Okt', 'Nov', 'Dec'],
     'meridiem' => ['priekšpusdiena', 'pēcpusdiena'],
 ];

--- a/src/Carbon/Lang/lv.php
+++ b/src/Carbon/Lang/lv.php
@@ -177,6 +177,6 @@ return [
     'weekdays_short' => ['Sv.', 'P.', 'O.', 'T.', 'C.', 'Pk.', 'S.'],
     'weekdays_min' => ['Sv.', 'P.', 'O.', 'T.', 'C.', 'Pk.', 'S.'],
     'months' => ['janvārī', 'februārī', 'martā', 'aprīlī', 'maijā', 'jūnijā', 'jūlijā', 'augustā', 'septembrī', 'oktobrī', 'novembrī', 'decembrī'],
-    'months_short' => ['Janv', 'Febr', 'Martā', 'Apr', 'Maijā', 'Jūn', 'Jūl', 'Aug', 'Sept', 'Okt', 'Nov', 'Dec'],
+    'months_short' => ['janv.', 'febr.', 'martā', 'apr.', 'maijā', 'jūn.', 'jūl.', 'aug.', 'sept.', 'okt.', 'nov.', 'dec.'],
     'meridiem' => ['priekšpusdiena', 'pēcpusdiena'],
 ];


### PR DESCRIPTION
Changed short names based on legislation "Par mēnešu nosaukumu saīsinājumiem latviešu valodā"

Fix #2479