### PR TITLE
Unify data providers method names

### DIFF
--- a/tests/Carbon/AddMonthsTest.php
+++ b/tests/Carbon/AddMonthsTest.php
@@ -33,7 +33,7 @@ class AddMonthsTest extends AbstractTestCase
         $this->carbon = $date;
     }
 
-    public function providerTestAddMonthNoOverflow(): Generator
+    public function dataForTestAddMonthNoOverflow(): Generator
     {
         yield [-2, 2015, 11, 30];
         yield [-1, 2015, 12, 31];
@@ -43,7 +43,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthNoOverflow
+     * @dataProvider \Tests\Carbon\AddMonthsTest::dataForTestAddMonthNoOverflow
      *
      * @param int $months
      * @param int $y
@@ -56,7 +56,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthNoOverflow
+     * @dataProvider \Tests\Carbon\AddMonthsTest::dataForTestAddMonthNoOverflow
      *
      * @param int $months
      * @param int $y
@@ -68,7 +68,7 @@ class AddMonthsTest extends AbstractTestCase
         $this->assertCarbon($this->carbon->addMonthsNoOverflow($months), $y, $m, $d);
     }
 
-    public function providerTestSubMonthNoOverflow(): Generator
+    public function dataForTestSubMonthNoOverflow(): Generator
     {
         yield [-2, 2016, 3, 31];
         yield [-1, 2016, 2, 29];
@@ -78,7 +78,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthNoOverflow
+     * @dataProvider \Tests\Carbon\AddMonthsTest::dataForTestSubMonthNoOverflow
      *
      * @param int $months
      * @param int $y
@@ -91,7 +91,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthNoOverflow
+     * @dataProvider \Tests\Carbon\AddMonthsTest::dataForTestSubMonthNoOverflow
      *
      * @param int $months
      * @param int $y
@@ -103,7 +103,7 @@ class AddMonthsTest extends AbstractTestCase
         $this->assertCarbon($this->carbon->subMonthsNoOverflow($months), $y, $m, $d);
     }
 
-    public function providerTestAddMonthWithOverflow(): Generator
+    public function dataForTestAddMonthWithOverflow(): Generator
     {
         yield [-2, 2015, 12, 1];
         yield [-1, 2015, 12, 31];
@@ -113,7 +113,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthWithOverflow
+     * @dataProvider \Tests\Carbon\AddMonthsTest::dataForTestAddMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -126,7 +126,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthWithOverflow
+     * @dataProvider \Tests\Carbon\AddMonthsTest::dataForTestAddMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -138,7 +138,7 @@ class AddMonthsTest extends AbstractTestCase
         $this->assertCarbon($this->carbon->addMonthsWithOverflow($months), $y, $m, $d);
     }
 
-    public function providerTestSubMonthWithOverflow(): Generator
+    public function dataForTestSubMonthWithOverflow(): Generator
     {
         yield [-2, 2016, 3, 31];
         yield [-1, 2016, 3, 2];
@@ -148,7 +148,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthWithOverflow
+     * @dataProvider \Tests\Carbon\AddMonthsTest::dataForTestSubMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -161,7 +161,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthWithOverflow
+     * @dataProvider \Tests\Carbon\AddMonthsTest::dataForTestSubMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -200,7 +200,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthWithOverflow
+     * @dataProvider \Tests\Carbon\AddMonthsTest::dataForTestAddMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -214,7 +214,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthWithOverflow
+     * @dataProvider \Tests\Carbon\AddMonthsTest::dataForTestAddMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -228,7 +228,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthWithOverflow
+     * @dataProvider \Tests\Carbon\AddMonthsTest::dataForTestSubMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -242,7 +242,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthWithOverflow
+     * @dataProvider \Tests\Carbon\AddMonthsTest::dataForTestSubMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -256,7 +256,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthNoOverflow
+     * @dataProvider \Tests\Carbon\AddMonthsTest::dataForTestAddMonthNoOverflow
      *
      * @param int $months
      * @param int $y
@@ -270,7 +270,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthNoOverflow
+     * @dataProvider \Tests\Carbon\AddMonthsTest::dataForTestAddMonthNoOverflow
      *
      * @param int $months
      * @param int $y
@@ -284,7 +284,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthNoOverflow
+     * @dataProvider \Tests\Carbon\AddMonthsTest::dataForTestSubMonthNoOverflow
      *
      * @param int $months
      * @param int $y
@@ -298,7 +298,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthNoOverflow
+     * @dataProvider \Tests\Carbon\AddMonthsTest::dataForTestSubMonthNoOverflow
      *
      * @param int $months
      * @param int $y

--- a/tests/Carbon/AddMonthsTest.php
+++ b/tests/Carbon/AddMonthsTest.php
@@ -33,7 +33,7 @@ class AddMonthsTest extends AbstractTestCase
         $this->carbon = $date;
     }
 
-    public function dataForTestAddMonthNoOverflow(): Generator
+    public static function dataForTestAddMonthNoOverflow(): Generator
     {
         yield [-2, 2015, 11, 30];
         yield [-1, 2015, 12, 31];
@@ -68,7 +68,7 @@ class AddMonthsTest extends AbstractTestCase
         $this->assertCarbon($this->carbon->addMonthsNoOverflow($months), $y, $m, $d);
     }
 
-    public function dataForTestSubMonthNoOverflow(): Generator
+    public static function dataForTestSubMonthNoOverflow(): Generator
     {
         yield [-2, 2016, 3, 31];
         yield [-1, 2016, 2, 29];
@@ -103,7 +103,7 @@ class AddMonthsTest extends AbstractTestCase
         $this->assertCarbon($this->carbon->subMonthsNoOverflow($months), $y, $m, $d);
     }
 
-    public function dataForTestAddMonthWithOverflow(): Generator
+    public static function dataForTestAddMonthWithOverflow(): Generator
     {
         yield [-2, 2015, 12, 1];
         yield [-1, 2015, 12, 31];
@@ -138,7 +138,7 @@ class AddMonthsTest extends AbstractTestCase
         $this->assertCarbon($this->carbon->addMonthsWithOverflow($months), $y, $m, $d);
     }
 
-    public function dataForTestSubMonthWithOverflow(): Generator
+    public static function dataForTestSubMonthWithOverflow(): Generator
     {
         yield [-2, 2016, 3, 31];
         yield [-1, 2016, 3, 2];

--- a/tests/Carbon/CreateTest.php
+++ b/tests/Carbon/CreateTest.php
@@ -308,7 +308,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\CreateTest::providerLocales
+     * @dataProvider \Tests\Carbon\CreateTest::dataForLocales
      * @group localization
      */
     public function testParseFromLocaleForEachLocale($locale)
@@ -385,7 +385,7 @@ class CreateTest extends AbstractTestCase
         $this->assertSame('2018-07-24 08:34', $date->format('Y-m-d H:i'));
     }
 
-    public function providerLocales(): Generator
+    public function dataForLocales(): Generator
     {
         yield ['aa_ER'];
         yield ['aa_ER@saaho'];

--- a/tests/Carbon/CreateTest.php
+++ b/tests/Carbon/CreateTest.php
@@ -308,7 +308,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider getLocales
+     * @dataProvider \Tests\Carbon\CreateTest::getLocales
      * @group localization
      */
     public function testParseFromLocaleForEachLocale($locale)

--- a/tests/Carbon/CreateTest.php
+++ b/tests/Carbon/CreateTest.php
@@ -308,7 +308,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\CreateTest::getLocales
+     * @dataProvider \Tests\Carbon\CreateTest::providerLocales
      * @group localization
      */
     public function testParseFromLocaleForEachLocale($locale)
@@ -385,7 +385,7 @@ class CreateTest extends AbstractTestCase
         $this->assertSame('2018-07-24 08:34', $date->format('Y-m-d H:i'));
     }
 
-    public function getLocales(): Generator
+    public function providerLocales(): Generator
     {
         yield ['aa_ER'];
         yield ['aa_ER@saaho'];

--- a/tests/Carbon/CreateTest.php
+++ b/tests/Carbon/CreateTest.php
@@ -385,7 +385,7 @@ class CreateTest extends AbstractTestCase
         $this->assertSame('2018-07-24 08:34', $date->format('Y-m-d H:i'));
     }
 
