### PR TITLE
Cache composer dependencies with a Github action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,6 +102,17 @@ jobs:
         if: matrix.laravel
         uses: niden/actions-memcached@v7
 
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: "php-${{ matrix.php }}-{{ matrix.setup }}-ubuntu-${{ hashFiles('**/composer.json') }}"
+          restore-keys: "php-${{ matrix.php }}-{{ matrix.setup }}-ubuntu-${{ hashFiles('**/composer.json') }}"
+
       - name: Install dependencies
         run: |
           composer remove --no-update phpmd/phpmd friendsofphp/php-cs-fixer --no-interaction;
@@ -196,6 +207,17 @@ jobs:
           extensions: json
           tools: composer:v2
           coverage: none
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: "php-${{ matrix.php }}-{{ matrix.setup }}-windows-${{ hashFiles('**/composer.json') }}"
+          restore-keys: "php-${{ matrix.php }}-{{ matrix.setup }}-windows-${{ hashFiles('**/composer.json') }}"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
This PR caches the composer dependencies with a Github action.

---

The key takes in consideration the PHP version, the desired composer stability setup, the OS and the `composer.json` file.
There is always the possibility to manually run the tests without cache