### PR TITLE
Allow precision 0 in Carbon DBAL types

### DIFF
--- a/src/Carbon/Doctrine/CarbonTypeConverter.php
+++ b/src/Carbon/Doctrine/CarbonTypeConverter.php
@@ -36,9 +36,16 @@ trait CarbonTypeConverter
      */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {
-        $precision = ($fieldDeclaration['precision'] ?? 10) === 10
-            ? DateTimeDefaultPrecision::get()
-            : $fieldDeclaration['precision'];
+        $precision = $fieldDeclaration['precision'] ?: 10;
+
+        if ($fieldDeclaration['secondPrecision'] ?? false) {
+            $precision = 0;
+        }
+
+        if ($precision === 10) {
+            $precision = DateTimeDefaultPrecision::get();
+        }
+
         $type = parent::getSQLDeclaration($fieldDeclaration, $platform);
 
         if (!$precision) {

--- a/src/Carbon/Doctrine/CarbonTypeConverter.php
+++ b/src/Carbon/Doctrine/CarbonTypeConverter.php
@@ -36,7 +36,7 @@ trait CarbonTypeConverter
      */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {
-        $precision = ($fieldDeclaration['precision'] ?: 10) === 10
+        $precision = ($fieldDeclaration['precision'] ?? 10) === 10
             ? DateTimeDefaultPrecision::get()
             : $fieldDeclaration['precision'];
         $type = parent::getSQLDeclaration($fieldDeclaration, $platform);

--- a/tests/Doctrine/CarbonTypesTest.php
+++ b/tests/Doctrine/CarbonTypesTest.php
@@ -64,9 +64,17 @@ class CarbonTypesTest extends AbstractTestCase
         $precision = DateTimeDefaultPrecision::get();
         $this->assertSame(6, $precision);
 
+        $this->assertSame('DATETIME', $type->getSQLDeclaration([
+            'precision' => 0,
+        ], new MySQL57Platform()));
+
         $this->assertSame('DATETIME(3)', $type->getSQLDeclaration([
             'precision' => 3,
         ], new MySQL57Platform()));
+
+        $this->assertSame('TIMESTAMP(0)', $type->getSQLDeclaration([
+            'precision' => 0,
+        ], new DB2Platform()));
 
         $this->assertSame('TIMESTAMP(6)', $type->getSQLDeclaration([
             'precision' => null,

--- a/tests/Doctrine/CarbonTypesTest.php
+++ b/tests/Doctrine/CarbonTypesTest.php
@@ -65,7 +65,8 @@ class CarbonTypesTest extends AbstractTestCase
         $this->assertSame(6, $precision);
 
         $this->assertSame('DATETIME', $type->getSQLDeclaration([
-            'precision' => 0,
+            'precision' => null,
+            'secondPrecision' => true,
         ], new MySQL57Platform()));
 
         $this->assertSame('DATETIME(3)', $type->getSQLDeclaration([
@@ -73,7 +74,8 @@ class CarbonTypesTest extends AbstractTestCase
         ], new MySQL57Platform()));
 
         $this->assertSame('TIMESTAMP(0)', $type->getSQLDeclaration([
-            'precision' => 0,
+            'precision' => null,
+            'secondPrecision' => true,
         ], new DB2Platform()));
 
         $this->assertSame('TIMESTAMP(6)', $type->getSQLDeclaration([

--- a/tests/Doctrine/CarbonTypesTest.php
+++ b/tests/Doctrine/CarbonTypesTest.php
@@ -82,6 +82,14 @@ class CarbonTypesTest extends AbstractTestCase
             'precision' => null,
         ], new DB2Platform()));
 
+        $this->assertSame('TIMESTAMP(6)', $type->getSQLDeclaration([
+            'precision' => 0,
+        ], new DB2Platform()));
+
+        $this->assertSame('DATETIME(6)', $type->getSQLDeclaration([
+            'precision' => 0,
+        ], new MySQL57Platform()));
+
         $this->assertSame('DATETIME(6)', $type->getSQLDeclaration([
             'precision' => null,
         ], new MySQL57Platform()));


### PR DESCRIPTION
Allow explicitly defined 0 precision for DBAL types without explicitly setting Datetime precision through `DateTimeDefaultPrecision::set()` because right now explicit 0 precision is treated same as `null`.