### PR TITLE
CarbonPeriod Handle infinite recurrences when parsing period string

### DIFF
--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -482,8 +482,8 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
         $end = null;
 
         foreach (explode('/', $iso) as $key => $part) {
-            if ($key === 0 && preg_match('/^R([0-9]*)$/', $part, $match)) {
-                $parsed = \strlen($match[1]) ? (int) $match[1] : null;
+            if ($key === 0 && preg_match('/^R([0-9]*|INF)$/', $part, $match)) {
+                $parsed = \strlen($match[1]) ? (($match[1] !== 'INF') ? (int) $match[1] : INF) : null;
             } elseif ($interval === null && $parsed = CarbonInterval::make($part)) {
                 $interval = $part;
             } elseif ($start === null && $parsed = Carbon::make($part)) {

--- a/tests/CarbonPeriod/CreateTest.php
+++ b/tests/CarbonPeriod/CreateTest.php
@@ -78,6 +78,15 @@ class CreateTest extends AbstractTestCase
         $this->assertNull($period->getRecurrences());
     }
 
+    public function testCreateFromIso8601StringWithInfiniteRecurrences()
+    {
+        $period = CarbonPeriod::create('RINF/2012-07-01T00:00:00/P7D');
+        $this->assertSame('2012-07-01', $period->getStartDate()->toDateString());
+        $this->assertSame('P7D', $period->getDateInterval()->spec());
+        $this->assertNull($period->getEndDate());
+        $this->assertInfinite($period->getRecurrences());
+    }
+
     /**
      * @dataProvider \Tests\CarbonPeriod\CreateTest::dataForPartialIso8601String
      */


### PR DESCRIPTION
Fixes #2527.
The regular expression to parse the recurrence is augmented with the INF value. Based on this, the recurrence value is set to INF, if RINF is found.