### PR TITLE
Reset testNow after exceptions occurring in setTestNow()

### DIFF
--- a/src/Carbon/Traits/Test.php
+++ b/src/Carbon/Traits/Test.php
@@ -129,6 +129,7 @@ trait Test
     public static function withTestNow($testNow = null, $callback = null)
     {
         static::setTestNow($testNow);
+
         try {
             $result = $callback();
         } finally {

--- a/src/Carbon/Traits/Test.php
+++ b/src/Carbon/Traits/Test.php
@@ -129,8 +129,11 @@ trait Test
     public static function withTestNow($testNow = null, $callback = null)
     {
         static::setTestNow($testNow);
-        $result = $callback();
-        static::setTestNow();
+        try {
+            $result = $callback();
+        } finally {
+            static::setTestNow();
+        }
 
         return $result;
     }

--- a/tests/Carbon/TestingAidsTest.php
+++ b/tests/Carbon/TestingAidsTest.php
@@ -326,4 +326,20 @@ class TestingAidsTest extends AbstractTestCase
         $currentTime = Carbon::now();
         $this->assertNotEquals($testNow, $currentTime->format('Y-m-d H:i:s'));
     }
+
+    public function testWithTestNowWithException()
+    {
+        $testNow = '2020-09-16 10:20:00';
+
+        try {
+            Carbon::withTestNow($testNow, static function () {
+                throw new \Exception();
+            });
+        } catch (\Exception $e) {
+            // ignore
+        }
+
+        $currentTime = Carbon::now();
+        $this->assertNotEquals($testNow, $currentTime->format('Y-m-d H:i:s'));
+    }
 }

--- a/tests/CarbonImmutable/TestingAidsTest.php
+++ b/tests/CarbonImmutable/TestingAidsTest.php
@@ -279,4 +279,20 @@ class TestingAidsTest extends AbstractTestCase
         $currentTime = Carbon::now();
         $this->assertNotEquals($testNow, $currentTime->format('Y-m-d H:i:s'));
     }
+
+    public function testWithTestNowWithException()
+    {
+        $testNow = '2020-09-16 10:20:00';
+
+        try {
+            Carbon::withTestNow($testNow, static function () {
+                throw new \Exception();
+            });
+        } catch (\Exception $e) {
+            // ignore
+        }
+
+        $currentTime = Carbon::now();
+        $this->assertNotEquals($testNow, $currentTime->format('Y-m-d H:i:s'));
+    }
 }


### PR DESCRIPTION
Moved `setTestNow()` to the `finally` clause so that `setTestNow()` is executed even if `$callback()` throws an exception.

Fix #2561