### PR TITLE
Fix CreateFromTimeTest

### DIFF
--- a/tests/Carbon/CreateFromTimeTest.php
+++ b/tests/Carbon/CreateFromTimeTest.php
@@ -97,14 +97,14 @@ class CreateFromTimeTest extends AbstractTestCase
     public function testCreateFromTimeWithDateTimeZone()
     {
         $d = Carbon::createFromTime(12, 0, 0, new DateTimeZone('Europe/London'));
-        $this->assertCarbon($d, Carbon::now()->year, Carbon::now()->month, Carbon::now()->day, 12, 0, 0);
+        $this->assertCarbon($d, Carbon::now('Europe/London')->year, Carbon::now('Europe/London')->month, Carbon::now('Europe/London')->day, 12, 0, 0);
         $this->assertSame('Europe/London', $d->tzName);
     }
 
     public function testCreateFromTimeWithTimeZoneString()
     {
         $d = Carbon::createFromTime(12, 0, 0, 'Europe/London');
-        $this->assertCarbon($d, Carbon::now()->year, Carbon::now()->month, Carbon::now()->day, 12, 0, 0);
+        $this->assertCarbon($d, Carbon::now('Europe/London')->year, Carbon::now('Europe/London')->month, Carbon::now('Europe/London')->day, 12, 0, 0);
         $this->assertSame('Europe/London', $d->tzName);
     }
 

--- a/tests/CarbonImmutable/CreateFromTimeTest.php
+++ b/tests/CarbonImmutable/CreateFromTimeTest.php
@@ -69,14 +69,14 @@ class CreateFromTimeTest extends AbstractTestCase
     public function testCreateFromTimeWithDateTimeZone()
     {
         $d = Carbon::createFromTime(12, 0, 0, new DateTimeZone('Europe/London'));
-        $this->assertCarbon($d, Carbon::now()->year, Carbon::now()->month, Carbon::now()->day, 12, 0, 0);
+        $this->assertCarbon($d, Carbon::now('Europe/London')->year, Carbon::now('Europe/London')->month, Carbon::now('Europe/London')->day, 12, 0, 0);
         $this->assertSame('Europe/London', $d->tzName);
     }
 
     public function testCreateFromTimeWithTimeZoneString()
     {
         $d = Carbon::createFromTime(12, 0, 0, 'Europe/London');
-        $this->assertCarbon($d, Carbon::now()->year, Carbon::now()->month, Carbon::now()->day, 12, 0, 0);
+        $this->assertCarbon($d, Carbon::now('Europe/London')->year, Carbon::now('Europe/London')->month, Carbon::now('Europe/London')->day, 12, 0, 0);
         $this->assertSame('Europe/London', $d->tzName);
     }
 


### PR DESCRIPTION
In the test when timezone is specified, `Carbon::now()` is used to calculate the expected date. If the test is run in an environment that defaults to a timezone other than the 'Europe/London' specified in the test, the test may fail because the dates obtained will be different for some hours of the day.
Specifying the time zone when asking for the expected date solves this problem.