-    public function dataForLocales(): Generator
+    public static function dataForLocales(): Generator
     {
         yield ['aa_ER'];
         yield ['aa_ER@saaho'];

--- a/tests/Carbon/Exceptions/NotLocaleAwareExceptionTest.php
+++ b/tests/Carbon/Exceptions/NotLocaleAwareExceptionTest.php
@@ -18,7 +18,7 @@ use Tests\AbstractTestCase;
 
 class NotLocaleAwareExceptionTest extends AbstractTestCase
 {
-    public function providerTestNotAPeriodException(): Generator
+    public function dataForTestNotAPeriodException(): Generator
     {
         yield [
             new stdClass(),
@@ -31,7 +31,7 @@ class NotLocaleAwareExceptionTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\Exceptions\NotLocaleAwareExceptionTest::providerTestNotAPeriodException
+     * @dataProvider \Tests\Carbon\Exceptions\NotLocaleAwareExceptionTest::dataForTestNotAPeriodException
      *
      * @param mixed  $object
      * @param string $message

--- a/tests/Carbon/Exceptions/NotLocaleAwareExceptionTest.php
+++ b/tests/Carbon/Exceptions/NotLocaleAwareExceptionTest.php
@@ -18,7 +18,7 @@ use Tests\AbstractTestCase;
 
 class NotLocaleAwareExceptionTest extends AbstractTestCase
 {
-    public function dataForTestNotAPeriodException(): Generator
+    public static function dataForTestNotAPeriodException(): Generator
     {
         yield [
             new stdClass(),

--- a/tests/Carbon/Exceptions/NotLocaleAwareExceptionTest.php
+++ b/tests/Carbon/Exceptions/NotLocaleAwareExceptionTest.php
@@ -18,7 +18,7 @@ use Tests\AbstractTestCase;
 
 class NotLocaleAwareExceptionTest extends AbstractTestCase
 {
-    public function dataProviderTestNotAPeriodException(): Generator
+    public function providerTestNotAPeriodException(): Generator
     {
         yield [
             new stdClass(),
@@ -31,7 +31,7 @@ class NotLocaleAwareExceptionTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\Exceptions\NotLocaleAwareExceptionTest::dataProviderTestNotAPeriodException
+     * @dataProvider \Tests\Carbon\Exceptions\NotLocaleAwareExceptionTest::providerTestNotAPeriodException
      *
      * @param mixed  $object
      * @param string $message

--- a/tests/Carbon/Exceptions/NotLocaleAwareExceptionTest.php
+++ b/tests/Carbon/Exceptions/NotLocaleAwareExceptionTest.php
@@ -31,7 +31,7 @@ class NotLocaleAwareExceptionTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider dataProviderTestNotAPeriodException
+     * @dataProvider \Tests\Carbon\Exceptions\NotLocaleAwareExceptionTest::dataProviderTestNotAPeriodException
      *
      * @param mixed  $object
      * @param string $message

--- a/tests/Carbon/GettersTest.php
+++ b/tests/Carbon/GettersTest.php
@@ -242,7 +242,7 @@ class GettersTest extends AbstractTestCase
         $this->assertSame($age, $d->age);
     }
 
-    public function dataForTestQuarter(): Generator
+    public static function dataForTestQuarter(): Generator
     {
         yield [1, 1];
         yield [2, 1];

--- a/tests/Carbon/GettersTest.php
+++ b/tests/Carbon/GettersTest.php
@@ -242,7 +242,7 @@ class GettersTest extends AbstractTestCase
         $this->assertSame($age, $d->age);
     }
 
-    public function providerTestQuarter(): Generator
+    public function dataForTestQuarter(): Generator
     {
         yield [1, 1];
         yield [2, 1];
@@ -259,7 +259,7 @@ class GettersTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\GettersTest::providerTestQuarter
+     * @dataProvider \Tests\Carbon\GettersTest::dataForTestQuarter
      *
      * @param int $month
      * @param int $quarter
@@ -271,7 +271,7 @@ class GettersTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\GettersTest::providerTestQuarter
+     * @dataProvider \Tests\Carbon\GettersTest::dataForTestQuarter
      *
      * @param int $month
      * @param int $quarter
@@ -283,7 +283,7 @@ class GettersTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\GettersTest::providerTestQuarter
+     * @dataProvider \Tests\Carbon\GettersTest::dataForTestQuarter
      *
      * @param int $month
      * @param int $quarter

--- a/tests/Carbon/GettersTest.php
+++ b/tests/Carbon/GettersTest.php
@@ -242,7 +242,7 @@ class GettersTest extends AbstractTestCase
         $this->assertSame($age, $d->age);
     }
 
-    public function dataProviderTestQuarter(): Generator
+    public function providerTestQuarter(): Generator
     {
         yield [1, 1];
         yield [2, 1];
@@ -259,7 +259,7 @@ class GettersTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\GettersTest::dataProviderTestQuarter
+     * @dataProvider \Tests\Carbon\GettersTest::providerTestQuarter
      *
      * @param int $month
      * @param int $quarter
@@ -271,7 +271,7 @@ class GettersTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\GettersTest::dataProviderTestQuarter
+     * @dataProvider \Tests\Carbon\GettersTest::providerTestQuarter
      *
      * @param int $month
      * @param int $quarter
@@ -283,7 +283,7 @@ class GettersTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\GettersTest::dataProviderTestQuarter
+     * @dataProvider \Tests\Carbon\GettersTest::providerTestQuarter
      *
      * @param int $month
      * @param int $quarter

--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -928,7 +928,7 @@ class IsTest extends AbstractTestCase
         $this->assertFalse(Carbon::hasFormatWithModifiers('1975705-01', 'Y#m#d'));
     }
 
-    public function getFormatLetters(): Generator
+    public function providerFormatLetters(): Generator
     {
         yield ['d'];
         yield ['D'];
@@ -971,7 +971,7 @@ class IsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\IsTest::getFormatLetters
+     * @dataProvider \Tests\Carbon\IsTest::providerFormatLetters
      */
     public function testHasFormatWithSingleLetter($letter)
     {

--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -928,7 +928,7 @@ class IsTest extends AbstractTestCase
         $this->assertFalse(Carbon::hasFormatWithModifiers('1975705-01', 'Y#m#d'));
     }
 
-    public function dataForFormatLetters(): Generator
+    public static function dataForFormatLetters(): Generator
     {
         yield ['d'];
         yield ['D'];

--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -971,7 +971,7 @@ class IsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider getFormatLetters
+     * @dataProvider \Tests\Carbon\IsTest::getFormatLetters
      */
     public function testHasFormatWithSingleLetter($letter)
     {

--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -928,7 +928,7 @@ class IsTest extends AbstractTestCase
         $this->assertFalse(Carbon::hasFormatWithModifiers('1975705-01', 'Y#m#d'));
     }
 
-    public function providerFormatLetters(): Generator
+    public function dataForFormatLetters(): Generator
     {
         yield ['d'];
         yield ['D'];
@@ -971,7 +971,7 @@ class IsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\IsTest::providerFormatLetters
+     * @dataProvider \Tests\Carbon\IsTest::dataForFormatLetters
      */
     public function testHasFormatWithSingleLetter($letter)
     {

--- a/tests/Carbon/IssetTest.php
+++ b/tests/Carbon/IssetTest.php
@@ -23,7 +23,7 @@ class IssetTest extends AbstractTestCase
         $this->assertFalse(isset($this->now->sdfsdfss));
     }
 
-    public function dataForTestIssetReturnTrueForProperties(): Generator
+    public static function dataForTestIssetReturnTrueForProperties(): Generator
     {
         yield ['age'];
         yield ['century'];

--- a/tests/Carbon/IssetTest.php
+++ b/tests/Carbon/IssetTest.php
@@ -23,7 +23,7 @@ class IssetTest extends AbstractTestCase
         $this->assertFalse(isset($this->now->sdfsdfss));
     }
 
-    public function providerTestIssetReturnTrueForProperties(): Generator
+    public function dataForTestIssetReturnTrueForProperties(): Generator
     {
         yield ['age'];
         yield ['century'];
@@ -93,7 +93,7 @@ class IssetTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\IssetTest::providerTestIssetReturnTrueForProperties
+     * @dataProvider \Tests\Carbon\IssetTest::dataForTestIssetReturnTrueForProperties
      *
      * @param string $property
      */

--- a/tests/Carbon/LocalizationTest.php
+++ b/tests/Carbon/LocalizationTest.php
@@ -174,7 +174,7 @@ class LocalizationTest extends AbstractTestCase
      *
      * @return \Generator
      */
-    public function providerLocales(): Generator
+    public function dataForLocales(): Generator
     {
         yield ['af'];
         yield ['ar'];
@@ -315,7 +315,7 @@ class LocalizationTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\LocalizationTest::providerLocales
+     * @dataProvider \Tests\Carbon\LocalizationTest::dataForLocales
      *
      * @param string $locale
      */
@@ -326,7 +326,7 @@ class LocalizationTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\LocalizationTest::providerLocales
+     * @dataProvider \Tests\Carbon\LocalizationTest::dataForLocales
      *
      * @param string $locale
      */
@@ -355,7 +355,7 @@ class LocalizationTest extends AbstractTestCase
      *
      * @return \Generator
      */
-    public function providerTestSetLocaleWithMalformedLocale(): Generator
+    public function dataForTestSetLocaleWithMalformedLocale(): Generator
     {
         yield ['DE'];
         yield ['pt-BR'];
@@ -368,7 +368,7 @@ class LocalizationTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\LocalizationTest::providerTestSetLocaleWithMalformedLocale
+     * @dataProvider \Tests\Carbon\LocalizationTest::dataForTestSetLocaleWithMalformedLocale
      *
      * @param string $malformedLocale
      */

--- a/tests/Carbon/LocalizationTest.php
+++ b/tests/Carbon/LocalizationTest.php
@@ -174,7 +174,7 @@ class LocalizationTest extends AbstractTestCase
      *
      * @return \Generator
      */
-    public function dataForLocales(): Generator
+    public static function dataForLocales(): Generator
     {
         yield ['af'];
         yield ['ar'];
@@ -355,7 +355,7 @@ class LocalizationTest extends AbstractTestCase
      *
      * @return \Generator
      */
-    public function dataForTestSetLocaleWithMalformedLocale(): Generator
+    public static function dataForTestSetLocaleWithMalformedLocale(): Generator
     {
         yield ['DE'];
         yield ['pt-BR'];

--- a/tests/Carbon/LocalizationTest.php
+++ b/tests/Carbon/LocalizationTest.php
@@ -355,7 +355,7 @@ class LocalizationTest extends AbstractTestCase
      *
      * @return \Generator
      */
-    public function dataProviderTestSetLocaleWithMalformedLocale(): Generator
+    public function providerTestSetLocaleWithMalformedLocale(): Generator
     {
         yield ['DE'];
         yield ['pt-BR'];
@@ -368,7 +368,7 @@ class LocalizationTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\LocalizationTest::dataProviderTestSetLocaleWithMalformedLocale
+     * @dataProvider \Tests\Carbon\LocalizationTest::providerTestSetLocaleWithMalformedLocale
      *
      * @param string $malformedLocale
      */

--- a/tests/Carbon/ModifyNearDSTChangeTest.php
+++ b/tests/Carbon/ModifyNearDSTChangeTest.php
@@ -25,7 +25,7 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
      * @param string $dateString
      * @param int    $addHours
      * @param string $expected
-     * @dataProvider getTransitionTests
+     * @dataProvider \Tests\Carbon\ModifyNearDSTChangeTest::getTransitionTests
      */
     public function testTransitionInNonDefaultTimezone($dateString, $addHours, $expected)
     {
@@ -41,7 +41,7 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
      * @param string $dateString
      * @param int    $addHours
      * @param string $expected
-     * @dataProvider getTransitionTests
+     * @dataProvider \Tests\Carbon\ModifyNearDSTChangeTest::getTransitionTests
      */
     public function testTransitionInDefaultTimezone($dateString, $addHours, $expected)
     {

--- a/tests/Carbon/ModifyNearDSTChangeTest.php
+++ b/tests/Carbon/ModifyNearDSTChangeTest.php
@@ -25,7 +25,7 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
      * @param string $dateString
      * @param int    $addHours
      * @param string $expected
-     * @dataProvider \Tests\Carbon\ModifyNearDSTChangeTest::providerTransitionTests
+     * @dataProvider \Tests\Carbon\ModifyNearDSTChangeTest::dataForTransitionTests
      */
     public function testTransitionInNonDefaultTimezone($dateString, $addHours, $expected)
     {
@@ -41,7 +41,7 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
      * @param string $dateString
      * @param int    $addHours
      * @param string $expected
-     * @dataProvider \Tests\Carbon\ModifyNearDSTChangeTest::providerTransitionTests
+     * @dataProvider \Tests\Carbon\ModifyNearDSTChangeTest::dataForTransitionTests
      */
     public function testTransitionInDefaultTimezone($dateString, $addHours, $expected)
     {
@@ -51,7 +51,7 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
         $this->assertSame($expected, $date->format('c'));
     }
 
-    public function providerTransitionTests(): Generator
+    public function dataForTransitionTests(): Generator
     {
         // arguments:
         // - Date string to Carbon::parse in America/New_York.

--- a/tests/Carbon/ModifyNearDSTChangeTest.php
+++ b/tests/Carbon/ModifyNearDSTChangeTest.php
@@ -25,7 +25,7 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
      * @param string $dateString
      * @param int    $addHours
      * @param string $expected
-     * @dataProvider \Tests\Carbon\ModifyNearDSTChangeTest::getTransitionTests
+     * @dataProvider \Tests\Carbon\ModifyNearDSTChangeTest::providerTransitionTests
      */
     public function testTransitionInNonDefaultTimezone($dateString, $addHours, $expected)
     {
@@ -41,7 +41,7 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
      * @param string $dateString
      * @param int    $addHours
      * @param string $expected
-     * @dataProvider \Tests\Carbon\ModifyNearDSTChangeTest::getTransitionTests
+     * @dataProvider \Tests\Carbon\ModifyNearDSTChangeTest::providerTransitionTests
      */
     public function testTransitionInDefaultTimezone($dateString, $addHours, $expected)
     {
@@ -51,7 +51,7 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
         $this->assertSame($expected, $date->format('c'));
     }
 
-    public function getTransitionTests(): Generator
+    public function providerTransitionTests(): Generator
     {
         // arguments:
         // - Date string to Carbon::parse in America/New_York.

--- a/tests/Carbon/ModifyNearDSTChangeTest.php
+++ b/tests/Carbon/ModifyNearDSTChangeTest.php
@@ -51,7 +51,7 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
         $this->assertSame($expected, $date->format('c'));
     }
 
-    public function dataForTransitionTests(): Generator
+    public static function dataForTransitionTests(): Generator
     {
         // arguments:
         // - Date string to Carbon::parse in America/New_York.

--- a/tests/Carbon/SerializationTest.php
+++ b/tests/Carbon/SerializationTest.php
@@ -66,7 +66,7 @@ class SerializationTest extends AbstractTestCase
         $this->assertSame('mercredi 18:30:11.654321', $copy->tz('Europe/Paris')->isoFormat('dddd HH:mm:ss.SSSSSS'));
     }
 
-    public function dataForTestFromUnserializedWithInvalidValue(): Generator
+    public static function dataForTestFromUnserializedWithInvalidValue(): Generator
     {
         yield [null];
         yield [true];

--- a/tests/Carbon/SerializationTest.php
+++ b/tests/Carbon/SerializationTest.php
@@ -66,7 +66,7 @@ class SerializationTest extends AbstractTestCase
         $this->assertSame('mercredi 18:30:11.654321', $copy->tz('Europe/Paris')->isoFormat('dddd HH:mm:ss.SSSSSS'));
     }
 
-    public function providerTestFromUnserializedWithInvalidValue(): Generator
+    public function dataForTestFromUnserializedWithInvalidValue(): Generator
     {
         yield [null];
         yield [true];
@@ -78,7 +78,7 @@ class SerializationTest extends AbstractTestCase
     /**
      * @param mixed $value
      *
-     * @dataProvider \Tests\Carbon\SerializationTest::providerTestFromUnserializedWithInvalidValue
+     * @dataProvider \Tests\Carbon\SerializationTest::dataForTestFromUnserializedWithInvalidValue
      */
     public function testFromUnserializedWithInvalidValue($value)
     {

--- a/tests/Carbon/SettersTest.php
+++ b/tests/Carbon/SettersTest.php
@@ -513,7 +513,7 @@ class SettersTest extends AbstractTestCase
         $this->assertCarbon($d, 2016, 2, 12, $hour, $minute, $second);
     }
 
-    public function dataForTestSetTimeFromTimeString(): Generator
+    public static function dataForTestSetTimeFromTimeString(): Generator
     {
         yield [9, 15, 30, '09:15:30'];
         yield [9, 15, 0, '09:15'];

--- a/tests/Carbon/SettersTest.php
+++ b/tests/Carbon/SettersTest.php
@@ -499,7 +499,7 @@ class SettersTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\SettersTest::providerTestSetTimeFromTimeString
+     * @dataProvider \Tests\Carbon\SettersTest::dataForTestSetTimeFromTimeString
      *
      * @param int    $hour
      * @param int    $minute
@@ -513,7 +513,7 @@ class SettersTest extends AbstractTestCase
         $this->assertCarbon($d, 2016, 2, 12, $hour, $minute, $second);
     }
 
-    public function providerTestSetTimeFromTimeString(): Generator
+    public function dataForTestSetTimeFromTimeString(): Generator
     {
         yield [9, 15, 30, '09:15:30'];
         yield [9, 15, 0, '09:15'];

--- a/tests/Carbon/SettersTest.php
+++ b/tests/Carbon/SettersTest.php
@@ -499,7 +499,7 @@ class SettersTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\SettersTest::dataProviderTestSetTimeFromTimeString
+     * @dataProvider \Tests\Carbon\SettersTest::providerTestSetTimeFromTimeString
      *
      * @param int    $hour
      * @param int    $minute
@@ -513,7 +513,7 @@ class SettersTest extends AbstractTestCase
         $this->assertCarbon($d, 2016, 2, 12, $hour, $minute, $second);
     }
 
-    public function dataProviderTestSetTimeFromTimeString(): Generator
+    public function providerTestSetTimeFromTimeString(): Generator
     {
         yield [9, 15, 30, '09:15:30'];
         yield [9, 15, 0, '09:15'];

--- a/tests/Carbon/StartEndOfTest.php
+++ b/tests/Carbon/StartEndOfTest.php
@@ -442,7 +442,7 @@ class StartEndOfTest extends AbstractTestCase
         $this->assertInstanceOfCarbon($dt->startOfQuarter());
     }
 
-    public function dataForTestStartOfQuarter(): Generator
+    public static function dataForTestStartOfQuarter(): Generator
     {
         yield [1, 1];
         yield [2, 1];
@@ -476,7 +476,7 @@ class StartEndOfTest extends AbstractTestCase
         $this->assertInstanceOfCarbon($dt->endOfQuarter());
     }
 
-    public function dataForTestEndOfQuarter(): Generator
+    public static function dataForTestEndOfQuarter(): Generator
     {
         yield [1, 3, 31];
         yield [2, 3, 31];

--- a/tests/Carbon/StartEndOfTest.php
+++ b/tests/Carbon/StartEndOfTest.php
@@ -442,7 +442,7 @@ class StartEndOfTest extends AbstractTestCase
         $this->assertInstanceOfCarbon($dt->startOfQuarter());
     }
 
-    public function providerTestStartOfQuarter(): Generator
+    public function dataForTestStartOfQuarter(): Generator
     {
         yield [1, 1];
         yield [2, 1];
@@ -459,7 +459,7 @@ class StartEndOfTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\StartEndOfTest::providerTestStartOfQuarter
+     * @dataProvider \Tests\Carbon\StartEndOfTest::dataForTestStartOfQuarter
      *
      * @param int $month
      * @param int $startOfQuarterMonth
@@ -476,7 +476,7 @@ class StartEndOfTest extends AbstractTestCase
         $this->assertInstanceOfCarbon($dt->endOfQuarter());
     }
 
-    public function providerTestEndOfQuarter(): Generator
+    public function dataForTestEndOfQuarter(): Generator
     {
         yield [1, 3, 31];
         yield [2, 3, 31];
@@ -493,7 +493,7 @@ class StartEndOfTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\StartEndOfTest::providerTestEndOfQuarter
+     * @dataProvider \Tests\Carbon\StartEndOfTest::dataForTestEndOfQuarter
      *
      * @param int $month
      * @param int $endOfQuarterMonth

--- a/tests/Carbon/StartEndOfTest.php
+++ b/tests/Carbon/StartEndOfTest.php
@@ -442,7 +442,7 @@ class StartEndOfTest extends AbstractTestCase
         $this->assertInstanceOfCarbon($dt->startOfQuarter());
     }
 
-    public function dataProviderTestStartOfQuarter(): Generator
+    public function providerTestStartOfQuarter(): Generator
     {
         yield [1, 1];
         yield [2, 1];
@@ -459,7 +459,7 @@ class StartEndOfTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\StartEndOfTest::dataProviderTestStartOfQuarter
+     * @dataProvider \Tests\Carbon\StartEndOfTest::providerTestStartOfQuarter
      *
      * @param int $month
      * @param int $startOfQuarterMonth
@@ -476,7 +476,7 @@ class StartEndOfTest extends AbstractTestCase
         $this->assertInstanceOfCarbon($dt->endOfQuarter());
     }
 
-    public function dataProviderTestEndOfQuarter(): Generator
+    public function providerTestEndOfQuarter(): Generator
     {
         yield [1, 3, 31];
         yield [2, 3, 31];
@@ -493,7 +493,7 @@ class StartEndOfTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\StartEndOfTest::dataProviderTestEndOfQuarter
+     * @dataProvider \Tests\Carbon\StartEndOfTest::providerTestEndOfQuarter
      *
      * @param int $month
      * @param int $endOfQuarterMonth

--- a/tests/CarbonImmutable/AddMonthsTest.php
+++ b/tests/CarbonImmutable/AddMonthsTest.php
@@ -45,7 +45,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthNoOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestAddMonthNoOverflow
      *
      * @param int $months
      * @param int $y
@@ -58,7 +58,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthNoOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestAddMonthNoOverflow
      *
      * @param int $months
      * @param int $y
@@ -82,7 +82,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthNoOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestSubMonthNoOverflow
      *
      * @param int $months
      * @param int $y
@@ -95,7 +95,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthNoOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestSubMonthNoOverflow
      *
      * @param int $months
      * @param int $y
@@ -119,7 +119,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthWithOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestAddMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -132,7 +132,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthWithOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestAddMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -156,7 +156,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthWithOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestSubMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -169,7 +169,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthWithOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestSubMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -208,7 +208,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthWithOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestAddMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -222,7 +222,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthWithOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestAddMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -236,7 +236,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthWithOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestSubMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -250,7 +250,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthWithOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestSubMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -264,7 +264,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthNoOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestAddMonthNoOverflow
      *
      * @param int $months
      * @param int $y
@@ -278,7 +278,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestAddMonthNoOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestAddMonthNoOverflow
      *
      * @param int $months
      * @param int $y
@@ -292,7 +292,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthNoOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestSubMonthNoOverflow
      *
      * @param int $months
      * @param int $y
@@ -306,7 +306,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\AddMonthsTest::providerTestSubMonthNoOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestSubMonthNoOverflow
      *
      * @param int $months
      * @param int $y

--- a/tests/CarbonImmutable/AddMonthsTest.php
+++ b/tests/CarbonImmutable/AddMonthsTest.php
@@ -33,7 +33,7 @@ class AddMonthsTest extends AbstractTestCase
         $this->carbon = $date;
     }
 
-    public function providerTestAddMonthNoOverflow()
+    public function dataForTestAddMonthNoOverflow()
     {
         return [
             [-2, 2015, 11, 30],
@@ -45,7 +45,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestAddMonthNoOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::dataForTestAddMonthNoOverflow
      *
      * @param int $months
      * @param int $y
@@ -58,7 +58,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestAddMonthNoOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::dataForTestAddMonthNoOverflow
      *
      * @param int $months
      * @param int $y
@@ -70,7 +70,7 @@ class AddMonthsTest extends AbstractTestCase
         $this->assertCarbon($this->carbon->addMonthsNoOverflow($months), $y, $m, $d);
     }
 
-    public function providerTestSubMonthNoOverflow()
+    public function dataForTestSubMonthNoOverflow()
     {
         return [
             [-2, 2016, 3, 31],
@@ -82,7 +82,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestSubMonthNoOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::dataForTestSubMonthNoOverflow
      *
      * @param int $months
      * @param int $y
@@ -95,7 +95,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestSubMonthNoOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::dataForTestSubMonthNoOverflow
      *
      * @param int $months
      * @param int $y
@@ -107,7 +107,7 @@ class AddMonthsTest extends AbstractTestCase
         $this->assertCarbon($this->carbon->subMonthsNoOverflow($months), $y, $m, $d);
     }
 
-    public function providerTestAddMonthWithOverflow()
+    public function dataForTestAddMonthWithOverflow()
     {
         return [
             [-2, 2015, 12, 1],
@@ -119,7 +119,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestAddMonthWithOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::dataForTestAddMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -132,7 +132,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestAddMonthWithOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::dataForTestAddMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -144,7 +144,7 @@ class AddMonthsTest extends AbstractTestCase
         $this->assertCarbon($this->carbon->addMonthsWithOverflow($months), $y, $m, $d);
     }
 
-    public function providerTestSubMonthWithOverflow()
+    public function dataForTestSubMonthWithOverflow()
     {
         return [
             [-2, 2016, 3, 31],
@@ -156,7 +156,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestSubMonthWithOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::dataForTestSubMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -169,7 +169,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestSubMonthWithOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::dataForTestSubMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -208,7 +208,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestAddMonthWithOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::dataForTestAddMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -222,7 +222,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestAddMonthWithOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::dataForTestAddMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -236,7 +236,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestSubMonthWithOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::dataForTestSubMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -250,7 +250,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestSubMonthWithOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::dataForTestSubMonthWithOverflow
      *
      * @param int $months
      * @param int $y
@@ -264,7 +264,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestAddMonthNoOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::dataForTestAddMonthNoOverflow
      *
      * @param int $months
      * @param int $y
@@ -278,7 +278,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestAddMonthNoOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::dataForTestAddMonthNoOverflow
      *
      * @param int $months
      * @param int $y
@@ -292,7 +292,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestSubMonthNoOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::dataForTestSubMonthNoOverflow
      *
      * @param int $months
      * @param int $y
@@ -306,7 +306,7 @@ class AddMonthsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::providerTestSubMonthNoOverflow
+     * @dataProvider \Tests\CarbonImmutable\AddMonthsTest::dataForTestSubMonthNoOverflow
      *
      * @param int $months
      * @param int $y

--- a/tests/CarbonImmutable/AddMonthsTest.php
+++ b/tests/CarbonImmutable/AddMonthsTest.php
@@ -33,7 +33,7 @@ class AddMonthsTest extends AbstractTestCase
         $this->carbon = $date;
     }
 
-    public function dataForTestAddMonthNoOverflow()
+    public static function dataForTestAddMonthNoOverflow()
     {
         return [
             [-2, 2015, 11, 30],
@@ -70,7 +70,7 @@ class AddMonthsTest extends AbstractTestCase
         $this->assertCarbon($this->carbon->addMonthsNoOverflow($months), $y, $m, $d);
     }
 
-    public function dataForTestSubMonthNoOverflow()
+    public static function dataForTestSubMonthNoOverflow()
     {
         return [
             [-2, 2016, 3, 31],
@@ -107,7 +107,7 @@ class AddMonthsTest extends AbstractTestCase
         $this->assertCarbon($this->carbon->subMonthsNoOverflow($months), $y, $m, $d);
     }
 
-    public function dataForTestAddMonthWithOverflow()
+    public static function dataForTestAddMonthWithOverflow()
     {
         return [
             [-2, 2015, 12, 1],
@@ -144,7 +144,7 @@ class AddMonthsTest extends AbstractTestCase
         $this->assertCarbon($this->carbon->addMonthsWithOverflow($months), $y, $m, $d);
     }
 
-    public function dataForTestSubMonthWithOverflow()
+    public static function dataForTestSubMonthWithOverflow()
     {
         return [
             [-2, 2016, 3, 31],

--- a/tests/CarbonImmutable/GettersTest.php
+++ b/tests/CarbonImmutable/GettersTest.php
@@ -166,7 +166,7 @@ class GettersTest extends AbstractTestCase
         $this->assertSame($age, $d->age);
     }
 
-    public function dataForTestQuarter()
+    public static function dataForTestQuarter()
     {
         return [
             [1, 1],

--- a/tests/CarbonImmutable/GettersTest.php
+++ b/tests/CarbonImmutable/GettersTest.php
@@ -166,7 +166,7 @@ class GettersTest extends AbstractTestCase
         $this->assertSame($age, $d->age);
     }
 
-    public function providerTestQuarter()
+    public function dataForTestQuarter()
     {
         return [
             [1, 1],
@@ -185,7 +185,7 @@ class GettersTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\GettersTest::providerTestQuarter
+     * @dataProvider \Tests\CarbonImmutable\GettersTest::dataForTestQuarter
      *
      * @param int $month
      * @param int $quarter
@@ -197,7 +197,7 @@ class GettersTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\GettersTest::providerTestQuarter
+     * @dataProvider \Tests\CarbonImmutable\GettersTest::dataForTestQuarter
      *
      * @param int $month
      * @param int $quarter
@@ -209,7 +209,7 @@ class GettersTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\GettersTest::providerTestQuarter
+     * @dataProvider \Tests\CarbonImmutable\GettersTest::dataForTestQuarter
      *
      * @param int $month
      * @param int $quarter

--- a/tests/CarbonImmutable/GettersTest.php
+++ b/tests/CarbonImmutable/GettersTest.php
@@ -166,7 +166,7 @@ class GettersTest extends AbstractTestCase
         $this->assertSame($age, $d->age);
     }
 
-    public function dataProviderTestQuarter()
+    public function providerTestQuarter()
     {
         return [
             [1, 1],
@@ -185,7 +185,7 @@ class GettersTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\GettersTest::dataProviderTestQuarter
+     * @dataProvider \Tests\CarbonImmutable\GettersTest::providerTestQuarter
      *
      * @param int $month
      * @param int $quarter
@@ -197,7 +197,7 @@ class GettersTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\GettersTest::dataProviderTestQuarter
+     * @dataProvider \Tests\CarbonImmutable\GettersTest::providerTestQuarter
      *
      * @param int $month
      * @param int $quarter
@@ -209,7 +209,7 @@ class GettersTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\GettersTest::dataProviderTestQuarter
+     * @dataProvider \Tests\CarbonImmutable\GettersTest::providerTestQuarter
      *
      * @param int $month
      * @param int $quarter

--- a/tests/CarbonImmutable/GettersTest.php
+++ b/tests/CarbonImmutable/GettersTest.php
@@ -185,7 +185,7 @@ class GettersTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\GettersTest::dataProviderTestQuarter
+     * @dataProvider \Tests\CarbonImmutable\GettersTest::dataProviderTestQuarter
      *
      * @param int $month
      * @param int $quarter
@@ -197,7 +197,7 @@ class GettersTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\GettersTest::dataProviderTestQuarter
+     * @dataProvider \Tests\CarbonImmutable\GettersTest::dataProviderTestQuarter
      *
      * @param int $month
      * @param int $quarter
@@ -209,7 +209,7 @@ class GettersTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\GettersTest::dataProviderTestQuarter
+     * @dataProvider \Tests\CarbonImmutable\GettersTest::dataProviderTestQuarter
      *
      * @param int $month
      * @param int $quarter

--- a/tests/CarbonImmutable/IsTest.php
+++ b/tests/CarbonImmutable/IsTest.php
@@ -915,7 +915,7 @@ class IsTest extends AbstractTestCase
         $this->assertFalse(Carbon::hasFormat('12/30/2019', 'd/m/Y'));
     }
 
-    public function providerFormatLetters(): Generator
+    public function dataForFormatLetters(): Generator
     {
         yield ['d'];
         yield ['D'];
@@ -958,7 +958,7 @@ class IsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\IsTest::providerFormatLetters
+     * @dataProvider \Tests\CarbonImmutable\IsTest::dataForFormatLetters
      */
     public function testHasFormatWithSingleLetter($letter)
     {

--- a/tests/CarbonImmutable/IsTest.php
+++ b/tests/CarbonImmutable/IsTest.php
@@ -915,7 +915,7 @@ class IsTest extends AbstractTestCase
         $this->assertFalse(Carbon::hasFormat('12/30/2019', 'd/m/Y'));
     }
 
-    public function getFormatLetters(): Generator
+    public function providerFormatLetters(): Generator
     {
         yield ['d'];
         yield ['D'];
@@ -958,7 +958,7 @@ class IsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\IsTest::getFormatLetters
+     * @dataProvider \Tests\CarbonImmutable\IsTest::providerFormatLetters
      */
     public function testHasFormatWithSingleLetter($letter)
     {

--- a/tests/CarbonImmutable/IsTest.php
+++ b/tests/CarbonImmutable/IsTest.php
@@ -958,7 +958,7 @@ class IsTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider getFormatLetters
+     * @dataProvider \Tests\CarbonImmutable\IsTest::getFormatLetters
      */
     public function testHasFormatWithSingleLetter($letter)
     {

--- a/tests/CarbonImmutable/IsTest.php
+++ b/tests/CarbonImmutable/IsTest.php
@@ -915,7 +915,7 @@ class IsTest extends AbstractTestCase
         $this->assertFalse(Carbon::hasFormat('12/30/2019', 'd/m/Y'));
     }
 
-    public function dataForFormatLetters(): Generator
+    public static function dataForFormatLetters(): Generator
     {
         yield ['d'];
         yield ['D'];

--- a/tests/CarbonImmutable/IssetTest.php
+++ b/tests/CarbonImmutable/IssetTest.php
@@ -23,7 +23,7 @@ class IssetTest extends AbstractTestCase
         $this->assertFalse(isset($this->immutableNow->sdfsdfss));
     }
 
-    public function dataForTestIssetReturnTrueForProperties(): Generator
+    public static function dataForTestIssetReturnTrueForProperties(): Generator
     {
         yield ['age'];
         yield ['century'];

--- a/tests/CarbonImmutable/IssetTest.php
+++ b/tests/CarbonImmutable/IssetTest.php
@@ -23,7 +23,7 @@ class IssetTest extends AbstractTestCase
         $this->assertFalse(isset($this->immutableNow->sdfsdfss));
     }
 
-    public function providerTestIssetReturnTrueForProperties(): Generator
+    public function dataForTestIssetReturnTrueForProperties(): Generator
     {
         yield ['age'];
         yield ['century'];
@@ -93,7 +93,7 @@ class IssetTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\IssetTest::providerTestIssetReturnTrueForProperties
+     * @dataProvider \Tests\CarbonImmutable\IssetTest::dataForTestIssetReturnTrueForProperties
      *
      * @param string $property
      */

--- a/tests/CarbonImmutable/LocalizationTest.php
+++ b/tests/CarbonImmutable/LocalizationTest.php
@@ -173,7 +173,7 @@ class LocalizationTest extends AbstractTestCase
      *
      * @return array
      */
-    public function dataForLocales()
+    public static function dataForLocales()
     {
         return [
             ['af'],
@@ -355,7 +355,7 @@ class LocalizationTest extends AbstractTestCase
      *
      * @return array
      */
-    public function dataForTestSetLocaleWithMalformedLocale()
+    public static function dataForTestSetLocaleWithMalformedLocale()
     {
         return [
             ['DE'],

--- a/tests/CarbonImmutable/LocalizationTest.php
+++ b/tests/CarbonImmutable/LocalizationTest.php
@@ -168,8 +168,8 @@ class LocalizationTest extends AbstractTestCase
     }
 
     /**
-     * @see \Tests\Carbon\LocalizationTest::testSetLocale
-     * @see \Tests\Carbon\LocalizationTest::testSetTranslator
+     * @see \Tests\CarbonImmutable\LocalizationTest::testSetLocale
+     * @see \Tests\CarbonImmutable\LocalizationTest::testSetTranslator
      *
      * @return array
      */
@@ -316,7 +316,7 @@ class LocalizationTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\LocalizationTest::providerLocales
+     * @dataProvider \Tests\CarbonImmutable\LocalizationTest::providerLocales
      *
      * @param string $locale
      */
@@ -327,7 +327,7 @@ class LocalizationTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\LocalizationTest::providerLocales
+     * @dataProvider \Tests\CarbonImmutable\LocalizationTest::providerLocales
      *
      * @param string $locale
      */
@@ -351,7 +351,7 @@ class LocalizationTest extends AbstractTestCase
     }
 
     /**
-     * @see \Tests\Carbon\LocalizationTest::testSetLocaleWithMalformedLocale
+     * @see \Tests\CarbonImmutable\LocalizationTest::testSetLocaleWithMalformedLocale
      *
      * @return array
      */
@@ -370,7 +370,7 @@ class LocalizationTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\LocalizationTest::dataProviderTestSetLocaleWithMalformedLocale
+     * @dataProvider \Tests\CarbonImmutable\LocalizationTest::dataProviderTestSetLocaleWithMalformedLocale
      *
      * @param string $malformedLocale
      */

--- a/tests/CarbonImmutable/LocalizationTest.php
+++ b/tests/CarbonImmutable/LocalizationTest.php
@@ -173,7 +173,7 @@ class LocalizationTest extends AbstractTestCase
      *
      * @return array
      */
-    public function providerLocales()
+    public function dataForLocales()
     {
         return [
             ['af'],
@@ -316,7 +316,7 @@ class LocalizationTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\LocalizationTest::providerLocales
+     * @dataProvider \Tests\CarbonImmutable\LocalizationTest::dataForLocales
      *
      * @param string $locale
      */
@@ -327,7 +327,7 @@ class LocalizationTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\LocalizationTest::providerLocales
+     * @dataProvider \Tests\CarbonImmutable\LocalizationTest::dataForLocales
      *
      * @param string $locale
      */
@@ -355,7 +355,7 @@ class LocalizationTest extends AbstractTestCase
      *
      * @return array
      */
-    public function providerTestSetLocaleWithMalformedLocale()
+    public function dataForTestSetLocaleWithMalformedLocale()
     {
         return [
             ['DE'],
@@ -370,7 +370,7 @@ class LocalizationTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\LocalizationTest::providerTestSetLocaleWithMalformedLocale
+     * @dataProvider \Tests\CarbonImmutable\LocalizationTest::dataForTestSetLocaleWithMalformedLocale
      *
      * @param string $malformedLocale
      */

--- a/tests/CarbonImmutable/LocalizationTest.php
+++ b/tests/CarbonImmutable/LocalizationTest.php
@@ -355,7 +355,7 @@ class LocalizationTest extends AbstractTestCase
      *
      * @return array
      */
-    public function dataProviderTestSetLocaleWithMalformedLocale()
+    public function providerTestSetLocaleWithMalformedLocale()
     {
         return [
             ['DE'],
@@ -370,7 +370,7 @@ class LocalizationTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\LocalizationTest::dataProviderTestSetLocaleWithMalformedLocale
+     * @dataProvider \Tests\CarbonImmutable\LocalizationTest::providerTestSetLocaleWithMalformedLocale
      *
      * @param string $malformedLocale
      */

--- a/tests/CarbonImmutable/ModifyNearDSTChangeTest.php
+++ b/tests/CarbonImmutable/ModifyNearDSTChangeTest.php
@@ -25,7 +25,7 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
      * @param string $dateString
      * @param int    $addHours
      * @param string $expected
-     * @dataProvider \Tests\CarbonImmutable\ModifyNearDSTChangeTest::providerTransitionTests
+     * @dataProvider \Tests\CarbonImmutable\ModifyNearDSTChangeTest::dataForTransitionTests
      */
     public function testTransitionInNonDefaultTimezone($dateString, $addHours, $expected)
     {
@@ -41,7 +41,7 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
      * @param string $dateString
      * @param int    $addHours
      * @param string $expected
-     * @dataProvider \Tests\CarbonImmutable\ModifyNearDSTChangeTest::providerTransitionTests
+     * @dataProvider \Tests\CarbonImmutable\ModifyNearDSTChangeTest::dataForTransitionTests
      */
     public function testTransitionInDefaultTimezone($dateString, $addHours, $expected)
     {
@@ -51,7 +51,7 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
         $this->assertSame($expected, $date->format('c'));
     }
 
-    public function providerTransitionTests(): Generator
+    public function dataForTransitionTests(): Generator
     {
         // arguments:
         // - Date string to Carbon::parse in America/New_York.

--- a/tests/CarbonImmutable/ModifyNearDSTChangeTest.php
+++ b/tests/CarbonImmutable/ModifyNearDSTChangeTest.php
@@ -25,7 +25,7 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
      * @param string $dateString
      * @param int    $addHours
      * @param string $expected
-     * @dataProvider getTransitionTests
+     * @dataProvider \Tests\CarbonImmutable\ModifyNearDSTChangeTest::getTransitionTests
      */
     public function testTransitionInNonDefaultTimezone($dateString, $addHours, $expected)
     {
@@ -41,7 +41,7 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
      * @param string $dateString
      * @param int    $addHours
      * @param string $expected
-     * @dataProvider getTransitionTests
+     * @dataProvider \Tests\CarbonImmutable\ModifyNearDSTChangeTest::getTransitionTests
      */
     public function testTransitionInDefaultTimezone($dateString, $addHours, $expected)
     {

--- a/tests/CarbonImmutable/ModifyNearDSTChangeTest.php
+++ b/tests/CarbonImmutable/ModifyNearDSTChangeTest.php
@@ -25,7 +25,7 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
      * @param string $dateString
      * @param int    $addHours
      * @param string $expected
-     * @dataProvider \Tests\CarbonImmutable\ModifyNearDSTChangeTest::getTransitionTests
+     * @dataProvider \Tests\CarbonImmutable\ModifyNearDSTChangeTest::providerTransitionTests
      */
     public function testTransitionInNonDefaultTimezone($dateString, $addHours, $expected)
     {
@@ -41,7 +41,7 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
      * @param string $dateString
      * @param int    $addHours
      * @param string $expected
-     * @dataProvider \Tests\CarbonImmutable\ModifyNearDSTChangeTest::getTransitionTests
+     * @dataProvider \Tests\CarbonImmutable\ModifyNearDSTChangeTest::providerTransitionTests
      */
     public function testTransitionInDefaultTimezone($dateString, $addHours, $expected)
     {
@@ -51,7 +51,7 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
         $this->assertSame($expected, $date->format('c'));
     }
 
-    public function getTransitionTests(): Generator
+    public function providerTransitionTests(): Generator
     {
         // arguments:
         // - Date string to Carbon::parse in America/New_York.

--- a/tests/CarbonImmutable/ModifyNearDSTChangeTest.php
+++ b/tests/CarbonImmutable/ModifyNearDSTChangeTest.php
@@ -51,7 +51,7 @@ class ModifyNearDSTChangeTest extends AbstractTestCase
         $this->assertSame($expected, $date->format('c'));
     }
 
-    public function dataForTransitionTests(): Generator
+    public static function dataForTransitionTests(): Generator
     {
         // arguments:
         // - Date string to Carbon::parse in America/New_York.

--- a/tests/CarbonImmutable/SerializationTest.php
+++ b/tests/CarbonImmutable/SerializationTest.php
@@ -61,7 +61,7 @@ class SerializationTest extends AbstractTestCase
         $this->assertEquals(Carbon::now(), unserialize(serialize(Carbon::now())));
     }
 
-    public function dataForTestFromUnserializedWithInvalidValue()
+    public static function dataForTestFromUnserializedWithInvalidValue()
     {
         return [
             [null],

--- a/tests/CarbonImmutable/SerializationTest.php
+++ b/tests/CarbonImmutable/SerializationTest.php
@@ -75,7 +75,7 @@ class SerializationTest extends AbstractTestCase
     /**
      * @param mixed $value
      *
-     * @dataProvider \Tests\Carbon\SerializationTest::providerTestFromUnserializedWithInvalidValue
+     * @dataProvider \Tests\CarbonImmutable\SerializationTest::providerTestFromUnserializedWithInvalidValue
      */
     public function testFromUnserializedWithInvalidValue($value)
     {

--- a/tests/CarbonImmutable/SerializationTest.php
+++ b/tests/CarbonImmutable/SerializationTest.php
@@ -61,7 +61,7 @@ class SerializationTest extends AbstractTestCase
         $this->assertEquals(Carbon::now(), unserialize(serialize(Carbon::now())));
     }
 
-    public function providerTestFromUnserializedWithInvalidValue()
+    public function dataForTestFromUnserializedWithInvalidValue()
     {
         return [
             [null],
@@ -75,7 +75,7 @@ class SerializationTest extends AbstractTestCase
     /**
      * @param mixed $value
      *
-     * @dataProvider \Tests\CarbonImmutable\SerializationTest::providerTestFromUnserializedWithInvalidValue
+     * @dataProvider \Tests\CarbonImmutable\SerializationTest::dataForTestFromUnserializedWithInvalidValue
      */
     public function testFromUnserializedWithInvalidValue($value)
     {

--- a/tests/CarbonImmutable/SettersTest.php
+++ b/tests/CarbonImmutable/SettersTest.php
@@ -342,7 +342,7 @@ class SettersTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\SettersTest::dataProviderTestSetTimeFromTimeString
+     * @dataProvider \Tests\CarbonImmutable\SettersTest::dataProviderTestSetTimeFromTimeString
      *
      * @param int    $hour
      * @param int    $minute

--- a/tests/CarbonImmutable/SettersTest.php
+++ b/tests/CarbonImmutable/SettersTest.php
@@ -342,7 +342,7 @@ class SettersTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\SettersTest::dataProviderTestSetTimeFromTimeString
+     * @dataProvider \Tests\CarbonImmutable\SettersTest::providerTestSetTimeFromTimeString
      *
      * @param int    $hour
      * @param int    $minute
@@ -356,7 +356,7 @@ class SettersTest extends AbstractTestCase
         $this->assertCarbon($d, 2016, 2, 12, $hour, $minute, $second);
     }
 
-    public function dataProviderTestSetTimeFromTimeString()
+    public function providerTestSetTimeFromTimeString()
     {
         return [
             [9, 15, 30, '09:15:30'],

--- a/tests/CarbonImmutable/SettersTest.php
+++ b/tests/CarbonImmutable/SettersTest.php
@@ -342,7 +342,7 @@ class SettersTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\SettersTest::providerTestSetTimeFromTimeString
+     * @dataProvider \Tests\CarbonImmutable\SettersTest::dataForTestSetTimeFromTimeString
      *
      * @param int    $hour
      * @param int    $minute
@@ -356,7 +356,7 @@ class SettersTest extends AbstractTestCase
         $this->assertCarbon($d, 2016, 2, 12, $hour, $minute, $second);
     }
 
-    public function providerTestSetTimeFromTimeString()
+    public function dataForTestSetTimeFromTimeString()
     {
         return [
             [9, 15, 30, '09:15:30'],

--- a/tests/CarbonImmutable/SettersTest.php
+++ b/tests/CarbonImmutable/SettersTest.php
@@ -356,7 +356,7 @@ class SettersTest extends AbstractTestCase
         $this->assertCarbon($d, 2016, 2, 12, $hour, $minute, $second);
     }
 
-    public function dataForTestSetTimeFromTimeString()
+    public static function dataForTestSetTimeFromTimeString()
     {
         return [
             [9, 15, 30, '09:15:30'],

--- a/tests/CarbonImmutable/StartEndOfTest.php
+++ b/tests/CarbonImmutable/StartEndOfTest.php
@@ -358,7 +358,7 @@ class StartEndOfTest extends AbstractTestCase
         $this->assertInstanceOfCarbon($dt->startOfQuarter());
     }
 
-    public function providerTestStartOfQuarter()
+    public function dataForTestStartOfQuarter()
     {
         return [
             [1, 1],
@@ -377,7 +377,7 @@ class StartEndOfTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\StartEndOfTest::providerTestStartOfQuarter
+     * @dataProvider \Tests\CarbonImmutable\StartEndOfTest::dataForTestStartOfQuarter
      *
      * @param int $month
      * @param int $startOfQuarterMonth
@@ -394,7 +394,7 @@ class StartEndOfTest extends AbstractTestCase
         $this->assertInstanceOfCarbon($dt->endOfQuarter());
     }
 
-    public function providerTestEndOfQuarter()
+    public function dataForTestEndOfQuarter()
     {
         return [
             [1, 3, 31],
@@ -413,7 +413,7 @@ class StartEndOfTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\StartEndOfTest::providerTestEndOfQuarter
+     * @dataProvider \Tests\CarbonImmutable\StartEndOfTest::dataForTestEndOfQuarter
      *
      * @param int $month
      * @param int $endOfQuarterMonth

--- a/tests/CarbonImmutable/StartEndOfTest.php
+++ b/tests/CarbonImmutable/StartEndOfTest.php
@@ -377,7 +377,7 @@ class StartEndOfTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\StartEndOfTest::dataProviderTestStartOfQuarter
+     * @dataProvider \Tests\CarbonImmutable\StartEndOfTest::dataProviderTestStartOfQuarter
      *
      * @param int $month
      * @param int $startOfQuarterMonth
@@ -413,7 +413,7 @@ class StartEndOfTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\Carbon\StartEndOfTest::dataProviderTestEndOfQuarter
+     * @dataProvider \Tests\CarbonImmutable\StartEndOfTest::dataProviderTestEndOfQuarter
      *
      * @param int $month
      * @param int $endOfQuarterMonth

--- a/tests/CarbonImmutable/StartEndOfTest.php
+++ b/tests/CarbonImmutable/StartEndOfTest.php
@@ -358,7 +358,7 @@ class StartEndOfTest extends AbstractTestCase
         $this->assertInstanceOfCarbon($dt->startOfQuarter());
     }
 
-    public function dataForTestStartOfQuarter()
+    public static function dataForTestStartOfQuarter()
     {
         return [
             [1, 1],
@@ -394,7 +394,7 @@ class StartEndOfTest extends AbstractTestCase
         $this->assertInstanceOfCarbon($dt->endOfQuarter());
     }
 
-    public function dataForTestEndOfQuarter()
+    public static function dataForTestEndOfQuarter()
     {
         return [
             [1, 3, 31],

--- a/tests/CarbonImmutable/StartEndOfTest.php
+++ b/tests/CarbonImmutable/StartEndOfTest.php
@@ -358,7 +358,7 @@ class StartEndOfTest extends AbstractTestCase
         $this->assertInstanceOfCarbon($dt->startOfQuarter());
     }
 
-    public function dataProviderTestStartOfQuarter()
+    public function providerTestStartOfQuarter()
     {
         return [
             [1, 1],
@@ -377,7 +377,7 @@ class StartEndOfTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\StartEndOfTest::dataProviderTestStartOfQuarter
+     * @dataProvider \Tests\CarbonImmutable\StartEndOfTest::providerTestStartOfQuarter
      *
      * @param int $month
      * @param int $startOfQuarterMonth
@@ -394,7 +394,7 @@ class StartEndOfTest extends AbstractTestCase
         $this->assertInstanceOfCarbon($dt->endOfQuarter());
     }
 
-    public function dataProviderTestEndOfQuarter()
+    public function providerTestEndOfQuarter()
     {
         return [
             [1, 3, 31],
@@ -413,7 +413,7 @@ class StartEndOfTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonImmutable\StartEndOfTest::dataProviderTestEndOfQuarter
+     * @dataProvider \Tests\CarbonImmutable\StartEndOfTest::providerTestEndOfQuarter
      *
      * @param int $month
      * @param int $endOfQuarterMonth

--- a/tests/CarbonInterval/AddTest.php
+++ b/tests/CarbonInterval/AddTest.php
@@ -85,7 +85,7 @@ class AddTest extends AbstractTestCase
         $this->assertCarbonInterval($ci, 4, 3, 28, 8, 10, 11);
     }
 
-    public function providerAddsResults(): Generator
+    public function dataForAddsResults(): Generator
     {
         yield [5, 2, 7];
         yield [-5, -2, -7];
@@ -98,7 +98,7 @@ class AddTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonInterval\AddTest::providerAddsResults
+     * @dataProvider \Tests\CarbonInterval\AddTest::dataForAddsResults
      *
      * @param int $base
      * @param int $increment

--- a/tests/CarbonInterval/AddTest.php
+++ b/tests/CarbonInterval/AddTest.php
@@ -85,7 +85,7 @@ class AddTest extends AbstractTestCase
         $this->assertCarbonInterval($ci, 4, 3, 28, 8, 10, 11);
     }
 
-    public function dataForAddsResults(): Generator
+    public static function dataForAddsResults(): Generator
     {
         yield [5, 2, 7];
         yield [-5, -2, -7];

--- a/tests/CarbonInterval/AddTest.php
+++ b/tests/CarbonInterval/AddTest.php
@@ -85,7 +85,7 @@ class AddTest extends AbstractTestCase
         $this->assertCarbonInterval($ci, 4, 3, 28, 8, 10, 11);
     }
 
-    public function provideAddsResults(): Generator
+    public function providerAddsResults(): Generator
     {
         yield [5, 2, 7];
         yield [-5, -2, -7];
@@ -98,7 +98,7 @@ class AddTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonInterval\AddTest::provideAddsResults
+     * @dataProvider \Tests\CarbonInterval\AddTest::providerAddsResults
      *
      * @param int $base
      * @param int $increment

--- a/tests/CarbonInterval/AddTest.php
+++ b/tests/CarbonInterval/AddTest.php
@@ -98,7 +98,7 @@ class AddTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider provideAddsResults
+     * @dataProvider \Tests\CarbonInterval\AddTest::provideAddsResults
      *
      * @param int $base
      * @param int $increment

--- a/tests/CarbonInterval/CascadeTest.php
+++ b/tests/CarbonInterval/CascadeTest.php
@@ -34,7 +34,7 @@ class CascadeTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider provideIntervalSpecs
+     * @dataProvider \Tests\CarbonInterval\CascadeTest::provideIntervalSpecs
      */
     public function testCascadesOverflowedValues($spec, $expected)
     {
@@ -55,7 +55,7 @@ class CascadeTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider provideMixedSignsIntervalSpecs
+     * @dataProvider \Tests\CarbonInterval\CascadeTest::provideMixedSignsIntervalSpecs
      *
      * @throws \Exception
      */
@@ -219,7 +219,7 @@ class CascadeTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider provideCustomIntervalSpecs
+     * @dataProvider \Tests\CarbonInterval\CascadeTest::provideCustomIntervalSpecs
      */
     public function testCustomCascadesOverflowedValues($spec, $expected)
     {
@@ -246,7 +246,7 @@ class CascadeTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider provideCustomIntervalSpecsLongFormat
+     * @dataProvider \Tests\CarbonInterval\CascadeTest::provideCustomIntervalSpecsLongFormat
      */
     public function testCustomCascadesOverflowedValuesLongFormat($spec, $expected)
     {

--- a/tests/CarbonInterval/CascadeTest.php
+++ b/tests/CarbonInterval/CascadeTest.php
@@ -34,7 +34,7 @@ class CascadeTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonInterval\CascadeTest::providerIntervalSpecs
+     * @dataProvider \Tests\CarbonInterval\CascadeTest::dataForIntervalSpecs
      */
     public function testCascadesOverflowedValues($spec, $expected)
     {
@@ -45,7 +45,7 @@ class CascadeTest extends AbstractTestCase
         $this->assertIntervalSpec($interval, $expected, true);
     }
 
-    public function providerIntervalSpecs(): Generator
+    public function dataForIntervalSpecs(): Generator
     {
         yield ['3600s', 'PT1H'];
         yield ['10000s', 'PT2H46M40S'];
@@ -55,7 +55,7 @@ class CascadeTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonInterval\CascadeTest::providerMixedSignsIntervalSpecs
+     * @dataProvider \Tests\CarbonInterval\CascadeTest::dataForMixedSignsIntervalSpecs
      *
      * @throws \Exception
      */
@@ -76,7 +76,7 @@ class CascadeTest extends AbstractTestCase
         $this->assertIntervalSpec($interval, $expected, 1 - $expectingInversion);
     }
 
-    public function providerMixedSignsIntervalSpecs(): Generator
+    public function dataForMixedSignsIntervalSpecs(): Generator
     {
         yield [
             [
@@ -219,7 +219,7 @@ class CascadeTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonInterval\CascadeTest::providerCustomIntervalSpecs
+     * @dataProvider \Tests\CarbonInterval\CascadeTest::dataForCustomIntervalSpecs
      */
     public function testCustomCascadesOverflowedValues($spec, $expected)
     {
@@ -236,7 +236,7 @@ class CascadeTest extends AbstractTestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function providerCustomIntervalSpecs(): Generator
+    public function dataForCustomIntervalSpecs(): Generator
     {
         yield ['3600s', '1h'];
         yield ['10000s', '2h 46m 40s'];
@@ -246,7 +246,7 @@ class CascadeTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonInterval\CascadeTest::providerCustomIntervalSpecsLongFormat
+     * @dataProvider \Tests\CarbonInterval\CascadeTest::dataForCustomIntervalSpecsLongFormat
      */
     public function testCustomCascadesOverflowedValuesLongFormat($spec, $expected)
     {
@@ -263,7 +263,7 @@ class CascadeTest extends AbstractTestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function providerCustomIntervalSpecsLongFormat()
+    public function dataForCustomIntervalSpecsLongFormat()
     {
         return [
             ['3600s',                        '1 hour'],

--- a/tests/CarbonInterval/CascadeTest.php
+++ b/tests/CarbonInterval/CascadeTest.php
@@ -34,7 +34,7 @@ class CascadeTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonInterval\CascadeTest::provideIntervalSpecs
+     * @dataProvider \Tests\CarbonInterval\CascadeTest::providerIntervalSpecs
      */
     public function testCascadesOverflowedValues($spec, $expected)
     {
@@ -45,7 +45,7 @@ class CascadeTest extends AbstractTestCase
         $this->assertIntervalSpec($interval, $expected, true);
     }
 
-    public function provideIntervalSpecs(): Generator
+    public function providerIntervalSpecs(): Generator
     {
         yield ['3600s', 'PT1H'];
         yield ['10000s', 'PT2H46M40S'];
@@ -55,7 +55,7 @@ class CascadeTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonInterval\CascadeTest::provideMixedSignsIntervalSpecs
+     * @dataProvider \Tests\CarbonInterval\CascadeTest::providerMixedSignsIntervalSpecs
      *
      * @throws \Exception
      */
@@ -76,7 +76,7 @@ class CascadeTest extends AbstractTestCase
         $this->assertIntervalSpec($interval, $expected, 1 - $expectingInversion);
     }
 
-    public function provideMixedSignsIntervalSpecs(): Generator
+    public function providerMixedSignsIntervalSpecs(): Generator
     {
         yield [
             [
@@ -219,7 +219,7 @@ class CascadeTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonInterval\CascadeTest::provideCustomIntervalSpecs
+     * @dataProvider \Tests\CarbonInterval\CascadeTest::providerCustomIntervalSpecs
      */
     public function testCustomCascadesOverflowedValues($spec, $expected)
     {
@@ -236,7 +236,7 @@ class CascadeTest extends AbstractTestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function provideCustomIntervalSpecs(): Generator
+    public function providerCustomIntervalSpecs(): Generator
     {
         yield ['3600s', '1h'];
         yield ['10000s', '2h 46m 40s'];
@@ -246,7 +246,7 @@ class CascadeTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonInterval\CascadeTest::provideCustomIntervalSpecsLongFormat
+     * @dataProvider \Tests\CarbonInterval\CascadeTest::providerCustomIntervalSpecsLongFormat
      */
     public function testCustomCascadesOverflowedValuesLongFormat($spec, $expected)
     {
@@ -263,7 +263,7 @@ class CascadeTest extends AbstractTestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function provideCustomIntervalSpecsLongFormat()
+    public function providerCustomIntervalSpecsLongFormat()
     {
         return [
             ['3600s',                        '1 hour'],

--- a/tests/CarbonInterval/CascadeTest.php
+++ b/tests/CarbonInterval/CascadeTest.php
@@ -45,7 +45,7 @@ class CascadeTest extends AbstractTestCase
         $this->assertIntervalSpec($interval, $expected, true);
     }
 
-    public function dataForIntervalSpecs(): Generator
+    public static function dataForIntervalSpecs(): Generator
     {
         yield ['3600s', 'PT1H'];
         yield ['10000s', 'PT2H46M40S'];
@@ -76,7 +76,7 @@ class CascadeTest extends AbstractTestCase
         $this->assertIntervalSpec($interval, $expected, 1 - $expectingInversion);
     }
 
-    public function dataForMixedSignsIntervalSpecs(): Generator
+    public static function dataForMixedSignsIntervalSpecs(): Generator
     {
         yield [
             [
@@ -236,7 +236,7 @@ class CascadeTest extends AbstractTestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function dataForCustomIntervalSpecs(): Generator
+    public static function dataForCustomIntervalSpecs(): Generator
     {
         yield ['3600s', '1h'];
         yield ['10000s', '2h 46m 40s'];
@@ -263,7 +263,7 @@ class CascadeTest extends AbstractTestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function dataForCustomIntervalSpecsLongFormat()
+    public static function dataForCustomIntervalSpecsLongFormat()
     {
         return [
             ['3600s',                        '1 hour'],

--- a/tests/CarbonInterval/FromStringTest.php
+++ b/tests/CarbonInterval/FromStringTest.php
@@ -21,7 +21,7 @@ use Tests\AbstractTestCase;
 class FromStringTest extends AbstractTestCase
 {
     /**
-     * @dataProvider \Tests\CarbonInterval\FromStringTest::providerValidStrings
+     * @dataProvider \Tests\CarbonInterval\FromStringTest::dataForValidStrings
      *
      * @param string         $string
      * @param CarbonInterval $expected
@@ -33,7 +33,7 @@ class FromStringTest extends AbstractTestCase
         $this->assertEquals($expected, $result, "'$string' does not return expected interval.");
     }
 
-    public function providerValidStrings(): Generator
+    public function dataForValidStrings(): Generator
     {
         // zero interval
         yield ['', new CarbonInterval(0)];
@@ -108,7 +108,7 @@ class FromStringTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonInterval\FromStringTest::providerInvalidStrings
+     * @dataProvider \Tests\CarbonInterval\FromStringTest::dataForInvalidStrings
      *
      * @param string $string
      * @param string $part
@@ -126,7 +126,7 @@ class FromStringTest extends AbstractTestCase
         $this->assertStringContainsString($part, $message);
     }
 
-    public function providerInvalidStrings(): Generator
+    public function dataForInvalidStrings(): Generator
     {
         yield ['1q', '1q'];
         yield ['about 12..14m', '12..'];

--- a/tests/CarbonInterval/FromStringTest.php
+++ b/tests/CarbonInterval/FromStringTest.php
@@ -21,7 +21,7 @@ use Tests\AbstractTestCase;
 class FromStringTest extends AbstractTestCase
 {
     /**
-     * @dataProvider provideValidStrings
+     * @dataProvider \Tests\CarbonInterval\FromStringTest::provideValidStrings
      *
      * @param string         $string
      * @param CarbonInterval $expected
@@ -108,7 +108,7 @@ class FromStringTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider provideInvalidStrings
+     * @dataProvider \Tests\CarbonInterval\FromStringTest::provideInvalidStrings
      *
      * @param string $string
      * @param string $part

--- a/tests/CarbonInterval/FromStringTest.php
+++ b/tests/CarbonInterval/FromStringTest.php
@@ -33,7 +33,7 @@ class FromStringTest extends AbstractTestCase
         $this->assertEquals($expected, $result, "'$string' does not return expected interval.");
     }
 
-    public function dataForValidStrings(): Generator
+    public static function dataForValidStrings(): Generator
     {
         // zero interval
         yield ['', new CarbonInterval(0)];
@@ -126,7 +126,7 @@ class FromStringTest extends AbstractTestCase
         $this->assertStringContainsString($part, $message);
     }
 
-    public function dataForInvalidStrings(): Generator
+    public static function dataForInvalidStrings(): Generator
     {
         yield ['1q', '1q'];
         yield ['about 12..14m', '12..'];

--- a/tests/CarbonInterval/FromStringTest.php
+++ b/tests/CarbonInterval/FromStringTest.php
@@ -21,7 +21,7 @@ use Tests\AbstractTestCase;
 class FromStringTest extends AbstractTestCase
 {
     /**
-     * @dataProvider \Tests\CarbonInterval\FromStringTest::provideValidStrings
+     * @dataProvider \Tests\CarbonInterval\FromStringTest::providerValidStrings
      *
      * @param string         $string
      * @param CarbonInterval $expected
@@ -33,7 +33,7 @@ class FromStringTest extends AbstractTestCase
         $this->assertEquals($expected, $result, "'$string' does not return expected interval.");
     }
 
-    public function provideValidStrings(): Generator
+    public function providerValidStrings(): Generator
     {
         // zero interval
         yield ['', new CarbonInterval(0)];
@@ -108,7 +108,7 @@ class FromStringTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonInterval\FromStringTest::provideInvalidStrings
+     * @dataProvider \Tests\CarbonInterval\FromStringTest::providerInvalidStrings
      *
      * @param string $string
      * @param string $part
@@ -126,7 +126,7 @@ class FromStringTest extends AbstractTestCase
         $this->assertStringContainsString($part, $message);
     }
 
-    public function provideInvalidStrings(): Generator
+    public function providerInvalidStrings(): Generator
     {
         yield ['1q', '1q'];
         yield ['about 12..14m', '12..'];

--- a/tests/CarbonInterval/ParseFromLocaleTest.php
+++ b/tests/CarbonInterval/ParseFromLocaleTest.php
@@ -21,7 +21,7 @@ use Tests\AbstractTestCase;
 class ParseFromLocaleTest extends AbstractTestCase
 {
     /**
-     * @dataProvider \Tests\CarbonInterval\ParseFromLocaleTest::providerValidStrings
+     * @dataProvider \Tests\CarbonInterval\ParseFromLocaleTest::dataForValidStrings
      *
      * @param string         $string
      * @param string         $locale
@@ -34,7 +34,7 @@ class ParseFromLocaleTest extends AbstractTestCase
         $this->assertEquals($expected, $result, "'{$string}' does not return expected interval.");
     }
 
-    public function providerValidStrings(): Generator
+    public function dataForValidStrings(): Generator
     {
         // zero interval
         yield ['', 'en', new CarbonInterval(0)];
@@ -112,7 +112,7 @@ class ParseFromLocaleTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonInterval\ParseFromLocaleTest::providerInvalidStrings
+     * @dataProvider \Tests\CarbonInterval\ParseFromLocaleTest::dataForInvalidStrings
      *
      * @param string $string
      * @param string $part
@@ -131,7 +131,7 @@ class ParseFromLocaleTest extends AbstractTestCase
         $this->assertStringContainsString($part, $message);
     }
 
-    public function providerInvalidStrings(): Generator
+    public function dataForInvalidStrings(): Generator
     {
         yield ['1q', '1q', 'en'];
         yield ['about 12..14m', '12..', 'en'];

--- a/tests/CarbonInterval/ParseFromLocaleTest.php
+++ b/tests/CarbonInterval/ParseFromLocaleTest.php
@@ -34,7 +34,7 @@ class ParseFromLocaleTest extends AbstractTestCase
         $this->assertEquals($expected, $result, "'{$string}' does not return expected interval.");
     }
 
-    public function dataForValidStrings(): Generator
+    public static function dataForValidStrings(): Generator
     {
         // zero interval
         yield ['', 'en', new CarbonInterval(0)];
@@ -131,7 +131,7 @@ class ParseFromLocaleTest extends AbstractTestCase
         $this->assertStringContainsString($part, $message);
     }
 
-    public function dataForInvalidStrings(): Generator
+    public static function dataForInvalidStrings(): Generator
     {
         yield ['1q', '1q', 'en'];
         yield ['about 12..14m', '12..', 'en'];

--- a/tests/CarbonInterval/ParseFromLocaleTest.php
+++ b/tests/CarbonInterval/ParseFromLocaleTest.php
@@ -21,7 +21,7 @@ use Tests\AbstractTestCase;
 class ParseFromLocaleTest extends AbstractTestCase
 {
     /**
-     * @dataProvider provideValidStrings
+     * @dataProvider \Tests\CarbonInterval\ParseFromLocaleTest::provideValidStrings
      *
      * @param string         $string
      * @param string         $locale
@@ -112,7 +112,7 @@ class ParseFromLocaleTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider provideInvalidStrings
+     * @dataProvider \Tests\CarbonInterval\ParseFromLocaleTest::provideInvalidStrings
      *
      * @param string $string
      * @param string $part

--- a/tests/CarbonInterval/ParseFromLocaleTest.php
+++ b/tests/CarbonInterval/ParseFromLocaleTest.php
@@ -21,7 +21,7 @@ use Tests\AbstractTestCase;
 class ParseFromLocaleTest extends AbstractTestCase
 {
     /**
-     * @dataProvider \Tests\CarbonInterval\ParseFromLocaleTest::provideValidStrings
+     * @dataProvider \Tests\CarbonInterval\ParseFromLocaleTest::providerValidStrings
      *
      * @param string         $string
      * @param string         $locale
@@ -34,7 +34,7 @@ class ParseFromLocaleTest extends AbstractTestCase
         $this->assertEquals($expected, $result, "'{$string}' does not return expected interval.");
     }
 
-    public function provideValidStrings(): Generator
+    public function providerValidStrings(): Generator
     {
         // zero interval
         yield ['', 'en', new CarbonInterval(0)];
@@ -112,7 +112,7 @@ class ParseFromLocaleTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonInterval\ParseFromLocaleTest::provideInvalidStrings
+     * @dataProvider \Tests\CarbonInterval\ParseFromLocaleTest::providerInvalidStrings
      *
      * @param string $string
      * @param string $part
@@ -131,7 +131,7 @@ class ParseFromLocaleTest extends AbstractTestCase
         $this->assertStringContainsString($part, $message);
     }
 
-    public function provideInvalidStrings(): Generator
+    public function providerInvalidStrings(): Generator
     {
         yield ['1q', '1q', 'en'];
         yield ['about 12..14m', '12..', 'en'];

--- a/tests/CarbonInterval/ToPeriodTest.php
+++ b/tests/CarbonInterval/ToPeriodTest.php
@@ -22,7 +22,7 @@ use Tests\AbstractTestCase;
 class ToPeriodTest extends AbstractTestCase
 {
     /**
-     * @dataProvider \Tests\CarbonInterval\ToPeriodTest::provideToPeriodParameters
+     * @dataProvider \Tests\CarbonInterval\ToPeriodTest::providerToPeriodParameters
      */
     public function testConvertToDatePeriod($interval, $arguments, $expected)
     {
@@ -33,7 +33,7 @@ class ToPeriodTest extends AbstractTestCase
         $this->assertSame($expected, $period->spec());
     }
 
-    public function provideToPeriodParameters(): Generator
+    public function providerToPeriodParameters(): Generator
     {
         yield [
                 CarbonInterval::days(3),

--- a/tests/CarbonInterval/ToPeriodTest.php
+++ b/tests/CarbonInterval/ToPeriodTest.php
@@ -22,7 +22,7 @@ use Tests\AbstractTestCase;
 class ToPeriodTest extends AbstractTestCase
 {
     /**
-     * @dataProvider \Tests\CarbonInterval\ToPeriodTest::providerToPeriodParameters
+     * @dataProvider \Tests\CarbonInterval\ToPeriodTest::dataForToPeriodParameters
      */
     public function testConvertToDatePeriod($interval, $arguments, $expected)
     {
@@ -33,7 +33,7 @@ class ToPeriodTest extends AbstractTestCase
         $this->assertSame($expected, $period->spec());
     }
 
-    public function providerToPeriodParameters(): Generator
+    public function dataForToPeriodParameters(): Generator
     {
         yield [
                 CarbonInterval::days(3),

--- a/tests/CarbonInterval/ToPeriodTest.php
+++ b/tests/CarbonInterval/ToPeriodTest.php
@@ -33,7 +33,7 @@ class ToPeriodTest extends AbstractTestCase
         $this->assertSame($expected, $period->spec());
     }
 
-    public function dataForToPeriodParameters(): Generator
+    public static function dataForToPeriodParameters(): Generator
     {
         yield [
                 CarbonInterval::days(3),

--- a/tests/CarbonInterval/ToPeriodTest.php
+++ b/tests/CarbonInterval/ToPeriodTest.php
@@ -22,7 +22,7 @@ use Tests\AbstractTestCase;
 class ToPeriodTest extends AbstractTestCase
 {
     /**
-     * @dataProvider provideToPeriodParameters
+     * @dataProvider \Tests\CarbonInterval\ToPeriodTest::provideToPeriodParameters
      */
     public function testConvertToDatePeriod($interval, $arguments, $expected)
     {

--- a/tests/CarbonInterval/TotalTest.php
+++ b/tests/CarbonInterval/TotalTest.php
@@ -22,7 +22,7 @@ use Tests\AbstractTestCase;
 class TotalTest extends AbstractTestCase
 {
     /**
-     * @dataProvider \Tests\CarbonInterval\TotalTest::providerIntervalSpecs
+     * @dataProvider \Tests\CarbonInterval\TotalTest::dataForIntervalSpecs
      */
     public function testReturnsTotalValue($spec, $unit, $expected)
     {
@@ -33,7 +33,7 @@ class TotalTest extends AbstractTestCase
         );
     }
 
-    public function providerIntervalSpecs(): Generator
+    public function dataForIntervalSpecs(): Generator
     {
         yield ['10s',                'seconds', 10];
         yield ['100s',               'seconds', 100];
@@ -87,7 +87,7 @@ class TotalTest extends AbstractTestCase
         $this->assertSame(-12312, $interval->totalMilliseconds);
     }
 
-    public function providerNegativeIntervals(): Generator
+    public function dataForNegativeIntervals(): Generator
     {
         yield [-1, CarbonInterval::hours(0)->hours(-150)];
         yield [-1, CarbonInterval::hours(150)->invert()];
@@ -95,7 +95,7 @@ class TotalTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonInterval\TotalTest::providerNegativeIntervals
+     * @dataProvider \Tests\CarbonInterval\TotalTest::dataForNegativeIntervals
      */
     public function testGetNegativeTotalsViaGetters($factor, $interval)
     {

--- a/tests/CarbonInterval/TotalTest.php
+++ b/tests/CarbonInterval/TotalTest.php
@@ -22,7 +22,7 @@ use Tests\AbstractTestCase;
 class TotalTest extends AbstractTestCase
 {
     /**
-     * @dataProvider provideIntervalSpecs
+     * @dataProvider \Tests\CarbonInterval\TotalTest::provideIntervalSpecs
      */
     public function testReturnsTotalValue($spec, $unit, $expected)
     {
@@ -95,7 +95,7 @@ class TotalTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider getNegativeIntervals
+     * @dataProvider \Tests\CarbonInterval\TotalTest::getNegativeIntervals
      */
     public function testGetNegativeTotalsViaGetters($factor, $interval)
     {

--- a/tests/CarbonInterval/TotalTest.php
+++ b/tests/CarbonInterval/TotalTest.php
@@ -22,7 +22,7 @@ use Tests\AbstractTestCase;
 class TotalTest extends AbstractTestCase
 {
     /**
-     * @dataProvider \Tests\CarbonInterval\TotalTest::provideIntervalSpecs
+     * @dataProvider \Tests\CarbonInterval\TotalTest::providerIntervalSpecs
      */
     public function testReturnsTotalValue($spec, $unit, $expected)
     {
@@ -33,7 +33,7 @@ class TotalTest extends AbstractTestCase
         );
     }
 
-    public function provideIntervalSpecs(): Generator
+    public function providerIntervalSpecs(): Generator
     {
         yield ['10s',                'seconds', 10];
         yield ['100s',               'seconds', 100];
@@ -87,7 +87,7 @@ class TotalTest extends AbstractTestCase
         $this->assertSame(-12312, $interval->totalMilliseconds);
     }
 
-    public function getNegativeIntervals(): Generator
+    public function providerNegativeIntervals(): Generator
     {
         yield [-1, CarbonInterval::hours(0)->hours(-150)];
         yield [-1, CarbonInterval::hours(150)->invert()];
@@ -95,7 +95,7 @@ class TotalTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonInterval\TotalTest::getNegativeIntervals
+     * @dataProvider \Tests\CarbonInterval\TotalTest::providerNegativeIntervals
      */
     public function testGetNegativeTotalsViaGetters($factor, $interval)
     {

--- a/tests/CarbonInterval/TotalTest.php
+++ b/tests/CarbonInterval/TotalTest.php
@@ -33,7 +33,7 @@ class TotalTest extends AbstractTestCase
         );
     }
 
-    public function dataForIntervalSpecs(): Generator
+    public static function dataForIntervalSpecs(): Generator
     {
         yield ['10s',                'seconds', 10];
         yield ['100s',               'seconds', 100];
@@ -87,7 +87,7 @@ class TotalTest extends AbstractTestCase
         $this->assertSame(-12312, $interval->totalMilliseconds);
     }
 
-    public function dataForNegativeIntervals(): Generator
+    public static function dataForNegativeIntervals(): Generator
     {
         yield [-1, CarbonInterval::hours(0)->hours(-150)];
         yield [-1, CarbonInterval::hours(150)->invert()];

--- a/tests/CarbonPeriod/CreateTest.php
+++ b/tests/CarbonPeriod/CreateTest.php
@@ -44,7 +44,7 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function dataForIso8601String(): Generator
+    public static function dataForIso8601String(): Generator
     {
         yield [
             ['R4/2012-07-01T00:00:00/P7D'],
@@ -98,7 +98,7 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function dataForPartialIso8601String(): Generator
+    public static function dataForPartialIso8601String(): Generator
     {
         yield ['2008-02-15/03-14', '2008-02-15', '2008-03-14'];
         yield ['2007-12-14T13:30/15:30', '2007-12-14 13:30', '2007-12-14 15:30'];
@@ -116,7 +116,7 @@ class CreateTest extends AbstractTestCase
         CarbonPeriod::create($iso);
     }
 
-    public function dataForInvalidIso8601String(): Generator
+    public static function dataForInvalidIso8601String(): Generator
     {
         yield ['R2/R4'];
         yield ['2008-02-15/2008-02-16/2008-02-17'];
@@ -144,7 +144,7 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function dataForStartDateAndEndDate(): Generator
+    public static function dataForStartDateAndEndDate(): Generator
     {
         yield [
                 ['2015-09-30', '2015-10-03'],
@@ -199,7 +199,7 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function dataForStartDateAndIntervalAndEndDate(): Generator
+    public static function dataForStartDateAndIntervalAndEndDate(): Generator
     {
         yield [
             ['2018-04-21', 'P3D', '2018-04-26'],
@@ -258,7 +258,7 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function dataForStartDateAndIntervalAndRecurrences(): Generator
+    public static function dataForStartDateAndIntervalAndRecurrences(): Generator
     {
         yield [
             ['2018-04-16', 'P2D', 3],
@@ -287,7 +287,7 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function dataForStartDateAndRecurrences(): Generator
+    public static function dataForStartDateAndRecurrences(): Generator
     {
         yield [
                 ['2018-04-16', 2],
@@ -337,7 +337,7 @@ class CreateTest extends AbstractTestCase
         CarbonPeriod::create(...$arguments);
     }
 
-    public function dataForInvalidParameters(): Generator
+    public static function dataForInvalidParameters(): Generator
     {
         yield [new stdClass(), CarbonInterval::days(1), Carbon::tomorrow()];
         yield [Carbon::now(), new stdClass(), Carbon::tomorrow()];

--- a/tests/CarbonPeriod/CreateTest.php
+++ b/tests/CarbonPeriod/CreateTest.php
@@ -30,7 +30,7 @@ use Tests\AbstractTestCase;
 class CreateTest extends AbstractTestCase
 {
     /**
-     * @dataProvider provideIso8601String
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::provideIso8601String
      */
     public function testCreateFromIso8601String($arguments, $expected)
     {
@@ -79,7 +79,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider providePartialIso8601String
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::providePartialIso8601String
      */
     public function testCreateFromPartialIso8601String($iso, $from, $to)
     {
@@ -105,7 +105,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider provideInvalidIso8601String
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::provideInvalidIso8601String
      */
     public function testCreateFromInvalidIso8601String($iso)
     {
@@ -127,7 +127,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider provideStartDateAndEndDate
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::provideStartDateAndEndDate
      */
     public function testCreateFromStartDateAndEndDate($arguments, $expected)
     {
@@ -181,7 +181,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider provideStartDateAndIntervalAndEndDate
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::provideStartDateAndIntervalAndEndDate
      */
     public function testCreateFromStartDateAndIntervalAndEndDate($arguments, $expected)
     {
@@ -241,7 +241,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider provideStartDateAndIntervalAndRecurrences
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::provideStartDateAndIntervalAndRecurrences
      */
     public function testCreateFromStartDateAndIntervalAndRecurrences($arguments, $expected)
     {
@@ -271,7 +271,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider provideStartDateAndRecurrences
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::provideStartDateAndRecurrences
      */
     public function testCreateFromStartDateAndRecurrences($arguments, $expected)
     {
@@ -326,7 +326,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider provideInvalidParameters
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::provideInvalidParameters
      */
     public function testCreateFromInvalidParameters(...$arguments)
     {

--- a/tests/CarbonPeriod/CreateTest.php
+++ b/tests/CarbonPeriod/CreateTest.php
@@ -30,7 +30,7 @@ use Tests\AbstractTestCase;
 class CreateTest extends AbstractTestCase
 {
     /**
-     * @dataProvider \Tests\CarbonPeriod\CreateTest::providerIso8601String
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::dataForIso8601String
      */
     public function testCreateFromIso8601String($arguments, $expected)
     {
@@ -44,7 +44,7 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function providerIso8601String(): Generator
+    public function dataForIso8601String(): Generator
     {
         yield [
             ['R4/2012-07-01T00:00:00/P7D'],
@@ -79,7 +79,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonPeriod\CreateTest::providerPartialIso8601String
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::dataForPartialIso8601String
      */
     public function testCreateFromPartialIso8601String($iso, $from, $to)
     {
@@ -98,14 +98,14 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function providerPartialIso8601String(): Generator
+    public function dataForPartialIso8601String(): Generator
     {
         yield ['2008-02-15/03-14', '2008-02-15', '2008-03-14'];
         yield ['2007-12-14T13:30/15:30', '2007-12-14 13:30', '2007-12-14 15:30'];
     }
 
     /**
-     * @dataProvider \Tests\CarbonPeriod\CreateTest::providerInvalidIso8601String
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::dataForInvalidIso8601String
      */
     public function testCreateFromInvalidIso8601String($iso)
     {
@@ -116,7 +116,7 @@ class CreateTest extends AbstractTestCase
         CarbonPeriod::create($iso);
     }
 
-    public function providerInvalidIso8601String(): Generator
+    public function dataForInvalidIso8601String(): Generator
     {
         yield ['R2/R4'];
         yield ['2008-02-15/2008-02-16/2008-02-17'];
@@ -127,7 +127,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonPeriod\CreateTest::providerStartDateAndEndDate
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::dataForStartDateAndEndDate
      */
     public function testCreateFromStartDateAndEndDate($arguments, $expected)
     {
@@ -144,7 +144,7 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function providerStartDateAndEndDate(): Generator
+    public function dataForStartDateAndEndDate(): Generator
     {
         yield [
                 ['2015-09-30', '2015-10-03'],
@@ -181,7 +181,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonPeriod\CreateTest::providerStartDateAndIntervalAndEndDate
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::dataForStartDateAndIntervalAndEndDate
      */
     public function testCreateFromStartDateAndIntervalAndEndDate($arguments, $expected)
     {
@@ -199,7 +199,7 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function providerStartDateAndIntervalAndEndDate(): Generator
+    public function dataForStartDateAndIntervalAndEndDate(): Generator
     {
         yield [
             ['2018-04-21', 'P3D', '2018-04-26'],
@@ -241,7 +241,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonPeriod\CreateTest::providerStartDateAndIntervalAndRecurrences
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::dataForStartDateAndIntervalAndRecurrences
      */
     public function testCreateFromStartDateAndIntervalAndRecurrences($arguments, $expected)
     {
@@ -258,7 +258,7 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function providerStartDateAndIntervalAndRecurrences(): Generator
+    public function dataForStartDateAndIntervalAndRecurrences(): Generator
     {
         yield [
             ['2018-04-16', 'P2D', 3],
@@ -271,7 +271,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonPeriod\CreateTest::providerStartDateAndRecurrences
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::dataForStartDateAndRecurrences
      */
     public function testCreateFromStartDateAndRecurrences($arguments, $expected)
     {
@@ -287,7 +287,7 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function providerStartDateAndRecurrences(): Generator
+    public function dataForStartDateAndRecurrences(): Generator
     {
         yield [
                 ['2018-04-16', 2],
@@ -326,7 +326,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonPeriod\CreateTest::providerInvalidParameters
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::dataForInvalidParameters
      */
     public function testCreateFromInvalidParameters(...$arguments)
     {
@@ -337,7 +337,7 @@ class CreateTest extends AbstractTestCase
         CarbonPeriod::create(...$arguments);
     }
 
-    public function providerInvalidParameters(): Generator
+    public function dataForInvalidParameters(): Generator
     {
         yield [new stdClass(), CarbonInterval::days(1), Carbon::tomorrow()];
         yield [Carbon::now(), new stdClass(), Carbon::tomorrow()];

--- a/tests/CarbonPeriod/CreateTest.php
+++ b/tests/CarbonPeriod/CreateTest.php
@@ -30,7 +30,7 @@ use Tests\AbstractTestCase;
 class CreateTest extends AbstractTestCase
 {
     /**
-     * @dataProvider \Tests\CarbonPeriod\CreateTest::provideIso8601String
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::providerIso8601String
      */
     public function testCreateFromIso8601String($arguments, $expected)
     {
@@ -44,7 +44,7 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function provideIso8601String(): Generator
+    public function providerIso8601String(): Generator
     {
         yield [
             ['R4/2012-07-01T00:00:00/P7D'],
@@ -79,7 +79,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonPeriod\CreateTest::providePartialIso8601String
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::providerPartialIso8601String
      */
     public function testCreateFromPartialIso8601String($iso, $from, $to)
     {
@@ -98,14 +98,14 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function providePartialIso8601String(): Generator
+    public function providerPartialIso8601String(): Generator
     {
         yield ['2008-02-15/03-14', '2008-02-15', '2008-03-14'];
         yield ['2007-12-14T13:30/15:30', '2007-12-14 13:30', '2007-12-14 15:30'];
     }
 
     /**
-     * @dataProvider \Tests\CarbonPeriod\CreateTest::provideInvalidIso8601String
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::providerInvalidIso8601String
      */
     public function testCreateFromInvalidIso8601String($iso)
     {
@@ -116,7 +116,7 @@ class CreateTest extends AbstractTestCase
         CarbonPeriod::create($iso);
     }
 
-    public function provideInvalidIso8601String(): Generator
+    public function providerInvalidIso8601String(): Generator
     {
         yield ['R2/R4'];
         yield ['2008-02-15/2008-02-16/2008-02-17'];
@@ -127,7 +127,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonPeriod\CreateTest::provideStartDateAndEndDate
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::providerStartDateAndEndDate
      */
     public function testCreateFromStartDateAndEndDate($arguments, $expected)
     {
@@ -144,7 +144,7 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function provideStartDateAndEndDate(): Generator
+    public function providerStartDateAndEndDate(): Generator
     {
         yield [
                 ['2015-09-30', '2015-10-03'],
@@ -181,7 +181,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonPeriod\CreateTest::provideStartDateAndIntervalAndEndDate
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::providerStartDateAndIntervalAndEndDate
      */
     public function testCreateFromStartDateAndIntervalAndEndDate($arguments, $expected)
     {
@@ -199,7 +199,7 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function provideStartDateAndIntervalAndEndDate(): Generator
+    public function providerStartDateAndIntervalAndEndDate(): Generator
     {
         yield [
             ['2018-04-21', 'P3D', '2018-04-26'],
@@ -241,7 +241,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonPeriod\CreateTest::provideStartDateAndIntervalAndRecurrences
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::providerStartDateAndIntervalAndRecurrences
      */
     public function testCreateFromStartDateAndIntervalAndRecurrences($arguments, $expected)
     {
@@ -258,7 +258,7 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function provideStartDateAndIntervalAndRecurrences(): Generator
+    public function providerStartDateAndIntervalAndRecurrences(): Generator
     {
         yield [
             ['2018-04-16', 'P2D', 3],
@@ -271,7 +271,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonPeriod\CreateTest::provideStartDateAndRecurrences
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::providerStartDateAndRecurrences
      */
     public function testCreateFromStartDateAndRecurrences($arguments, $expected)
     {
@@ -287,7 +287,7 @@ class CreateTest extends AbstractTestCase
         );
     }
 
-    public function provideStartDateAndRecurrences(): Generator
+    public function providerStartDateAndRecurrences(): Generator
     {
         yield [
                 ['2018-04-16', 2],
@@ -326,7 +326,7 @@ class CreateTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonPeriod\CreateTest::provideInvalidParameters
+     * @dataProvider \Tests\CarbonPeriod\CreateTest::providerInvalidParameters
      */
     public function testCreateFromInvalidParameters(...$arguments)
     {
@@ -337,7 +337,7 @@ class CreateTest extends AbstractTestCase
         CarbonPeriod::create(...$arguments);
     }
 
-    public function provideInvalidParameters(): Generator
+    public function providerInvalidParameters(): Generator
     {
         yield [new stdClass(), CarbonInterval::days(1), Carbon::tomorrow()];
         yield [Carbon::now(), new stdClass(), Carbon::tomorrow()];

--- a/tests/CarbonPeriod/IteratorTest.php
+++ b/tests/CarbonPeriod/IteratorTest.php
@@ -129,7 +129,7 @@ class IteratorTest extends AbstractTestCase
         );
     }
 
-    public function dataForIterateBackwardsArguments(): Generator
+    public static function dataForIterateBackwardsArguments(): Generator
     {
         yield [
             ['2015-10-15', '2015-10-06'],

--- a/tests/CarbonPeriod/IteratorTest.php
+++ b/tests/CarbonPeriod/IteratorTest.php
@@ -112,7 +112,7 @@ class IteratorTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonPeriod\IteratorTest::providerIterateBackwardsArguments
+     * @dataProvider \Tests\CarbonPeriod\IteratorTest::dataForIterateBackwardsArguments
      */
     public function testIterateBackwards($arguments, $expected)
     {
@@ -129,7 +129,7 @@ class IteratorTest extends AbstractTestCase
         );
     }
 
-    public function providerIterateBackwardsArguments(): Generator
+    public function dataForIterateBackwardsArguments(): Generator
     {
         yield [
             ['2015-10-15', '2015-10-06'],

--- a/tests/CarbonPeriod/IteratorTest.php
+++ b/tests/CarbonPeriod/IteratorTest.php
@@ -112,7 +112,7 @@ class IteratorTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider provideIterateBackwardsArguments
+     * @dataProvider \Tests\CarbonPeriod\IteratorTest::provideIterateBackwardsArguments
      */
     public function testIterateBackwards($arguments, $expected)
     {

--- a/tests/CarbonPeriod/IteratorTest.php
+++ b/tests/CarbonPeriod/IteratorTest.php
@@ -112,7 +112,7 @@ class IteratorTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonPeriod\IteratorTest::provideIterateBackwardsArguments
+     * @dataProvider \Tests\CarbonPeriod\IteratorTest::providerIterateBackwardsArguments
      */
     public function testIterateBackwards($arguments, $expected)
     {
@@ -129,7 +129,7 @@ class IteratorTest extends AbstractTestCase
         );
     }
 
-    public function provideIterateBackwardsArguments(): Generator
+    public function providerIterateBackwardsArguments(): Generator
     {
         yield [
             ['2015-10-15', '2015-10-06'],

--- a/tests/CarbonPeriod/ToStringTest.php
+++ b/tests/CarbonPeriod/ToStringTest.php
@@ -23,7 +23,7 @@ use Tests\AbstractTestCase;
 class ToStringTest extends AbstractTestCase
 {
     /**
-     * @dataProvider \Tests\CarbonPeriod\ToStringTest::providerToString
+     * @dataProvider \Tests\CarbonPeriod\ToStringTest::dataForToString
      */
     public function testToString($period, $expected)
     {
@@ -33,7 +33,7 @@ class ToStringTest extends AbstractTestCase
         );
     }
 
-    public function providerToString(): Generator
+    public function dataForToString(): Generator
     {
         Carbon::setTestNowAndTimezone(new Carbon('2015-09-01', 'America/Toronto'));
 
@@ -89,7 +89,7 @@ class ToStringTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonPeriod\ToStringTest::providerToIso8601String
+     * @dataProvider \Tests\CarbonPeriod\ToStringTest::dataForToIso8601String
      */
     public function testToIso8601String($period, $expected)
     {
@@ -99,7 +99,7 @@ class ToStringTest extends AbstractTestCase
         );
     }
 
-    public function providerToIso8601String(): Generator
+    public function dataForToIso8601String(): Generator
     {
         Carbon::setTestNowAndTimezone(new Carbon('2015-09-01', 'America/Toronto'));
 

--- a/tests/CarbonPeriod/ToStringTest.php
+++ b/tests/CarbonPeriod/ToStringTest.php
@@ -23,7 +23,7 @@ use Tests\AbstractTestCase;
 class ToStringTest extends AbstractTestCase
 {
     /**
-     * @dataProvider provideToString
+     * @dataProvider \Tests\CarbonPeriod\ToStringTest::provideToString
      */
     public function testToString($period, $expected)
     {
@@ -89,7 +89,7 @@ class ToStringTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider provideToIso8601String
+     * @dataProvider \Tests\CarbonPeriod\ToStringTest::provideToIso8601String
      */
     public function testToIso8601String($period, $expected)
     {

--- a/tests/CarbonPeriod/ToStringTest.php
+++ b/tests/CarbonPeriod/ToStringTest.php
@@ -33,7 +33,7 @@ class ToStringTest extends AbstractTestCase
         );
     }
 
-    public function dataForToString(): Generator
+    public static function dataForToString(): Generator
     {
         Carbon::setTestNowAndTimezone(new Carbon('2015-09-01', 'America/Toronto'));
 
@@ -99,7 +99,7 @@ class ToStringTest extends AbstractTestCase
         );
     }
 
-    public function dataForToIso8601String(): Generator
+    public static function dataForToIso8601String(): Generator
     {
         Carbon::setTestNowAndTimezone(new Carbon('2015-09-01', 'America/Toronto'));
 

--- a/tests/CarbonPeriod/ToStringTest.php
+++ b/tests/CarbonPeriod/ToStringTest.php
@@ -23,7 +23,7 @@ use Tests\AbstractTestCase;
 class ToStringTest extends AbstractTestCase
 {
     /**
-     * @dataProvider \Tests\CarbonPeriod\ToStringTest::provideToString
+     * @dataProvider \Tests\CarbonPeriod\ToStringTest::providerToString
      */
     public function testToString($period, $expected)
     {
@@ -33,7 +33,7 @@ class ToStringTest extends AbstractTestCase
         );
     }
 
-    public function provideToString(): Generator
+    public function providerToString(): Generator
     {
         Carbon::setTestNowAndTimezone(new Carbon('2015-09-01', 'America/Toronto'));
 
@@ -89,7 +89,7 @@ class ToStringTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider \Tests\CarbonPeriod\ToStringTest::provideToIso8601String
+     * @dataProvider \Tests\CarbonPeriod\ToStringTest::providerToIso8601String
      */
     public function testToIso8601String($period, $expected)
     {
@@ -99,7 +99,7 @@ class ToStringTest extends AbstractTestCase
         );
     }
 
-    public function provideToIso8601String(): Generator
+    public function providerToIso8601String(): Generator
     {
         Carbon::setTestNowAndTimezone(new Carbon('2015-09-01', 'America/Toronto'));
 

--- a/tests/CarbonTimeZone/ConversionsTest.php
+++ b/tests/CarbonTimeZone/ConversionsTest.php
@@ -50,7 +50,7 @@ class ConversionsTest extends AbstractTestCaseWithOldNow
         $this->assertSame('America/Chicago', (new CarbonTimeZone('America/Toronto'))->toOffsetTimeZone($date)->toRegionTimeZone($date)->getName());
     }
 
-    public function dataForToOffsetName(): Generator
+    public static function dataForToOffsetName(): Generator
     {
         // timezone - number
         yield ['2018-12-20', '-05:00', -5];

--- a/tests/CarbonTimeZone/ConversionsTest.php
+++ b/tests/CarbonTimeZone/ConversionsTest.php
@@ -50,7 +50,7 @@ class ConversionsTest extends AbstractTestCaseWithOldNow
         $this->assertSame('America/Chicago', (new CarbonTimeZone('America/Toronto'))->toOffsetTimeZone($date)->toRegionTimeZone($date)->getName());
     }
 
-    public function dataProviderToOffsetName(): Generator
+    public function providerToOffsetName(): Generator
     {
         // timezone - number
         yield ['2018-12-20', '-05:00', -5];
@@ -82,7 +82,7 @@ class ConversionsTest extends AbstractTestCaseWithOldNow
      * @param string     $date
      * @param string     $expectedOffset
      * @param string|int $timezone
-     * @dataProvider \Tests\CarbonTimeZone\ConversionsTest::dataProviderToOffsetName
+     * @dataProvider \Tests\CarbonTimeZone\ConversionsTest::providerToOffsetName
      */
     public function testToOffsetName($date, $expectedOffset, $timezone)
     {
@@ -96,7 +96,7 @@ class ConversionsTest extends AbstractTestCaseWithOldNow
      * @param string     $date
      * @param string     $expectedOffset
      * @param string|int $timezone
-     * @dataProvider \Tests\CarbonTimeZone\ConversionsTest::dataProviderToOffsetName
+     * @dataProvider \Tests\CarbonTimeZone\ConversionsTest::providerToOffsetName
      */
     public function testToOffsetNameDateAsParam($date, $expectedOffset, $timezone)
     {

--- a/tests/CarbonTimeZone/ConversionsTest.php
+++ b/tests/CarbonTimeZone/ConversionsTest.php
@@ -50,7 +50,7 @@ class ConversionsTest extends AbstractTestCaseWithOldNow
         $this->assertSame('America/Chicago', (new CarbonTimeZone('America/Toronto'))->toOffsetTimeZone($date)->toRegionTimeZone($date)->getName());
     }
 
-    public function providerToOffsetName(): Generator
+    public function dataForToOffsetName(): Generator
     {
         // timezone - number
         yield ['2018-12-20', '-05:00', -5];
@@ -82,7 +82,7 @@ class ConversionsTest extends AbstractTestCaseWithOldNow
      * @param string     $date
      * @param string     $expectedOffset
      * @param string|int $timezone
-     * @dataProvider \Tests\CarbonTimeZone\ConversionsTest::providerToOffsetName
+     * @dataProvider \Tests\CarbonTimeZone\ConversionsTest::dataForToOffsetName
      */
     public function testToOffsetName($date, $expectedOffset, $timezone)
     {
@@ -96,7 +96,7 @@ class ConversionsTest extends AbstractTestCaseWithOldNow
      * @param string     $date
      * @param string     $expectedOffset
      * @param string|int $timezone
-     * @dataProvider \Tests\CarbonTimeZone\ConversionsTest::providerToOffsetName
+     * @dataProvider \Tests\CarbonTimeZone\ConversionsTest::dataForToOffsetName
      */
     public function testToOffsetNameDateAsParam($date, $expectedOffset, $timezone)
     {

--- a/tests/CarbonTimeZone/ConversionsTest.php
+++ b/tests/CarbonTimeZone/ConversionsTest.php
@@ -82,7 +82,7 @@ class ConversionsTest extends AbstractTestCaseWithOldNow
      * @param string     $date
      * @param string     $expectedOffset
      * @param string|int $timezone
-     * @dataProvider dataProviderToOffsetName
+     * @dataProvider \Tests\CarbonTimeZone\ConversionsTest::dataProviderToOffsetName
      */
     public function testToOffsetName($date, $expectedOffset, $timezone)
     {
@@ -96,7 +96,7 @@ class ConversionsTest extends AbstractTestCaseWithOldNow
      * @param string     $date
      * @param string     $expectedOffset
      * @param string|int $timezone
-     * @dataProvider dataProviderToOffsetName
+     * @dataProvider \Tests\CarbonTimeZone\ConversionsTest::dataProviderToOffsetName
      */
     public function testToOffsetNameDateAsParam($date, $expectedOffset, $timezone)
     {

--- a/tests/CommonTraits/MacroContextNestingTest.php
+++ b/tests/CommonTraits/MacroContextNestingTest.php
@@ -22,7 +22,7 @@ use Tests\AbstractTestCaseWithOldNow;
 
 class MacroContextNestingTest extends AbstractTestCaseWithOldNow
 {
-    public function providerMacroableClasses(): Generator
+    public function dataForMacroableClasses(): Generator
     {
         yield [Carbon::class, Carbon::parse('2010-05-23'), null];
         yield [CarbonImmutable::class, CarbonImmutable::parse('2010-05-23'), null];
@@ -31,7 +31,7 @@ class MacroContextNestingTest extends AbstractTestCaseWithOldNow
     }
 
     /**
-     * @dataProvider \Tests\CommonTraits\MacroContextNestingTest::providerMacroableClasses
+     * @dataProvider \Tests\CommonTraits\MacroContextNestingTest::dataForMacroableClasses
      *
      * @param string      $class
      * @param mixed       $sample
@@ -64,7 +64,7 @@ class MacroContextNestingTest extends AbstractTestCaseWithOldNow
     }
 
     /**
-     * @dataProvider \Tests\CommonTraits\MacroContextNestingTest::providerMacroableClasses
+     * @dataProvider \Tests\CommonTraits\MacroContextNestingTest::dataForMacroableClasses
      *
      * @param string $class
      * @param mixed  $sample

--- a/tests/CommonTraits/MacroContextNestingTest.php
+++ b/tests/CommonTraits/MacroContextNestingTest.php
@@ -31,7 +31,7 @@ class MacroContextNestingTest extends AbstractTestCaseWithOldNow
     }
 
     /**
-     * @dataProvider getMacroableClasses
+     * @dataProvider \Tests\CommonTraits\MacroContextNestingTest::getMacroableClasses
      *
      * @param string      $class
      * @param mixed       $sample
@@ -64,7 +64,7 @@ class MacroContextNestingTest extends AbstractTestCaseWithOldNow
     }
 
     /**
-     * @dataProvider getMacroableClasses
+     * @dataProvider \Tests\CommonTraits\MacroContextNestingTest::getMacroableClasses
      *
      * @param string $class
      * @param mixed  $sample

--- a/tests/CommonTraits/MacroContextNestingTest.php
+++ b/tests/CommonTraits/MacroContextNestingTest.php
@@ -22,7 +22,7 @@ use Tests\AbstractTestCaseWithOldNow;
 
 class MacroContextNestingTest extends AbstractTestCaseWithOldNow
 {
-    public function dataForMacroableClasses(): Generator
+    public static function dataForMacroableClasses(): Generator
     {
         yield [Carbon::class, Carbon::parse('2010-05-23'), null];
         yield [CarbonImmutable::class, CarbonImmutable::parse('2010-05-23'), null];

--- a/tests/CommonTraits/MacroContextNestingTest.php
+++ b/tests/CommonTraits/MacroContextNestingTest.php
@@ -22,7 +22,7 @@ use Tests\AbstractTestCaseWithOldNow;
 
 class MacroContextNestingTest extends AbstractTestCaseWithOldNow
 {
-    public function getMacroableClasses(): Generator
+    public function providerMacroableClasses(): Generator
     {
         yield [Carbon::class, Carbon::parse('2010-05-23'), null];
         yield [CarbonImmutable::class, CarbonImmutable::parse('2010-05-23'), null];
@@ -31,7 +31,7 @@ class MacroContextNestingTest extends AbstractTestCaseWithOldNow
     }
 
     /**
-     * @dataProvider \Tests\CommonTraits\MacroContextNestingTest::getMacroableClasses
+     * @dataProvider \Tests\CommonTraits\MacroContextNestingTest::providerMacroableClasses
      *
      * @param string      $class
      * @param mixed       $sample
@@ -64,7 +64,7 @@ class MacroContextNestingTest extends AbstractTestCaseWithOldNow
     }
 
     /**
-     * @dataProvider \Tests\CommonTraits\MacroContextNestingTest::getMacroableClasses
+     * @dataProvider \Tests\CommonTraits\MacroContextNestingTest::providerMacroableClasses
      *
      * @param string $class
      * @param mixed  $sample

--- a/tests/Doctrine/CarbonTypesTest.php
+++ b/tests/Doctrine/CarbonTypesTest.php
@@ -33,14 +33,14 @@ class CarbonTypesTest extends AbstractTestCase
 {
     public static function setUpBeforeClass(): void
     {
-        foreach (static::getTypes() as [$name, , $typeClass]) {
+        foreach (static::providerTypes() as [$name, , $typeClass]) {
             Type::hasType($name)
                 ? Type::overrideType($name, $typeClass)
                 : Type::addType($name, $typeClass);
         }
     }
 
-    public static function getTypes(): Generator
+    public static function providerTypes(): Generator
     {
         yield ['datetime', Carbon::class, DateTimeType::class, false];
         yield ['datetime_immutable', CarbonImmutable::class, DateTimeImmutableType::class, true];
@@ -53,7 +53,7 @@ class CarbonTypesTest extends AbstractTestCase
      *
      * @param string $name
      *
-     * @dataProvider \Tests\Doctrine\CarbonTypesTest::getTypes
+     * @dataProvider \Tests\Doctrine\CarbonTypesTest::providerTypes
      *
      * @throws Exception
      */
@@ -95,7 +95,7 @@ class CarbonTypesTest extends AbstractTestCase
      * @param string $name
      * @param string $class
      *
-     * @dataProvider \Tests\Doctrine\CarbonTypesTest::getTypes
+     * @dataProvider \Tests\Doctrine\CarbonTypesTest::providerTypes
      *
      * @throws Exception
      */
@@ -124,7 +124,7 @@ class CarbonTypesTest extends AbstractTestCase
      * @param string $name
      * @param string $class
      *
-     * @dataProvider \Tests\Doctrine\CarbonTypesTest::getTypes
+     * @dataProvider \Tests\Doctrine\CarbonTypesTest::providerTypes
      *
      * @throws Exception
      */
@@ -143,7 +143,7 @@ class CarbonTypesTest extends AbstractTestCase
      *
      * @param string $name
      *
-     * @dataProvider \Tests\Doctrine\CarbonTypesTest::getTypes
+     * @dataProvider \Tests\Doctrine\CarbonTypesTest::providerTypes
      *
      * @throws Exception
      */
@@ -163,7 +163,7 @@ class CarbonTypesTest extends AbstractTestCase
      *
      * @param string $name
      *
-     * @dataProvider \Tests\Doctrine\CarbonTypesTest::getTypes
+     * @dataProvider \Tests\Doctrine\CarbonTypesTest::providerTypes
      *
      * @throws Exception
      */
@@ -186,7 +186,7 @@ class CarbonTypesTest extends AbstractTestCase
      * @param string $typeClass
      * @param bool   $hintRequired
      *
-     * @dataProvider \Tests\Doctrine\CarbonTypesTest::getTypes
+     * @dataProvider \Tests\Doctrine\CarbonTypesTest::providerTypes
      *
      * @throws Exception
      */

--- a/tests/Doctrine/CarbonTypesTest.php
+++ b/tests/Doctrine/CarbonTypesTest.php
@@ -33,14 +33,14 @@ class CarbonTypesTest extends AbstractTestCase
 {
     public static function setUpBeforeClass(): void
     {
-        foreach (static::providerTypes() as [$name, , $typeClass]) {
+        foreach (static::dataForTypes() as [$name, , $typeClass]) {
             Type::hasType($name)
                 ? Type::overrideType($name, $typeClass)
                 : Type::addType($name, $typeClass);
         }
     }
 
-    public static function providerTypes(): Generator
+    public static function dataForTypes(): Generator
     {
         yield ['datetime', Carbon::class, DateTimeType::class, false];
         yield ['datetime_immutable', CarbonImmutable::class, DateTimeImmutableType::class, true];
@@ -53,7 +53,7 @@ class CarbonTypesTest extends AbstractTestCase
      *
      * @param string $name
      *
-     * @dataProvider \Tests\Doctrine\CarbonTypesTest::providerTypes
+     * @dataProvider \Tests\Doctrine\CarbonTypesTest::dataForTypes
      *
      * @throws Exception
      */
@@ -95,7 +95,7 @@ class CarbonTypesTest extends AbstractTestCase
      * @param string $name
      * @param string $class
      *
-     * @dataProvider \Tests\Doctrine\CarbonTypesTest::providerTypes
+     * @dataProvider \Tests\Doctrine\CarbonTypesTest::dataForTypes
      *
      * @throws Exception
      */
@@ -124,7 +124,7 @@ class CarbonTypesTest extends AbstractTestCase
      * @param string $name
      * @param string $class
      *
-     * @dataProvider \Tests\Doctrine\CarbonTypesTest::providerTypes
+     * @dataProvider \Tests\Doctrine\CarbonTypesTest::dataForTypes
      *
      * @throws Exception
      */
@@ -143,7 +143,7 @@ class CarbonTypesTest extends AbstractTestCase
      *
      * @param string $name
      *
-     * @dataProvider \Tests\Doctrine\CarbonTypesTest::providerTypes
+     * @dataProvider \Tests\Doctrine\CarbonTypesTest::dataForTypes
      *
      * @throws Exception
      */
@@ -163,7 +163,7 @@ class CarbonTypesTest extends AbstractTestCase
      *
      * @param string $name
      *
-     * @dataProvider \Tests\Doctrine\CarbonTypesTest::providerTypes
+     * @dataProvider \Tests\Doctrine\CarbonTypesTest::dataForTypes
      *
      * @throws Exception
      */
@@ -186,7 +186,7 @@ class CarbonTypesTest extends AbstractTestCase
      * @param string $typeClass
      * @param bool   $hintRequired
      *
-     * @dataProvider \Tests\Doctrine\CarbonTypesTest::providerTypes
+     * @dataProvider \Tests\Doctrine\CarbonTypesTest::dataForTypes
      *
      * @throws Exception
      */

--- a/tests/Doctrine/CarbonTypesTest.php
+++ b/tests/Doctrine/CarbonTypesTest.php
@@ -53,7 +53,7 @@ class CarbonTypesTest extends AbstractTestCase
      *
      * @param string $name
      *
-     * @dataProvider getTypes
+     * @dataProvider \Tests\Doctrine\CarbonTypesTest::getTypes
      *
      * @throws Exception
      */
@@ -95,7 +95,7 @@ class CarbonTypesTest extends AbstractTestCase
      * @param string $name
      * @param string $class
      *
-     * @dataProvider getTypes
+     * @dataProvider \Tests\Doctrine\CarbonTypesTest::getTypes
      *
      * @throws Exception
      */
@@ -124,7 +124,7 @@ class CarbonTypesTest extends AbstractTestCase
      * @param string $name
      * @param string $class
      *
-     * @dataProvider getTypes
+     * @dataProvider \Tests\Doctrine\CarbonTypesTest::getTypes
      *
      * @throws Exception
      */
@@ -143,7 +143,7 @@ class CarbonTypesTest extends AbstractTestCase
      *
      * @param string $name
      *
-     * @dataProvider getTypes
+     * @dataProvider \Tests\Doctrine\CarbonTypesTest::getTypes
      *
      * @throws Exception
      */
@@ -163,7 +163,7 @@ class CarbonTypesTest extends AbstractTestCase
      *
      * @param string $name
      *
-     * @dataProvider getTypes
+     * @dataProvider \Tests\Doctrine\CarbonTypesTest::getTypes
      *
      * @throws Exception
      */
@@ -186,7 +186,7 @@ class CarbonTypesTest extends AbstractTestCase
      * @param string $typeClass
      * @param bool   $hintRequired
      *
-     * @dataProvider getTypes
+     * @dataProvider \Tests\Doctrine\CarbonTypesTest::getTypes
      *
      * @throws Exception
      */

--- a/tests/Laravel/ServiceProviderTest.php
+++ b/tests/Laravel/ServiceProviderTest.php
@@ -28,7 +28,7 @@ use stdClass;
 
 class ServiceProviderTest extends TestCase
 {
-    public function providerDispatchers(): Generator
+    public function dataForDispatchers(): Generator
     {
         if (!class_exists(Dispatcher::class)) {
             include_once __DIR__.'/Dispatcher.php';
@@ -43,7 +43,7 @@ class ServiceProviderTest extends TestCase
     }
 
     /**
-     * @dataProvider \Tests\Laravel\ServiceProviderTest::providerDispatchers
+     * @dataProvider \Tests\Laravel\ServiceProviderTest::dataForDispatchers
      */
     public function testBoot($dispatcher)
     {

--- a/tests/Laravel/ServiceProviderTest.php
+++ b/tests/Laravel/ServiceProviderTest.php
@@ -28,7 +28,7 @@ use stdClass;
 
 class ServiceProviderTest extends TestCase
 {
-    public function getDispatchers(): Generator
+    public function providerDispatchers(): Generator
     {
         if (!class_exists(Dispatcher::class)) {
             include_once __DIR__.'/Dispatcher.php';
@@ -43,7 +43,7 @@ class ServiceProviderTest extends TestCase
     }
 
     /**
-     * @dataProvider \Tests\Laravel\ServiceProviderTest::getDispatchers
+     * @dataProvider \Tests\Laravel\ServiceProviderTest::providerDispatchers
      */
     public function testBoot($dispatcher)
     {

--- a/tests/Laravel/ServiceProviderTest.php
+++ b/tests/Laravel/ServiceProviderTest.php
@@ -43,7 +43,7 @@ class ServiceProviderTest extends TestCase
     }
 
     /**
-     * @dataProvider getDispatchers
+     * @dataProvider \Tests\Laravel\ServiceProviderTest::getDispatchers
      */
     public function testBoot($dispatcher)
     {

--- a/tests/Laravel/ServiceProviderTest.php
+++ b/tests/Laravel/ServiceProviderTest.php
@@ -28,7 +28,7 @@ use stdClass;
 
 class ServiceProviderTest extends TestCase
 {
-    public function dataForDispatchers(): Generator
+    public static function dataForDispatchers(): Generator
     {
         if (!class_exists(Dispatcher::class)) {
             include_once __DIR__.'/Dispatcher.php';


### PR DESCRIPTION
This PR ensure that all tests data providers are prefixed with `provider`.
This PR also enforces consistency and ensures that all all the methods are fully-qualified.
