### PR TITLE
Enforce ::class notation

### DIFF
--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -377,7 +377,7 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
             );
         }
 
-        $class = \get_called_class();
+        $class = static::class;
         $type = \gettype($period);
 
         throw new NotAPeriodException(

--- a/src/Carbon/Traits/Serialization.php
+++ b/src/Carbon/Traits/Serialization.php
@@ -142,7 +142,7 @@ trait Serialization
     #[ReturnTypeWillChange]
     public function __wakeup()
     {
-        if (get_parent_class() && method_exists(parent::class, '__wakeup')) {
+        if (parent::class && method_exists(parent::class, '__wakeup')) {
             // @codeCoverageIgnoreStart
             try {
                 parent::__wakeup();

--- a/tests/CarbonPeriod/MacroTest.php
+++ b/tests/CarbonPeriod/MacroTest.php
@@ -24,7 +24,7 @@ class MacroTest extends AbstractTestCase
 {
     protected function tearDown(): void
     {
-        $reflection = new ReflectionClass('Carbon\CarbonPeriod');
+        $reflection = new ReflectionClass(CarbonPeriod::class);
 
         $macrosProperty = $reflection->getProperty('macros');
 


### PR DESCRIPTION
This PR enforces `::class` notation.