### PR TITLE
Grammar fixes

### DIFF
--- a/src/Carbon/Lang/fr.php
+++ b/src/Carbon/Lang/fr.php
@@ -90,7 +90,7 @@ return [
     'weekdays_min' => ['di', 'lu', 'ma', 'me', 'je', 've', 'sa'],
     'ordinal' => function ($number, $period) {
         switch ($period) {
-            // In French, only the first has been ordinal, other number remains cardinal
+            // In French, only the first has to be ordinal, other number remains cardinal
             // @link https://fr.wikihow.com/%C3%A9crire-la-date-en-fran%C3%A7ais
             case 'D':
                 return $number.($number === 1 ? 'er' : '');

--- a/src/Carbon/Lang/fr.php
+++ b/src/Carbon/Lang/fr.php
@@ -90,7 +90,7 @@ return [
     'weekdays_min' => ['di', 'lu', 'ma', 'me', 'je', 've', 'sa'],
     'ordinal' => function ($number, $period) {
         switch ($period) {
-            // In french, only the first has be ordinal, other number remains cardinal
+            // In French, only the first has been ordinal, other number remains cardinal
             // @link https://fr.wikihow.com/%C3%A9crire-la-date-en-fran%C3%A7ais
             case 'D':
                 return $number.($number === 1 ? 'er' : '');


### PR DESCRIPTION
French needs to be capitalized when not used as verb.
Past participle issue or typo in same line "be" should be "been"