### PR TITLE
LessThan comparisons with null or empty string

### DIFF
--- a/src/Carbon/Traits/Comparison.php
+++ b/src/Carbon/Traits/Comparison.php
@@ -155,7 +155,7 @@ trait Comparison
      */
     public function greaterThan($date): bool
     {
-        return $this > $this->resolveCarbon($date);
+        return !$date || $this > $this->resolveCarbon($date);
     }
 
     /**
@@ -256,7 +256,7 @@ trait Comparison
      */
     public function lessThan($date): bool
     {
-        return $this < $this->resolveCarbon($date);
+        return $date && $this < $this->resolveCarbon($date);
     }
 
     /**

--- a/tests/Carbon/ComparisonTest.php
+++ b/tests/Carbon/ComparisonTest.php
@@ -360,4 +360,17 @@ class ComparisonTest extends AbstractTestCase
 
         $this->assertSame('06.300000', $baseDate->farthest($closestDate, $farthestDate)->format('s.u'));
     }
+
+    public function testWithNullOrEmpty()
+    {
+        $dt = Carbon::now();
+        $this->assertFalse($dt->lessThan(null));
+        $this->assertFalse($dt->lessThan(''));
+
+        $this->assertFalse($dt->lessThanOrEqualTo(null));
+        $this->assertFalse($dt->lessThanOrEqualTo(''));
+
+        $this->assertTrue($dt->greaterThan(null));
+        $this->assertTrue($dt->greaterThan(''));
+    }
 }


### PR DESCRIPTION
the issue was introduced from 2.56.0 to fix https://github.com/briannesbitt/Carbon/issues/2529

I saw https://github.com/briannesbitt/Carbon/issues/2544 conversations, and I met same issue.

There is another issue isn't mentioned,

```
>>> Carbon::now()->lessThanOrEqualTo('')
=> false

>>> Carbon::now()->lessThan('')
=> true
```

`lessThanOrEqualTo` and `lessThan` with different result was confused, I think it should be better if carbon deal with, and keep same result with version < 2.56.0, it would be appreciated if we don't need to change original code in project.

@kylekatarnls so, would you pls double check? and I also add test with null or empty, thanks. 

