### PR TITLE
FIX vulnerability CVE-2021-43608

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "symfony/translation": "^3.4 || ^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
-        "doctrine/dbal": "^2.0 || ^3.0",
+        "doctrine/dbal": "^2.0 || ^3.1.4",
         "doctrine/orm": "^2.7",
         "friendsofphp/php-cs-fixer": "^3.0",
         "kylekatarnls/multi-tester": "^2.0",


### PR DESCRIPTION
Doctrine DBAL 3.x before 3.1.4 allows SQL Injection: https://www.cve.org/CVERecord?id=CVE-2021-43608