### PR TITLE
Update SL language ("2 years ago" translation)

### DIFF
--- a/src/Carbon/Lang/sl.php
+++ b/src/Carbon/Lang/sl.php
@@ -49,8 +49,8 @@ return [
     'a_second' => '{1}nekaj sekund|:count sekunda|:count sekundi|:count sekunde|:count sekund',
     's' => ':count s',
 
-    'year_ago' => ':count letom|:count leti|:count leti|:count leti',
-    'y_ago' => ':count letom|:count leti|:count leti|:count leti',
+    'year_ago' => ':count letom|:count letoma|:count leti|:count leti',
+    'y_ago' => ':count letom|:count letoma|:count leti|:count leti',
     'month_ago' => ':count mesecem|:count meseci|:count meseci|:count meseci',
     'week_ago' => ':count tednom|:count tednoma|:count tedni|:count tedni',
     'day_ago' => ':count dnem|:count dnevoma|:count dnevi|:count dnevi',

--- a/tests/Localization/SlSiTest.php
+++ b/tests/Localization/SlSiTest.php
@@ -331,11 +331,11 @@ class SlSiTest extends LocalizationTestCase
 
         // Carbon::now()->subYears(2)->diffForHumans()
         // '2 years ago'
-        'pred 2 leti',
+        'pred 2 letoma',
 
         // Carbon::now()->subYears(2)->diffForHumans(null, false, true)
         // '2yrs ago'
-        'pred 2 leti',
+        'pred 2 letoma',
 
         // Carbon::now()->addSecond()->diffForHumans()
         // '1 second from now'
@@ -399,7 +399,7 @@ class SlSiTest extends LocalizationTestCase
 
         // Carbon::now()->subYears(2)->subMonths(3)->subDay()->subSecond()->diffForHumans(null, null, true, 4)
         // '2yrs 3mos 1d 1s ago'
-        'pred 2 leti 3 mes. 1 dnem 1 s',
+        'pred 2 letoma 3 mes. 1 dnem 1 s',
 
         // Carbon::now()->addWeek()->addHours(10)->diffForHumans(null, true, false, 2)
         // '1 week 10 hours'

--- a/tests/Localization/SlTest.php
+++ b/tests/Localization/SlTest.php
@@ -331,11 +331,11 @@ class SlTest extends LocalizationTestCase
 
         // Carbon::now()->subYears(2)->diffForHumans()
         // '2 years ago'
-        'pred 2 leti',
+        'pred 2 letoma',
 
         // Carbon::now()->subYears(2)->diffForHumans(null, false, true)
         // '2yrs ago'
-        'pred 2 leti',
+        'pred 2 letoma',
 
         // Carbon::now()->addSecond()->diffForHumans()
         // '1 second from now'
@@ -399,7 +399,7 @@ class SlTest extends LocalizationTestCase
 
         // Carbon::now()->subYears(2)->subMonths(3)->subDay()->subSecond()->diffForHumans(null, null, true, 4)
         // '2yrs 3mos 1d 1s ago'
-        'pred 2 leti 3 mes. 1 dnem 1 s',
+        'pred 2 letoma 3 mes. 1 dnem 1 s',
 
         // Carbon::now()->addWeek()->addHours(10)->diffForHumans(null, true, false, 2)
         // '1 week 10 hours'


### PR DESCRIPTION
Hello! I'm requesting to push this simple fix for Slovenian language: "pred 2 letoma" (2 years ago) is correct while "pred 2 leti" is wrong.

It is a common mistake and also explained here (in our language of course):
https://svetovalnica.zrc-sazu.si/topic/5955/kako-je-prav-pred-dvema-letoma-ali-pred-dvemi-leti