### PR TITLE
Add \DateTime and \DateTimeImmutable support to the Test::setTestNow()

### DIFF
--- a/src/Carbon/Traits/Test.php
+++ b/src/Carbon/Traits/Test.php
@@ -63,7 +63,7 @@ trait Test
      */
     public static function setTestNow($testNow = null)
     {
-        static::$testNow = $testNow instanceof self
+        static::$testNow = $testNow instanceof self || $testNow instanceof Closure
             ? $testNow
             : static::make($testNow);
     }

--- a/src/Carbon/Traits/Test.php
+++ b/src/Carbon/Traits/Test.php
@@ -28,7 +28,7 @@ trait Test
     /**
      * A test Carbon instance to be returned when now instances are created.
      *
-     * @var static
+     * @var Closure|static|null
      */
     protected static $testNow;
 
@@ -59,7 +59,7 @@ trait Test
      *
      * /!\ Use this method for unit tests only.
      *
-     * @param Closure|static|string|false|null $testNow real or mock Carbon instance
+     * @param DateTimeInterface|Closure|static|string|false|null $testNow real or mock Carbon instance
      */
     public static function setTestNow($testNow = null)
     {
@@ -67,7 +67,13 @@ trait Test
             $testNow = null;
         }
 
-        static::$testNow = \is_string($testNow) ? static::parse($testNow) : $testNow;
+        if (\is_string($testNow) ||
+            ($testNow instanceof DateTimeInterface && !$testNow instanceof CarbonInterface)
+        ) {
+            static::$testNow = static::parse($testNow);
+        } else {
+            static::$testNow = $testNow;
+        }
     }
 
     /**
@@ -87,7 +93,7 @@ trait Test
      *
      * /!\ Use this method for unit tests only.
      *
-     * @param Closure|static|string|false|null $testNow real or mock Carbon instance
+     * @param DateTimeInterface|Closure|static|string|false|null $testNow real or mock Carbon instance
      */
     public static function setTestNowAndTimezone($testNow = null, $tz = null)
     {
@@ -121,8 +127,8 @@ trait Test
      *
      * /!\ Use this method for unit tests only.
      *
-     * @param Closure|static|string|false|null $testNow  real or mock Carbon instance
-     * @param Closure|null                     $callback
+     * @param DateTimeInterface|Closure|static|string|false|null $testNow  real or mock Carbon instance
+     * @param Closure|null                                       $callback
      *
      * @return mixed
      */

--- a/src/Carbon/Traits/Test.php
+++ b/src/Carbon/Traits/Test.php
@@ -63,17 +63,9 @@ trait Test
      */
     public static function setTestNow($testNow = null)
     {
-        if ($testNow === false) {
-            $testNow = null;
-        }
-
-        if (\is_string($testNow) ||
-            ($testNow instanceof DateTimeInterface && !$testNow instanceof CarbonInterface)
-        ) {
-            static::$testNow = static::parse($testNow);
-        } else {
-            static::$testNow = $testNow;
-        }
+        static::$testNow = $testNow instanceof self
+            ? $testNow
+            : static::make($testNow);
     }
 
     /**

--- a/tests/Carbon/TestingAidsTest.php
+++ b/tests/Carbon/TestingAidsTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Tests\Carbon;
 
 use Carbon\Carbon;
+use DateTimeZone;
 use InvalidArgumentException;
 use stdClass;
 use Tests\AbstractTestCase;
@@ -283,6 +284,14 @@ class TestingAidsTest extends AbstractTestCase
 
         // Set microseconds to zero to match behavior of DateTime::createFromFormat()
         // See https://bugs.php.net/bug.php?id=74332
+        $this->assertSame('2018-05-06 05:10:15.000000', Carbon::createFromFormat('Y-m-d', '2018-05-06')->format('Y-m-d H:i:s.u'));
+        $this->assertSame('2013-09-01 10:20:30.654321', Carbon::createFromFormat('H:i:s.u', '10:20:30.654321')->format('Y-m-d H:i:s.u'));
+    }
+
+    public function testCreateFromDateTimeInterface()
+    {
+        Carbon::setTestNowAndTimezone(date_create('2013-09-01 05:10:15.123456', new DateTimeZone('America/Vancouver')));
+
         $this->assertSame('2018-05-06 05:10:15.000000', Carbon::createFromFormat('Y-m-d', '2018-05-06')->format('Y-m-d H:i:s.u'));
         $this->assertSame('2013-09-01 10:20:30.654321', Carbon::createFromFormat('H:i:s.u', '10:20:30.654321')->format('Y-m-d H:i:s.u'));
     }

--- a/tests/CarbonImmutable/TestingAidsTest.php
+++ b/tests/CarbonImmutable/TestingAidsTest.php
@@ -16,6 +16,7 @@ namespace Tests\CarbonImmutable;
 use Carbon\CarbonImmutable as Carbon;
 use Carbon\CarbonInterface;
 use Closure;
+use DateTimeZone;
 use stdClass;
 use Tests\AbstractTestCase;
 
@@ -257,6 +258,14 @@ class TestingAidsTest extends AbstractTestCase
 
         // Set microseconds to zero to match behavior of DateTime::createFromFormat()
         // See https://bugs.php.net/bug.php?id=74332
+        $this->assertSame('2018-05-06 05:10:15.000000', Carbon::createFromFormat('Y-m-d', '2018-05-06')->format('Y-m-d H:i:s.u'));
+        $this->assertSame('2013-09-01 10:20:30.654321', Carbon::createFromFormat('H:i:s.u', '10:20:30.654321')->format('Y-m-d H:i:s.u'));
+    }
+
+    public function testCreateFromDateTimeInterface()
+    {
+        Carbon::setTestNowAndTimezone(date_create_immutable('2013-09-01 05:10:15.123456', new DateTimeZone('America/Vancouver')));
+
         $this->assertSame('2018-05-06 05:10:15.000000', Carbon::createFromFormat('Y-m-d', '2018-05-06')->format('Y-m-d H:i:s.u'));
         $this->assertSame('2013-09-01 10:20:30.654321', Carbon::createFromFormat('H:i:s.u', '10:20:30.654321')->format('Y-m-d H:i:s.u'));
     }


### PR DESCRIPTION
This PR provides the ability to use \DateTimeInterface as the argument type for the Test::setTestNow() method.

Currently this method can receive instances of CarbonInterface, but cannot receive instances of \DateTime and \DateTimeImmutable php-classes exactly.

Support for \DateTime and \DateTimeImmutable types will provide more flexibility for client code.