### PR TITLE
Add options for microseconds on getDateIntervalSpec()

### DIFF
--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -2150,7 +2150,7 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
      *
      * @return string
      */
-    public static function getDateIntervalSpec(DateInterval $interval)
+    public static function getDateIntervalSpec(DateInterval $interval, bool $microseconds = false)
     {
         $date = array_filter([
             static::PERIOD_YEARS => abs($interval->y),
@@ -2158,10 +2158,15 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
             static::PERIOD_DAYS => abs($interval->d),
         ]);
 
+        $seconds = abs($interval->s);
+        if ($microseconds && $interval->f > 0) {
+            $seconds = sprintf('%d.%06d', $seconds, abs($interval->f) * 1000000);
+        }
+
         $time = array_filter([
             static::PERIOD_HOURS => abs($interval->h),
             static::PERIOD_MINUTES => abs($interval->i),
-            static::PERIOD_SECONDS => abs($interval->s),
+            static::PERIOD_SECONDS => $seconds,
         ]);
 
         $specString = static::PERIOD_PREFIX;
@@ -2185,9 +2190,9 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
      *
      * @return string
      */
-    public function spec()
+    public function spec(bool $microseconds = false)
     {
-        return static::getDateIntervalSpec($this);
+        return static::getDateIntervalSpec($this, $microseconds);
     }
 
     /**

--- a/tests/CarbonInterval/SpecTest.php
+++ b/tests/CarbonInterval/SpecTest.php
@@ -73,6 +73,12 @@ class SpecTest extends AbstractTestCase
         $this->assertSame('PT1S', $ci->spec());
     }
 
+    public function testMicrosecondsInterval()
+    {
+        $ci = new CarbonInterval(0, 0, 0, 0, 0, 0, 0, 12300);
+        $this->assertSame('PT0.012300S', $ci->spec(true));
+    }
+
     public function testMixedTimeInterval()
     {
         $ci = new CarbonInterval(0, 0, 0, 0, 1, 2, 3);


### PR DESCRIPTION
https://www.postgresql.org/docs/14/datatype-datetime.html#DATATYPE-INTERVAL-INPUT
Postgres date interval field values can have fractional parts.

https://tc39.es/proposal-temporal/docs/duration.html
Also see the `ECMAScript` Temporal Proposal : `duration.toString` has a `fractionalSecondDigits` option

