### PR TITLE
Fix PHP 8.2 issue with false for lastErrors

### DIFF
--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -927,8 +927,8 @@ trait Creator
      */
     private static function setLastErrors($lastErrors)
     {
-        if (is_array($lastErrors) || $lastErrors === false) {
-            static::$lastErrors = is_array($lastErrors) ? $lastErrors : [];
+        if (\is_array($lastErrors) || $lastErrors === false) {
+            static::$lastErrors = \is_array($lastErrors) ? $lastErrors : [];
         }
     }
 

--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -928,7 +928,12 @@ trait Creator
     private static function setLastErrors($lastErrors)
     {
         if (\is_array($lastErrors) || $lastErrors === false) {
-            static::$lastErrors = \is_array($lastErrors) ? $lastErrors : [];
+            static::$lastErrors = \is_array($lastErrors) ? $lastErrors : [
+                'warning_count' => 0,
+                'warnings' => [],
+                'error_count' => 0,
+                'errors' => [],
+            ];
         }
     }
 

--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -921,13 +921,15 @@ trait Creator
     /**
      * Set last errors.
      *
-     * @param array $lastErrors
+     * @param array|bool $lastErrors
      *
      * @return void
      */
-    private static function setLastErrors(array $lastErrors)
+    private static function setLastErrors($lastErrors)
     {
-        static::$lastErrors = $lastErrors;
+        if (is_array($lastErrors) || $lastErrors === false) {
+            static::$lastErrors = is_array($lastErrors) ? $lastErrors : [];
+        }
     }
 
     /**

--- a/tests/Carbon/LastErrorTest.php
+++ b/tests/Carbon/LastErrorTest.php
@@ -33,12 +33,12 @@ class LastErrorTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->noErrors = PHP_VERSION < 8.2 ? [
+        $this->noErrors = [
             'warning_count' => 0,
             'warnings' => [],
             'error_count' => 0,
             'errors' => [],
-        ] : false;
+        ];
 
         $this->lastErrors = [
             'warning_count' => 1,

--- a/tests/Carbon/LastErrorTest.php
+++ b/tests/Carbon/LastErrorTest.php
@@ -57,9 +57,7 @@ class LastErrorTest extends AbstractTestCase
         $this->assertSame($carbon->getLastErrors(), $datetime->getLastErrors());
 
         $carbon = new Carbon('2017-02-15');
-        $datetime = new DateTime('2017-02-15');
 
         $this->assertSame($this->noErrors, $carbon->getLastErrors());
-        $this->assertSame($carbon->getLastErrors(), $datetime->getLastErrors());
     }
 }

--- a/tests/Carbon/LastErrorTest.php
+++ b/tests/Carbon/LastErrorTest.php
@@ -33,12 +33,12 @@ class LastErrorTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->noErrors = [
+        $this->noErrors = PHP_VERSION < 8.2 ? [
             'warning_count' => 0,
             'warnings' => [],
             'error_count' => 0,
             'errors' => [],
-        ];
+        ] : false;
 
         $this->lastErrors = [
             'warning_count' => 1,

--- a/tests/CarbonImmutable/LastErrorTest.php
+++ b/tests/CarbonImmutable/LastErrorTest.php
@@ -33,12 +33,12 @@ class LastErrorTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->noErrors = PHP_VERSION < 8.2 ? [
+        $this->noErrors = [
             'warning_count' => 0,
             'warnings' => [],
             'error_count' => 0,
             'errors' => [],
-        ] : false;
+        ];
 
         $this->lastErrors = [
             'warning_count' => 1,
@@ -57,9 +57,7 @@ class LastErrorTest extends AbstractTestCase
         $this->assertSame($carbon->getLastErrors(), $datetime->getLastErrors());
 
         $carbon = new Carbon('2017-02-15');
-        $datetime = new DateTime('2017-02-15');
 
         $this->assertSame($this->noErrors, $carbon->getLastErrors());
-        $this->assertSame($carbon->getLastErrors(), $datetime->getLastErrors());
     }
 }

--- a/tests/CarbonImmutable/LastErrorTest.php
+++ b/tests/CarbonImmutable/LastErrorTest.php
@@ -33,12 +33,12 @@ class LastErrorTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->noErrors = [
+        $this->noErrors = PHP_VERSION < 8.2 ? [
             'warning_count' => 0,
             'warnings' => [],
             'error_count' => 0,
             'errors' => [],
-        ];
+        ] : false;
 
         $this->lastErrors = [
             'warning_count' => 1,


### PR DESCRIPTION
`DateTime::lastErrors` can return either an array or false. Right now, while testing PHP 8.2 on Laravel we discovered there's a type mismatch here on the `setLastErrors` that doesn't takes `false` into account. I've removed the type-hint because union types aren't supported yet for all PHP versions this library supports. Instead, type checks are now done inside the method. If we get `false`, we clear the `$lastErrors` property.

See failing tests in Laravel right now:

```
2022-09-01T13:53:42.6921975Z 676) Illuminate\Tests\Integration\Database\EloquentPaginateTest::testPaginationWithDistinct
2022-09-01T13:53:42.6922324Z TypeError: Carbon\CarbonImmutable::setLastErrors(): Argument #1 ($lastErrors) must be of type array, bool given, called in /home/runner/work/framework/framework/vendor/nesbot/carbon/src/Carbon/Traits/Creator.php on line 98
2022-09-01T13:53:42.6922330Z 
2022-09-01T13:53:42.6922515Z /home/runner/work/framework/framework/vendor/nesbot/carbon/src/Carbon/Traits/Creator.php:928
2022-09-01T13:53:42.6922693Z /home/runner/work/framework/framework/vendor/nesbot/carbon/src/Carbon/Traits/Creator.php:98
2022-09-01T13:53:42.6922868Z /home/runner/work/framework/framework/vendor/nesbot/carbon/src/Carbon/Traits/Creator.php:252
2022-09-01T13:53:42.6923038Z /home/runner/work/framework/framework/src/Illuminate/Support/DateFactory.php:217
2022-09-01T13:53:42.6923209Z /home/runner/work/framework/framework/src/Illuminate/Support/Facades/Facade.php:338
2022-09-01T13:53:42.6923399Z /home/runner/work/framework/framework/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php:96
2022-09-01T13:53:42.6923590Z /home/runner/work/framework/framework/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php:46
2022-09-01T13:53:42.6923765Z /home/runner/work/framework/framework/src/Illuminate/Database/Eloquent/Model.php:1172
2022-09-01T13:53:42.6923931Z /home/runner/work/framework/framework/src/Illuminate/Database/Eloquent/Model.php:1022
2022-09-01T13:53:42.6924148Z /home/runner/work/framework/framework/src/Illuminate/Database/Eloquent/Builder.php:975
2022-09-01T13:53:42.6924315Z /home/runner/work/framework/framework/src/Illuminate/Support/helpers.php:302
2022-09-01T13:53:42.6924487Z /home/runner/work/framework/framework/src/Illuminate/Database/Eloquent/Builder.php:974
2022-09-01T13:53:42.6924673Z /home/runner/work/framework/framework/src/Illuminate/Support/Traits/ForwardsCalls.php:23
2022-09-01T13:53:42.6924839Z /home/runner/work/framework/framework/src/Illuminate/Database/Eloquent/Model.php:2191
2022-09-01T13:53:42.6924994Z /home/runner/work/framework/framework/src/Illuminate/Database/Eloquent/Model.php:2203
2022-09-01T13:53:42.6925188Z /home/runner/work/framework/framework/tests/Integration/Database/EloquentPaginateTest.php:40
2022-09-01T13:53:42.6925195Z 
```