### PR TITLE
Translate escaped word in `createFromLocaleFormat()`

### DIFF
--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -862,6 +862,19 @@ trait Creator
      */
     public static function createFromLocaleFormat($format, $locale, $time, $tz = null)
     {
+        $format = preg_replace_callback(
+            '/(?:\\\\[a-zA-Z]|[bfkqCEJKQRV]){2,}/',
+            static function (array $match) use ($locale): string {
+                $word = str_replace('\\', '', $match[0]);
+                $translatedWord = static::translateTimeString($word, $locale, 'en');
+
+                return $word === $translatedWord
+                    ? $match[0]
+                    : preg_replace('/[a-zA-Z]/', '\\\\$0', $translatedWord);
+            },
+            $format
+        );
+
         return static::rawCreateFromFormat($format, static::translateTimeString($time, $locale, 'en'), $tz);
     }
 

--- a/tests/Carbon/CreateTest.php
+++ b/tests/Carbon/CreateTest.php
@@ -350,6 +350,36 @@ class CreateTest extends AbstractTestCase
         $date = Carbon::createFromLocaleFormat('Y M d H,i,s', 'zh_TW', '2019 四月 4 12,04,21', 'Asia/Shanghai')->locale('zh');
 
         $this->assertSame('2019年4月4日星期四 中午 12点04分 Asia/Shanghai', $date->isoFormat('LLLL zz'));
+
+        $this->assertSame(
+            '2022-12-05 America/Mexico_City',
+            Carbon::createFromLocaleFormat('d * F * Y', 'es', '05 de diciembre de 2022', 'America/Mexico_City')
+                ->format('Y-m-d e')
+        );
+
+        $this->assertSame(
+            '2022-12-05 America/Mexico_City',
+            Carbon::createFromLocaleFormat('d \of F \of Y', 'es', '05 de diciembre de 2022', 'America/Mexico_City')
+                ->format('Y-m-d e')
+        );
+
+        $this->assertSame(
+            '2022-12-05 America/Mexico_City',
+            Carbon::createFromLocaleFormat('d \o\f F \o\f Y', 'es', '05 de diciembre de 2022', 'America/Mexico_City')
+                ->format('Y-m-d e')
+        );
+
+        $this->assertSame(
+            '2022-12-05 America/Mexico_City',
+            Carbon::createFromLocaleFormat('d \d\e F \d\e Y', 'es', '05 de diciembre de 2022', 'America/Mexico_City')
+                ->format('Y-m-d e')
+        );
+
+        $this->assertSame(
+            '2022-12-05 America/Mexico_City',
+            Carbon::createFromLocaleFormat('d \n\o\t F \n\o\t Y', 'es', '05 not diciembre not 2022', 'America/Mexico_City')
+                ->format('Y-m-d e')
+        );
     }
 
     public function testCreateFromIsoFormat()

--- a/tests/CarbonImmutable/CreateTest.php
+++ b/tests/CarbonImmutable/CreateTest.php
@@ -264,6 +264,36 @@ class CreateTest extends AbstractTestCase
         $date = Carbon::createFromLocaleFormat('Y M d H,i,s', 'zh_TW', '2019 四月 4 12,04,21', 'Asia/Shanghai')->locale('zh');
 
         $this->assertSame('2019年4月4日星期四 中午 12点04分 Asia/Shanghai', $date->isoFormat('LLLL zz'));
+
+        $this->assertSame(
+            '2022-12-05 America/Mexico_City',
+            Carbon::createFromLocaleFormat('d * F * Y', 'es', '05 de diciembre de 2022', 'America/Mexico_City')
+                ->format('Y-m-d e')
+        );
+
+        $this->assertSame(
+            '2022-12-05 America/Mexico_City',
+            Carbon::createFromLocaleFormat('d \of F \of Y', 'es', '05 de diciembre de 2022', 'America/Mexico_City')
+                ->format('Y-m-d e')
+        );
+
+        $this->assertSame(
+            '2022-12-05 America/Mexico_City',
+            Carbon::createFromLocaleFormat('d \o\f F \o\f Y', 'es', '05 de diciembre de 2022', 'America/Mexico_City')
+                ->format('Y-m-d e')
+        );
+
+        $this->assertSame(
+            '2022-12-05 America/Mexico_City',
+            Carbon::createFromLocaleFormat('d \d\e F \d\e Y', 'es', '05 de diciembre de 2022', 'America/Mexico_City')
+                ->format('Y-m-d e')
+        );
+
+        $this->assertSame(
+            '2022-12-05 America/Mexico_City',
+            Carbon::createFromLocaleFormat('d \n\o\t F \n\o\t Y', 'es', '05 not diciembre not 2022', 'America/Mexico_City')
+                ->format('Y-m-d e')
+        );
     }
 
     public function testCreateFromIsoFormat()


### PR DESCRIPTION
Fix #2716