### PR TITLE
Remove exit call in unit tests

### DIFF
--- a/tests/CarbonInterval/RoundingTest.php
+++ b/tests/CarbonInterval/RoundingTest.php
@@ -67,10 +67,6 @@ class RoundingTest extends AbstractTestCase
 
     public function testTotalAfterRound()
     {
-        var_dump(CarbonInterval::make('43h3m6s')->hours);
-        var_dump(CarbonInterval::make('43h3m6s')->cascade()->hours);
-        var_dump(CarbonInterval::make('43h3m6s')->roundMinutes()->hours);
-        exit;
         $this->assertSame(43, CarbonInterval::make('43h3m6s')->roundMinutes()->hours);
         $this->assertSame(43.04, CarbonInterval::make('43h3m6s')->roundMinutes()->totalHours);
     }


### PR DESCRIPTION
The exit call breaks the test suite by exiting PHPUnit. These calls are presumably just unintentional leftovers of development.