### PR TITLE
Improve float comparison precision in tests

### DIFF
--- a/tests/Carbon/DiffTest.php
+++ b/tests/Carbon/DiffTest.php
@@ -1635,7 +1635,7 @@ class DiffTest extends AbstractTestCase
         $this->assertSame(-1, Carbon::parse('2018-11-28 00:00:00', 'Europe/Paris')->floatDiffInMonths(Carbon::parse('2018-10-28 00:00:00', 'Europe/Paris'), false));
 
         if (version_compare(PHP_VERSION, '7.2.0-dev', '>=')) {
-            $this->assertSame(0.99999999998843, Carbon::parse('2020-12-17 00:00:00.000001')->floatDiffInDays('2020-12-16 00:00:00.000002'));
+            $this->assertSame(0.9999999999884259, Carbon::parse('2020-12-17 00:00:00.000001')->floatDiffInDays('2020-12-16 00:00:00.000002'));
         }
     }
 

--- a/tests/CarbonImmutable/DiffTest.php
+++ b/tests/CarbonImmutable/DiffTest.php
@@ -1584,7 +1584,7 @@ class DiffTest extends AbstractTestCase
         $this->assertSame(-1, Carbon::parse('2018-11-28 00:00:00', 'Europe/Paris')->floatDiffInMonths(Carbon::parse('2018-10-28 00:00:00', 'Europe/Paris'), false));
 
         if (version_compare(PHP_VERSION, '7.2.0-dev', '>=')) {
-            $this->assertSame(0.99999999998843, Carbon::parse('2020-12-17 00:00:00.000001')->floatDiffInDays('2020-12-16 00:00:00.000002'));
+            $this->assertSame(0.9999999999884259, Carbon::parse('2020-12-17 00:00:00.000001')->floatDiffInDays('2020-12-16 00:00:00.000002'));
         }
     }
 


### PR DESCRIPTION
PHPUnit 9.5.14 increased the precision of float comparisons from
0.0000000001 to PHP_FLOAT_EPSILON, causing some tests to fail.