### PR TITLE
Allow grammar rule customization for unit declensions

### DIFF
--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -1620,18 +1620,23 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
         $unit = $short ? 's' : 'second';
         $isFuture = $this->invert === 1;
         $transId = $relativeToNow ? ($isFuture ? 'from_now' : 'ago') : ($isFuture ? 'after' : 'before');
+        $declensionMode = null;
 
         /** @var \Symfony\Component\Translation\Translator $translator */
         $translator = $this->getLocalTranslator();
 
-        $handleDeclensions = function ($unit, $count) use ($interpolations, $transId, $translator, $altNumbers, $absolute) {
+        $handleDeclensions = function ($unit, $count, $index = 0, $parts = 1) use ($interpolations, $transId, $translator, $altNumbers, $absolute, &$declensionMode) {
             if (!$absolute) {
-                // Some languages have special pluralization for past and future tense.
-                $key = $unit.'_'.$transId;
-                $result = $this->translate($key, $interpolations, $count, $translator, $altNumbers);
+                $declensionMode = $declensionMode ?? $this->translate($transId.'_mode');
 
-                if ($result !== $key) {
-                    return $result;
+                if ($this->needsDeclension($declensionMode, $index, $parts)) {
+                    // Some languages have special pluralization for past and future tense.
+                    $key = $unit.'_'.$transId;
+                    $result = $this->translate($key, $interpolations, $count, $translator, $altNumbers);
+
+                    if ($result !== $key) {
+                        return $result;
+                    }
                 }
             }
 
@@ -1696,17 +1701,17 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
             }
         }
 
-        $transChoice = function ($short, $unitData) use ($absolute, $handleDeclensions, $translator, $aUnit, $altNumbers, $interpolations) {
+        $transChoice = function ($short, $unitData, $index, $parts) use ($absolute, $handleDeclensions, $translator, $aUnit, $altNumbers, $interpolations) {
             $count = $unitData['value'];
 
             if ($short) {
-                $result = $handleDeclensions($unitData['unitShort'], $count);
+                $result = $handleDeclensions($unitData['unitShort'], $count, $index, $parts);
 
                 if ($result !== null) {
                     return $result;
                 }
             } elseif ($aUnit) {
-                $result = $handleDeclensions('a_'.$unitData['unit'], $count);
+                $result = $handleDeclensions('a_'.$unitData['unit'], $count, $index, $parts);
 
                 if ($result !== null) {
                     return $result;
@@ -1714,7 +1719,7 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
             }
 
             if (!$absolute) {
-                return $handleDeclensions($unitData['unit'], $count);
+                return $handleDeclensions($unitData['unit'], $count, $index, $parts);
             }
 
             return $this->translate($unitData['unit'], $interpolations, $count, $translator, $altNumbers);
@@ -1726,7 +1731,7 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
             if ($diffIntervalData['value'] > 0) {
                 $unit = $short ? $diffIntervalData['unitShort'] : $diffIntervalData['unit'];
                 $count = $diffIntervalData['value'];
-                $interval[] = $transChoice($short, $diffIntervalData);
+                $interval[] = [$short, $diffIntervalData];
             } elseif ($options & CarbonInterface::SEQUENTIAL_PARTS_ONLY && \count($interval) > 0) {
                 break;
             }
@@ -1742,6 +1747,12 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
 
                 break;
             }
+        }
+
+        $actualParts = \count($interval);
+
+        foreach ($interval as $index => &$item) {
+            $item = $transChoice($item[0], $item[1], $index, $actualParts);
         }
 
         if (\count($interval) === 0) {
@@ -2751,5 +2762,15 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
     public function ceil($precision = 1)
     {
         return $this->round($precision, 'ceil');
+    }
+
+    private function needsDeclension(string $mode, int $index, int $parts): bool
+    {
+        switch ($mode) {
+            case 'last':
+                return $index === $parts - 1;
+            default:
+                return true;
+        }
     }
 }

--- a/src/Carbon/Lang/mn.php
+++ b/src/Carbon/Lang/mn.php
@@ -44,6 +44,7 @@ return [
     'second' => ':count секунд',
     's' => ':countс',
 
+    'ago_mode' => 'last',
     'ago' => ':time өмнө',
     'year_ago' => ':count жилийн',
     'y_ago' => ':count жилийн',
@@ -57,6 +58,7 @@ return [
     'minute_ago' => ':count минутын',
     'second_ago' => ':count секундын',
 
+    'from_now_mode' => 'last',
     'from_now' => 'одоогоос :time',
     'year_from_now' => ':count жилийн дараа',
     'y_from_now' => ':count жилийн дараа',
@@ -68,7 +70,7 @@ return [
     'minute_from_now' => ':count минутын дараа',
     'second_from_now' => ':count секундын дараа',
 
-    // Does it required to make translation for before, after as follows? hmm, I think we've made it with ago and from now keywords already. Anyway, I've included it just in case of undesired action...
+    'after_mode' => 'last',
     'after' => ':time дараа',
     'year_after' => ':count жилийн',
     'y_after' => ':count жилийн',
@@ -80,6 +82,7 @@ return [
     'minute_after' => ':count минутын',
     'second_after' => ':count секундын',
 
+    'before_mode' => 'last',
     'before' => ':time өмнө',
     'year_before' => ':count жилийн',
     'y_before' => ':count жилийн',

--- a/tests/Carbon/LocalizationTest.php
+++ b/tests/Carbon/LocalizationTest.php
@@ -914,4 +914,28 @@ class LocalizationTest extends AbstractTestCase
             Carbon::parse('2020-02-15')->locale('de')->monthName
         );
     }
+
+    public function testDeclensionModes()
+    {
+        $this->assertSame(
+            '2 жил 3 сар 1 өдөр 1с өмнө',
+            Carbon::now()
+                ->subYears(2)
+                ->subMonths(3)
+                ->subDay()
+                ->subSecond()
+                ->locale('mn')
+                ->diffForHumans(null, null, true, 4)
+        );
+        $this->assertSame(
+            '2 жил 3 сар 1 өдөр 1 секундын өмнө',
+            Carbon::now()
+                ->subYears(2)
+                ->subMonths(3)
+                ->subDay()
+                ->subSecond()
+                ->locale('mn')
+                ->diffForHumans(null, null, false, 4)
+        );
+    }
 }

--- a/tests/CarbonImmutable/LocalizationTest.php
+++ b/tests/CarbonImmutable/LocalizationTest.php
@@ -864,4 +864,28 @@ class LocalizationTest extends AbstractTestCase
         $this->assertSame('za minutę', $minute->diffForHumans(['aUnit' => true]));
         $this->assertSame('za sekundę', $second->translate('from_now', ['time' => 'sekunda']));
     }
+
+    public function testDeclensionModes()
+    {
+        $this->assertSame(
+            '2 жил 3 сар 1 өдөр 1с өмнө',
+            Carbon::now()
+                ->subYears(2)
+                ->subMonths(3)
+                ->subDay()
+                ->subSecond()
+                ->locale('mn')
+                ->diffForHumans(null, null, true, 4)
+        );
+        $this->assertSame(
+            '2 жил 3 сар 1 өдөр 1 секундын өмнө',
+            Carbon::now()
+                ->subYears(2)
+                ->subMonths(3)
+                ->subDay()
+                ->subSecond()
+                ->locale('mn')
+                ->diffForHumans(null, null, false, 4)
+        );
+    }
 }

--- a/tests/Localization/MnMnTest.php
+++ b/tests/Localization/MnMnTest.php
@@ -210,7 +210,7 @@ class MnMnTest extends LocalizationTestCase
         // Carbon::now()->subMonths(5)->diffForHumans(null, null, true, 4)
         '5 сарын өмнө',
         // Carbon::now()->subYears(2)->subMonths(3)->subDay()->subSecond()->diffForHumans(null, null, true, 4)
-        '2 жилийн 3 сарын 1 хоногийн 1с өмнө',
+        '2 жил 3 сар 1 өдөр 1с өмнө',
         // Carbon::now()->addWeek()->addHours(10)->diffForHumans(null, true, false, 2)
         '1 долоо хоног 10 цаг',
         // Carbon::now()->addWeek()->addDays(6)->diffForHumans(null, true, false, 2)

--- a/tests/Localization/MnTest.php
+++ b/tests/Localization/MnTest.php
@@ -210,7 +210,7 @@ class MnTest extends LocalizationTestCase
         // Carbon::now()->subMonths(5)->diffForHumans(null, null, true, 4)
         '5 сарын өмнө',
         // Carbon::now()->subYears(2)->subMonths(3)->subDay()->subSecond()->diffForHumans(null, null, true, 4)
-        '2 жилийн 3 сарын 1 хоногийн 1с өмнө',
+        '2 жил 3 сар 1 өдөр 1с өмнө',
         // Carbon::now()->addWeek()->addHours(10)->diffForHumans(null, true, false, 2)
         '1 долоо хоног 10 цаг',
         // Carbon::now()->addWeek()->addDays(6)->diffForHumans(null, true, false, 2)


### PR DESCRIPTION
This will allow declension in Mongolian to apply only to the last part when the interval is a sequence of units:

When last unit can be shorten, we just get no declensions:
```php
Carbon::now()
    ->subYears(2)
    ->subMonths(3)
    ->subDay()
    ->subSecond()
    ->locale('mn')
    ->diffForHumans(null, null, true, 4)
```
```
2 жил 3 сар 1 өдөр 1с өмнө
```

When last unit is entire, we get declension only on this last unit:
```php
Carbon::now()
    ->subYears(2)
    ->subMonths(3)
    ->subDay()
    ->subSecond()
    ->locale('mn')
    ->diffForHumans(null, null, false, 4)
```
```
2 жил 3 сар 1 өдөр 1 секундын өмнө
```

👋  @lucifer-crybaby @Batmandakh your review is welcome. 🙏 