### PR TITLE
Fix Php 8.2 utf8_encode deprecation

### DIFF
--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -1853,7 +1853,13 @@ trait Date
             ? strftime($format, $time)
             : @strftime($format, $time);
 
-        return static::$utf8 ? utf8_encode($formatted) : $formatted;
+        return static::$utf8
+            ? (
+                \function_exists('mb_convert_encoding')
+                ? mb_convert_encoding($formatted, 'UTF-8', mb_list_encodings())
+                : utf8_encode($formatted)
+            )
+            : $formatted;
     }
 
     /**

--- a/tests/Carbon/StringsTest.php
+++ b/tests/Carbon/StringsTest.php
@@ -183,7 +183,7 @@ class StringsTest extends AbstractTestCase
             Carbon::setUtf8(false);
 
             $this->assertSame('décembre', $nonUtf8Date);
-            $this->assertSame(utf8_encode('décembre'), $utf8Date);
+            $this->assertSame(mb_convert_encoding('décembre', 'UTF-8', mb_list_encodings()), $utf8Date);
         });
     }
 

--- a/tests/CarbonImmutable/StringsTest.php
+++ b/tests/CarbonImmutable/StringsTest.php
@@ -116,7 +116,7 @@ class StringsTest extends AbstractTestCase
             Carbon::setUtf8(false);
 
             $this->assertSame('décembre', $nonUtf8Date);
-            $this->assertSame(utf8_encode('décembre'), $utf8Date);
+            $this->assertSame(mb_convert_encoding('décembre', 'UTF-8', mb_list_encodings()), $utf8Date);
         });
     }
 


### PR DESCRIPTION
Closes #2630
>`utf8_encode()` deprecated
https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated