### PR TITLE
Provide basic completion assistance in PhpStorm

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,0 +1,10 @@
+<?php
+namespace PHPSTORM_META {
+    registerArgumentsSet("date_units", "millenania", "millennium", "century", "centuries", "decade", "decades", "year", "years", "y", "yr", "yrs", "quarter", "quarters", "month", "months", "mo", "mos", "week", "weeks", "w", "day", "days", "d", "hour", "hours", "h", "minute", "minutes", "m", "second", "seconds", "s", "millisecond", "milliseconds", "milli", "ms", "microsecond", "microseconds", "micro", "µs");
+    expectedArguments(\Carbon\Traits\Units::add(), 0, argumentsSet("date_units"));
+    expectedArguments(\Carbon\Traits\Units::add(), 1, argumentsSet("date_units"));
+    expectedArguments(\Carbon\CarbonInterface::add(), 0, argumentsSet("date_units"));
+    expectedArguments(\Carbon\CarbonInterface::add(), 1, argumentsSet("date_units"));
+
+    expectedArguments(\Carbon\CarbonInterface::getTimeFormatByPrecision(), 0, "minute", "second", "m", "millisecond", "µ", "microsecond", "minutes", "seconds", "ms", "milliseconds", "µs", "microseconds");
+}


### PR DESCRIPTION
Hey! This file will be statically analyzed by PhpStorm and results will be used to enrich auto-completion experience in the IDE while working with the library (see https://www.jetbrains.com/help/phpstorm/ide-advanced-metadata.html#expected-arguments for extensive documentation on the syntax).

<img width="620" alt="Screenshot 2022-12-19 at 10 56 15" src="https://user-images.githubusercontent.com/5152749/208401172-df8d87a5-1dbd-4daf-93f5-9daeaaa64174.png">
<img width="864" alt="Screenshot 2022-12-19 at 11 02 51" src="https://user-images.githubusercontent.com/5152749/208401177-fbf74b7b-6c6c-4544-a450-8d2f0cc9b4e8.png">


Similar files are existing in other packages in different form, for instance, in PHPUnit: https://github.com/sebastianbergmann/phpunit/blob/main/.phpstorm.meta.php
