### PR TITLE
Fix: #2536 - improve test for Symfony v4/5 contracts

### DIFF
--- a/src/Carbon/Traits/Localization.php
+++ b/src/Carbon/Traits/Localization.php
@@ -23,7 +23,10 @@ use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Symfony\Contracts\Translation\TranslatorInterface as ContractsTranslatorInterface;
 
-if (!interface_exists('Symfony\\Component\\Translation\\TranslatorInterface')) {
+if (
+    PHP_VERSION_ID < 72000 && !interface_exists('Symfony\\Component\\Translation\\TranslatorInterface') ||
+    PHP_VERSION_ID >= 72000 && interface_exists('Symfony\\Contracts\\Translation\\TranslatorInterface')
+) {
     class_alias(
         'Symfony\\Contracts\\Translation\\TranslatorInterface',
         'Symfony\\Component\\Translation\\TranslatorInterface'


### PR DESCRIPTION
Only one of the two interface files should exist.  Hence these two statements should be equivalent:

* `if (!interface_exists('Symfony\\Component\\Translation\\TranslatorInterface'))`
* `if (interface_exists('Symfony\\Contracts\\Translation\\TranslatorInterface'))`

If both interface files exist (i.e. the old one is still present), then replacing the first test with the second one solves #2536 - but only for PHP 7.2 and upwards.  For PHP 7.1, we need the original test.

The following code will fix this problem and will pass the unit tests. 
I also tested on my own application using PHP 7.1 - 8.1.

```
if (
    PHP_VERSION_ID < 72000 && !interface_exists('Symfony\\Component\\Translation\\TranslatorInterface') ||
    PHP_VERSION_ID >= 72000 && interface_exists('Symfony\\Contracts\\Translation\\TranslatorInterface')
) {
    class_alias(
        'Symfony\\Contracts\\Translation\\TranslatorInterface',
        'Symfony\\Component\\Translation\\TranslatorInterface'
    );
}
```

I am not completely happy with this - I haven't managed to work out exactly why the PHP dependency is relevant.