### PR TITLE
Add allowed type to create method

### DIFF
--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -354,13 +354,13 @@ trait Creator
      * If $hour is not null then the default values for $minute and $second
      * will be 0.
      *
-     * @param int|null                 $year
-     * @param int|null                 $month
-     * @param int|null                 $day
-     * @param int|null                 $hour
-     * @param int|null                 $minute
-     * @param int|null                 $second
-     * @param DateTimeZone|string|null $tz
+     * @param \DateTimeInterface|int|null $year
+     * @param int|null                    $month
+     * @param int|null                    $day
+     * @param int|null                    $hour
+     * @param int|null                    $minute
+     * @param int|null                    $second
+     * @param DateTimeZone|string|null    $tz
      *
      * @throws InvalidFormatException
      *

--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -354,13 +354,13 @@ trait Creator
      * If $hour is not null then the default values for $minute and $second
      * will be 0.
      *
-     * @param \DateTimeInterface|int|null $year
-     * @param int|null                    $month
-     * @param int|null                    $day
-     * @param int|null                    $hour
-     * @param int|null                    $minute
-     * @param int|null                    $second
-     * @param DateTimeZone|string|null    $tz
+     * @param DateTimeInterface|int|null $year
+     * @param int|null                   $month
+     * @param int|null                   $day
+     * @param int|null                   $hour
+     * @param int|null                   $minute
+     * @param int|null                   $second
+     * @param DateTimeZone|string|null   $tz
      *
      * @throws InvalidFormatException
      *


### PR DESCRIPTION
I noticed in Laravel that I got a type error when we tried to pass a `DateTimeInterface` in this method for the first argument. The code underneath seems to allow it so I thought it would be good to add it to the param's list of allowed types. I hope I got the styling right.

See https://github.com/laravel/framework/blob/a67043763ef330015acc1ffe45ba6302a648389c/src/Illuminate/Console/Scheduling/ScheduleListCommand.php#L178-L182