### PR TITLE
Add QUARTERS_PER_YEAR constant

### DIFF
--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -586,6 +586,7 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
     public const YEARS_PER_DECADE = 10;
     public const MONTHS_PER_YEAR = 12;
     public const MONTHS_PER_QUARTER = 3;
+    public const QUARTERS_PER_YEAR = 4;
     public const WEEKS_PER_YEAR = 52;
     public const WEEKS_PER_MONTH = 4;
     public const DAYS_PER_YEAR = 365;


### PR DESCRIPTION
Hello,

I would like to be able to use `Carbon::QUARTERS_PER_YEAR` instead of a magic `4` number (or custom constant) on my code.

This simple PR adds the constant to the `CarbonInterface`.