### PR TITLE
Fixes updating locale when app instance changes in Octane

### DIFF
--- a/src/Carbon/Laravel/ServiceProvider.php
+++ b/src/Carbon/Laravel/ServiceProvider.php
@@ -44,7 +44,9 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
     public function updateLocale()
     {
-        $app = $this->app && method_exists($this->app, 'getLocale') ? $this->app : app('translator');
+        $app = function_exists('app') ? app() : $this->app;
+        $app = $app && method_exists($app, 'getLocale') ? $app : app('translator');
+
         $locale = $app->getLocale();
         Carbon::setLocale($locale);
         CarbonImmutable::setLocale($locale);

--- a/src/Carbon/Laravel/ServiceProvider.php
+++ b/src/Carbon/Laravel/ServiceProvider.php
@@ -103,9 +103,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             return ($this->appGetter)();
         }
 
-        return \function_exists('config') && \is_array(config('octane'))
-            ? ($this->getGlobalApp() ?? $this->app)
-            : ($this->app ?? $this->getGlobalApp());
+        return $this->app ?? $this->getGlobalApp();
     }
 
     protected function getGlobalApp()


### PR DESCRIPTION
When an Octane server is starts, we boot the framework once. After, every time Octane serves a request, it uses a "clone" of that application instance used to boot framework to serve that request. 

This is done, so any change made to that "cloned" application instance does not impact the original application instance and specially does not get propagated to the next request - similar to a regular PHP FPM implementation where requests are served always using a fresh application instance.

Now, currently, Carbon's service provider is capturing a reference to the original application instance, the one we use to "clone" an application for every new request. Meaning the following:

Before this pull request:

```php
// Users do:
app()->setLocale("pt"); // Change the state of the request application instance...

// Carbon listens the event, and changes the state of the original application instance, used to and performs:
$locale = $this->app->getLocale(); // Returns the original locale: "en";
Carbon::setLocale($locale); // Locale won't change on the application instance used on the request...
```

After, with this pull request:
```php
// Users do:
app()->setLocale("pt"); // Change the state of the request application instance...

// Carbon listens the event, and changes the state of the original application instance, used to and performs:
$locale = app()->getLocale(); // Returns the new locale... 
Carbon::setLocale($locale); // Carbon locale will change with the new locale... 
```

Note, with this change, another issue happens: The global locale of `Carbon`, `CarbonImmutable`, `CarbonPeriod`, `CarbonInterval` gets changed to the new locale set on the request. For this, we are going to update Octane, so this state gets "resetted" when Octane finishes to serve the request.

So, once https://github.com/laravel/octane/pull/552 is merge and tagged, we can put this pull request "Ready To Review".

Fixes https://github.com/laravel/octane/issues/551.