### PR TITLE
No need to use version_compare when the constant is sufficient.

### DIFF
--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -977,7 +977,7 @@ class IsTest extends AbstractTestCase
     {
         $output = Carbon::now()->format($letter);
 
-        if ($output === '1000' && $letter === 'v' && version_compare(PHP_VERSION, '7.2.12', '<')) {
+        if ($output === '1000' && $letter === 'v' && PHP_VERSION_ID < 70212) {
             $output = '000';
         }
 

--- a/tests/CarbonImmutable/IsTest.php
+++ b/tests/CarbonImmutable/IsTest.php
@@ -964,7 +964,7 @@ class IsTest extends AbstractTestCase
     {
         $output = Carbon::now()->format($letter);
 
-        if ($output === '1000' && $letter === 'v' && version_compare(PHP_VERSION, '7.2.12', '<')) {
+        if ($output === '1000' && $letter === 'v' && PHP_VERSION_ID < 70212) {
             $output = '000';
         }
 


### PR DESCRIPTION
No need to use `version_compare` when the constant is sufficient.