### PR TITLE
Add CarbonPeriodImmutable class

### DIFF
--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -1883,7 +1883,7 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
     /**
      * Invert the interval.
      *
-     * @param bool|int $inverted if a parameter is passed, the passed value casted as 1 or 0 is used
+     * @param bool|int $inverted if a parameter is passed, the passed value cast as 1 or 0 is used
      *                           as the new value of the ->invert property.
      *
      * @return $this

--- a/src/Carbon/CarbonPeriodImmutable.php
+++ b/src/Carbon/CarbonPeriodImmutable.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Carbon;
+
+class CarbonPeriodImmutable extends CarbonPeriod
+{
+    /**
+     * Date class of iteration items.
+     *
+     * @var string
+     */
+    protected $dateClass = CarbonImmutable::class;
+
+    /**
+     * Prepare the instance to be set (self if mutable to be mutated,
+     * copy if immutable to generate a new instance).
+     *
+     * @return static
+     */
+    protected function copyIfImmutable()
+    {
+        return $this->constructed ? clone $this : $this;
+    }
+}

--- a/src/Carbon/Traits/Converter.php
+++ b/src/Carbon/Traits/Converter.php
@@ -16,6 +16,7 @@ use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 use Carbon\CarbonInterval;
 use Carbon\CarbonPeriod;
+use Carbon\CarbonPeriodImmutable;
 use Carbon\Exceptions\UnitException;
 use Closure;
 use DateTime;
@@ -605,16 +606,18 @@ trait Converter
             $interval = CarbonInterval::make("$interval ".static::pluralUnit($unit));
         }
 
-        $period = (new CarbonPeriod())->setDateClass(static::class)->setStartDate($this);
+        $period = ($this->isMutable() ? new CarbonPeriod() : new CarbonPeriodImmutable())
+            ->setDateClass(static::class)
+            ->setStartDate($this);
 
         if ($interval) {
-            $period->setDateInterval($interval);
+            $period = $period->setDateInterval($interval);
         }
 
         if (\is_int($end) || (\is_string($end) && ctype_digit($end))) {
-            $period->setRecurrences($end);
+            $period = $period->setRecurrences($end);
         } elseif ($end) {
-            $period->setEndDate($end);
+            $period = $period->setEndDate($end);
         }
 
         return $period;

--- a/src/Carbon/Traits/Options.php
+++ b/src/Carbon/Traits/Options.php
@@ -441,7 +441,7 @@ trait Options
             return $var;
         });
 
-        foreach (['dumpProperties', 'constructedObjectId'] as $property) {
+        foreach (['dumpProperties', 'constructedObjectId', 'constructed'] as $property) {
             if (isset($infos[$property])) {
                 unset($infos[$property]);
             }

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -17,6 +17,7 @@ use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 use Carbon\CarbonInterval;
+use Carbon\CarbonPeriod;
 use Carbon\Translator;
 use Closure;
 use DateTime;
@@ -53,6 +54,11 @@ abstract class AbstractTestCase extends TestCase
      * @var string
      */
     private $saveTz;
+
+    /**
+     * @var class-string<CarbonPeriod>
+     */
+    protected $periodClass = CarbonPeriod::class;
 
     protected function getTimestamp()
     {

--- a/tests/CarbonPeriod/AliasTest.php
+++ b/tests/CarbonPeriod/AliasTest.php
@@ -24,18 +24,19 @@ class AliasTest extends AbstractTestCase
 {
     public function testSetStartDate()
     {
-        $period = CarbonPeriod::start($date = '2017-09-13 12:30:45', false);
+        $periodClass = $this->periodClass;
+        $period = $periodClass::start($date = '2017-09-13 12:30:45', false);
         $this->assertEquals(Carbon::parse($date), $period->getStartDate());
         $this->assertEquals(Carbon::parse($date), $period->start);
-        $this->assertSame(CarbonPeriod::EXCLUDE_START_DATE, $period->getOptions());
+        $this->assertSame($periodClass::EXCLUDE_START_DATE, $period->getOptions());
 
-        $period->since($date = '2014-10-12 15:42:34', true);
+        $period = $period->since($date = '2014-10-12 15:42:34', true);
         $this->assertEquals(Carbon::parse($date), $period->getStartDate());
         $this->assertEmpty($period->getOptions());
 
-        $period->sinceNow(false);
+        $period = $period->sinceNow(false);
         $this->assertEquals(Carbon::now(), $period->getStartDate());
-        $this->assertSame(CarbonPeriod::EXCLUDE_START_DATE, $period->getOptions());
+        $this->assertSame($periodClass::EXCLUDE_START_DATE, $period->getOptions());
     }
 
     public function testSetStartDateWithNamedParameters()
@@ -44,47 +45,49 @@ class AliasTest extends AbstractTestCase
             $this->markTestSkipped('This tests needs PHP 8 named arguments syntax.');
         }
 
+        $periodClass = $this->periodClass;
         $date = '2017-09-13 12:30:45';
-        $period = eval('return \Carbon\CarbonPeriod::start(date: $date, inclusive: false);');
+        $period = eval('return \\'.$periodClass.'::start(date: $date, inclusive: false);');
         $this->assertEquals(Carbon::parse($date), $period->getStartDate());
         $this->assertEquals(Carbon::parse($date), $period->start);
         $this->assertSame(CarbonPeriod::EXCLUDE_START_DATE, $period->getOptions());
 
-        $period = eval('return \Carbon\CarbonPeriod::start(date: $date);');
+        $period = eval('return \\'.$periodClass.'::start(date: $date);');
         $this->assertEquals(Carbon::parse($date), $period->getStartDate());
         $this->assertEquals(Carbon::parse($date), $period->start);
         $this->assertEmpty($period->getOptions());
 
         $date = '2014-10-12 15:42:34';
-        eval('$period->since(date: $date, inclusive: true);');
+        $period = eval('return $period->since(date: $date, inclusive: true);');
         $this->assertEquals(Carbon::parse($date), $period->getStartDate());
         $this->assertEmpty($period->getOptions());
 
-        eval('$period->sinceNow(inclusive: false);');
+        $period = eval('return $period->sinceNow(inclusive: false);');
         $this->assertEquals(Carbon::now(), $period->getStartDate());
-        $this->assertSame(CarbonPeriod::EXCLUDE_START_DATE, $period->getOptions());
+        $this->assertSame($periodClass::EXCLUDE_START_DATE, $period->getOptions());
 
-        $period = CarbonPeriod::sinceNow();
+        $period = $periodClass::sinceNow();
         $this->assertEquals(Carbon::now(), $period->getStartDate());
         $this->assertEmpty($period->getOptions());
     }
 
     public function testSetEndDate()
     {
-        $period = CarbonPeriod::end($date = '2017-09-13 12:30:45', false);
+        $periodClass = $this->periodClass;
+        $period = $periodClass::end($date = '2017-09-13 12:30:45', false);
         $this->assertEquals(Carbon::parse($date), $period->getEndDate());
         $this->assertEquals(Carbon::parse($date), $period->end);
-        $this->assertSame(CarbonPeriod::EXCLUDE_END_DATE, $period->getOptions());
+        $this->assertSame($periodClass::EXCLUDE_END_DATE, $period->getOptions());
 
-        $period->until($date = '2014-10-12 15:42:34', true);
+        $period = $period->until($date = '2014-10-12 15:42:34', true);
         $this->assertEquals(Carbon::parse($date), $period->getEndDate());
         $this->assertEmpty($period->getOptions());
 
-        $period->untilNow(false);
+        $period = $period->untilNow(false);
         $this->assertEquals(Carbon::now(), $period->getEndDate());
-        $this->assertSame(CarbonPeriod::EXCLUDE_END_DATE, $period->getOptions());
+        $this->assertSame($periodClass::EXCLUDE_END_DATE, $period->getOptions());
 
-        $period->end();
+        $period = $period->end();
         $this->assertNull($period->getEndDate());
     }
 
@@ -94,20 +97,21 @@ class AliasTest extends AbstractTestCase
             $this->markTestSkipped('This tests needs PHP 8 named arguments syntax.');
         }
 
+        $periodClass = $this->periodClass;
         $date = '2017-09-13 12:30:45';
-        $period = eval('return \Carbon\CarbonPeriod::end(date: $date, inclusive: false);');
+        $period = eval('return \\'.$periodClass.'::end(date: $date, inclusive: false);');
         $this->assertEquals(Carbon::parse($date), $period->getEndDate());
         $this->assertEquals(Carbon::parse($date), $period->end);
-        $this->assertSame(CarbonPeriod::EXCLUDE_END_DATE, $period->getOptions());
+        $this->assertSame($periodClass::EXCLUDE_END_DATE, $period->getOptions());
 
         $date = '2014-10-12 15:42:34';
-        eval('$period->until(date: $date, inclusive: true);');
+        $period = eval('return $period->until(date: $date, inclusive: true);');
         $this->assertEquals(Carbon::parse($date), $period->getEndDate());
         $this->assertEmpty($period->getOptions());
 
-        eval('$period->untilNow(inclusive: false);');
+        $period = eval('return $period->untilNow(inclusive: false);');
         $this->assertEquals(Carbon::now(), $period->getEndDate());
-        $this->assertSame(CarbonPeriod::EXCLUDE_END_DATE, $period->getOptions());
+        $this->assertSame($periodClass::EXCLUDE_END_DATE, $period->getOptions());
     }
 
     public function testManageFilters()
@@ -116,7 +120,8 @@ class AliasTest extends AbstractTestCase
             return true;
         };
 
-        $period = CarbonPeriod::filter($filter, 'foo');
+        $periodClass = $this->periodClass;
+        $period = $periodClass::filter($filter, 'foo');
         $this->assertSame([[$filter, 'foo']], $period->getFilters());
 
         $period = $period->push($filter, 'bar');
@@ -134,23 +139,25 @@ class AliasTest extends AbstractTestCase
 
     public function testSetRecurrences()
     {
-        $period = CarbonPeriod::recurrences(5);
+        $periodClass = $this->periodClass;
+        $period = $periodClass::recurrences(5);
         $this->assertSame(5, $period->getRecurrences());
         $this->assertSame(5, $period->recurrences);
 
-        $period->times(3);
+        $period = $period->times(3);
         $this->assertSame(3, $period->getRecurrences());
 
-        $period->recurrences();
+        $period = $period->recurrences();
         $this->assertNull($period->getRecurrences());
     }
 
     public function testManageOptions()
     {
-        $start = CarbonPeriod::EXCLUDE_START_DATE;
-        $end = CarbonPeriod::EXCLUDE_END_DATE;
+        $periodClass = $this->periodClass;
+        $start = $periodClass::EXCLUDE_START_DATE;
+        $end = $periodClass::EXCLUDE_END_DATE;
 
-        $period = CarbonPeriod::options($start);
+        $period = $periodClass::options($start);
         $this->assertSame($start, $period->getOptions());
 
         $period = $period->toggle($start | $end);
@@ -165,58 +172,64 @@ class AliasTest extends AbstractTestCase
 
     public function testSetDates()
     {
-        $period = CarbonPeriod::dates($start = '2014-10-12 15:42:34', $end = '2017-09-13 12:30:45');
+        $periodClass = $this->periodClass;
+        $period = $periodClass::dates($start = '2014-10-12 15:42:34', $end = '2017-09-13 12:30:45');
         $this->assertEquals(Carbon::parse($start), $period->getStartDate());
         $this->assertEquals(Carbon::parse($end), $period->getEndDate());
 
-        $period->dates(Carbon::now());
+        $period = $period->dates(Carbon::now());
         $this->assertEquals(Carbon::now(), $period->getStartDate());
         $this->assertNull($period->getEndDate());
     }
 
     public function testManageInterval()
     {
-        $period = CarbonPeriod::interval('PT6H');
+        $periodClass = $this->periodClass;
+        $period = $periodClass::interval('PT6H');
         $this->assertEquals(CarbonInterval::create('PT6H'), $period->getDateInterval());
         $this->assertEquals(CarbonInterval::create('PT6H'), $period->interval);
     }
 
     public function testInvertInterval()
     {
-        $period = CarbonPeriod::invert();
+        $periodClass = $this->periodClass;
+        $period = $periodClass::invert();
         $this->assertEquals(CarbonInterval::create('P1D')->invert(), $period->getDateInterval());
     }
 
     public function testModifyIntervalPlural()
     {
-        $period = CarbonPeriod::weeks(2);
+        $periodClass = $this->periodClass;
+        $period = $periodClass::weeks(2);
         $this->assertSame('P14D', $period->getDateInterval()->spec());
 
-        $period->years(2)->months(3)->days(4)->hours(5)->minutes(30)->seconds(15);
+        $period = $period->years(2)->months(3)->days(4)->hours(5)->minutes(30)->seconds(15);
         $this->assertSame('P2Y3M4DT5H30M15S', $period->getDateInterval()->spec());
 
-        $period->years(0)->months(0)->dayz(0)->hours(0)->minutes(0)->seconds(1);
+        $period = $period->years(0)->months(0)->dayz(0)->hours(0)->minutes(0)->seconds(1);
         $this->assertSame('PT1S', $period->getDateInterval()->spec());
     }
 
     public function testModifyIntervalSingular()
     {
-        $period = CarbonPeriod::week();
+        $periodClass = $this->periodClass;
+        $period = $periodClass::week();
         $this->assertSame('P7D', $period->getDateInterval()->spec());
 
-        $period->year()->month()->day()->hour()->minute()->second();
+        $period = $period->year()->month()->day()->hour()->minute()->second();
         $this->assertSame('P1Y1M1DT1H1M1S', $period->getDateInterval()->spec());
 
-        $period->year(2)->month(3)->day(4)->hour(5)->minute(6)->second(7);
+        $period = $period->year(2)->month(3)->day(4)->hour(5)->minute(6)->second(7);
         $this->assertSame('P2Y3M4DT5H6M7S', $period->getDateInterval()->spec());
     }
 
     public function testChainAliases()
     {
+        $periodClass = $this->periodClass;
         Carbon::setTestNow('2018-05-15');
-        $period = CarbonPeriod::days(3)->hours(5)->invert()
+        $period = $periodClass::days(3)->hours(5)->invert()
             ->sinceNow()->until(Carbon::now()->subDays(10))
-            ->options(CarbonPeriod::EXCLUDE_START_DATE)
+            ->options($periodClass::EXCLUDE_START_DATE)
             ->times(2);
 
         $this->assertSame(
@@ -233,18 +246,20 @@ class AliasTest extends AbstractTestCase
             'Method foobar does not exist.'
         ));
 
-        CarbonPeriod::foobar();
+        $periodClass = $this->periodClass;
+        $periodClass::foobar();
     }
 
     public function testOverrideDefaultInterval()
     {
-        $period = CarbonPeriod::hours(5);
+        $periodClass = $this->periodClass;
+        $period = $periodClass::hours(5);
         $this->assertSame('PT5H', $period->getDateInterval()->spec());
 
-        $period = CarbonPeriod::create()->hours(5);
+        $period = $periodClass::create()->hours(5);
         $this->assertSame('PT5H', $period->getDateInterval()->spec());
 
-        $period = CarbonPeriod::create('P1D')->hours(5);
+        $period = $periodClass::create('P1D')->hours(5);
         $this->assertSame('P1DT5H', $period->getDateInterval()->spec());
     }
 
@@ -254,7 +269,8 @@ class AliasTest extends AbstractTestCase
             'Empty interval is not accepted.'
         ));
 
-        CarbonPeriod::days(0);
+        $periodClass = $this->periodClass;
+        $periodClass::days(0);
     }
 
     public function testNamedParameters()
@@ -263,45 +279,46 @@ class AliasTest extends AbstractTestCase
             $this->markTestSkipped('This tests needs PHP 8 named arguments syntax.');
         }
 
-        $period = eval("return \Carbon\CarbonPeriod::between(start: '2022-09-13', end: '2022-10-12');");
+        $periodClass = $this->periodClass;
+        $period = eval("return \\$periodClass::between(start: '2022-09-13', end: '2022-10-12');");
         $this->assertEquals('2022-09-13', $period->getStartDate()->format('Y-m-d'));
         $this->assertEquals('2022-10-12', $period->getEndDate()->format('Y-m-d'));
 
-        eval('$period->years(years: 5);');
+        $period = eval('return $period->years(years: 5);');
         $this->assertEquals('5 years', (string) $period->getDateInterval());
 
-        eval('$period->interval(interval: \Carbon\CarbonInterval::year(years: 3));');
+        $period = eval('return $period->interval(interval: \Carbon\CarbonInterval::year(years: 3));');
         $this->assertEquals('3 years', (string) $period->getDateInterval());
 
-        $period = eval("return \Carbon\CarbonPeriod::between(start: '2022-09-13', end: '2022-10-12')->months(months: 5);");
+        $period = eval("return \\$periodClass::between(start: '2022-09-13', end: '2022-10-12')->months(months: 5);");
         $this->assertEquals('5 months', (string) $period->getDateInterval());
 
-        $period = eval("return \Carbon\CarbonPeriod::between(start: '2022-09-13', end: '2022-10-12')->weeks(weeks: 5);");
+        $period = eval("return \\$periodClass::between(start: '2022-09-13', end: '2022-10-12')->weeks(weeks: 5);");
         $this->assertEquals('5 weeks', (string) $period->getDateInterval());
 
-        $period = eval("return \Carbon\CarbonPeriod::between(start: '2022-09-13', end: '2022-10-12')->days(days: 5);");
+        $period = eval("return \\$periodClass::between(start: '2022-09-13', end: '2022-10-12')->days(days: 5);");
         $this->assertEquals('5 days', (string) $period->getDateInterval());
 
-        $period = eval("return \Carbon\CarbonPeriod::between(start: '2022-09-13', end: '2022-10-12')->hours(hours: 5);");
+        $period = eval("return \\$periodClass::between(start: '2022-09-13', end: '2022-10-12')->hours(hours: 5);");
         $this->assertEquals('5 hours', (string) $period->getDateInterval());
 
-        $period = eval("return \Carbon\CarbonPeriod::between(start: '2022-09-13', end: '2022-10-12')->minutes(minutes: 5);");
+        $period = eval("return \\$periodClass::between(start: '2022-09-13', end: '2022-10-12')->minutes(minutes: 5);");
         $this->assertEquals('5 minutes', (string) $period->getDateInterval());
 
-        $period = eval("return \Carbon\CarbonPeriod::between(start: '2022-09-13', end: '2022-10-12')->seconds(seconds: 5);");
+        $period = eval("return \\$periodClass::between(start: '2022-09-13', end: '2022-10-12')->seconds(seconds: 5);");
         $this->assertEquals('5 seconds', (string) $period->getDateInterval());
 
-        $period = eval("return \Carbon\CarbonPeriod::between(start: '2022-09-13', end: '2022-10-12')
+        $period = eval("return \\$periodClass::between(start: '2022-09-13', end: '2022-10-12')
             ->days(days: 5)
             ->floorDays(precision: 2);");
         $this->assertEquals('4 days', (string) $period->getDateInterval());
 
-        $period = eval("return \Carbon\CarbonPeriod::between(start: '2022-09-13', end: '2022-10-12')
+        $period = eval("return \\$periodClass::between(start: '2022-09-13', end: '2022-10-12')
             ->days(days: 5)
             ->roundDays(precision: 7);");
         $this->assertEquals('1 week', (string) $period->getDateInterval());
 
-        $period = eval("return \Carbon\CarbonPeriod::between(start: '2022-09-13', end: '2022-10-12')
+        $period = eval("return \\$periodClass::between(start: '2022-09-13', end: '2022-10-12')
             ->days(days: 5)
             ->ceilDays(precision: 2);");
         $this->assertEquals('6 days', (string) $period->getDateInterval());

--- a/tests/CarbonPeriod/CloneTest.php
+++ b/tests/CarbonPeriod/CloneTest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace Tests\CarbonPeriod;
 
-use Carbon\CarbonPeriod;
 use Tests\AbstractTestCase;
 
 class CloneTest extends AbstractTestCase
 {
     public function testClone()
     {
-        $period = CarbonPeriod::create('R4/2012-07-01T00:00:00/P7D');
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('R4/2012-07-01T00:00:00/P7D');
         $clone = $period->clone();
 
         $this->assertSame((string) $period, (string) $clone);
@@ -30,7 +30,8 @@ class CloneTest extends AbstractTestCase
 
     public function testCopy()
     {
-        $period = CarbonPeriod::create('R4/2012-07-01T00:00:00/P7D');
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('R4/2012-07-01T00:00:00/P7D');
         $clone = $period->copy();
 
         $this->assertSame((string) $period, (string) $clone);

--- a/tests/CarbonPeriod/ComparisonTest.php
+++ b/tests/CarbonPeriod/ComparisonTest.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Tests\CarbonPeriod;
 
 use Carbon\Carbon;
+use Carbon\CarbonImmutable;
 use Carbon\CarbonInterval;
-use Carbon\CarbonPeriod;
 use DateInterval;
 use DatePeriod;
 use DateTime;
@@ -26,135 +26,144 @@ class ComparisonTest extends AbstractTestCase
 {
     public function testEqualToTrue()
     {
-        $period = CarbonPeriod::create('2010-01-01', '2010-02-01');
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('2010-01-01', '2010-02-01');
 
         $this->assertTrue($period->equalTo($period));
         $this->assertTrue($period->eq($period));
-        $this->assertTrue($period->eq(CarbonPeriod::create('2010-01-01', '2010-02-01')));
-        $this->assertTrue($period->eq(CarbonPeriod::create('R3/2010-01-01/P1D/2010-02-01')));
+        $this->assertTrue($period->eq($periodClass::create('2010-01-01', '2010-02-01')));
+        $this->assertTrue($period->eq($periodClass::create('R3/2010-01-01/P1D/2010-02-01')));
         $this->assertTrue($period->eq(Carbon::parse('2010-01-01')->daysUntil('2010-02-01')));
         $this->assertTrue($period->eq(
             new DatePeriod(new DateTime('2010-01-01'), CarbonInterval::day(), new DateTime('2010-02-01'))
         ));
 
-        $period = CarbonPeriod::create('2010-01-01', '2010-02-01', 'P2D');
+        $period = $periodClass::create('2010-01-01', '2010-02-01', 'P2D');
 
-        $this->assertTrue($period->eq(CarbonPeriod::create('2010-01-01', '2010-02-01', 'P2D')));
-        $this->assertTrue($period->eq(CarbonPeriod::create('2010-01-01', '2010-02-01', CarbonInterval::day(2))));
-        $this->assertTrue($period->eq(CarbonPeriod::create('2010-01-01', '2010-02-01')->setDateInterval('P2D')));
-        $this->assertTrue($period->eq(CarbonPeriod::create('R3/2010-01-01/P2D/2010-02-01')));
+        $this->assertTrue($period->eq($periodClass::create('2010-01-01', '2010-02-01', 'P2D')));
+        $this->assertTrue($period->eq($periodClass::create('2010-01-01', '2010-02-01', CarbonInterval::day(2))));
+        $this->assertTrue($period->eq($periodClass::create('2010-01-01', '2010-02-01')->setDateInterval('P2D')));
+        $this->assertTrue($period->eq($periodClass::create('R3/2010-01-01/P2D/2010-02-01')));
 
-        $period = CarbonPeriod::create('2010-01-01', '2010-02-01', CarbonPeriod::EXCLUDE_START_DATE);
+        $period = $periodClass::create('2010-01-01', '2010-02-01', $periodClass::EXCLUDE_START_DATE);
 
-        $this->assertTrue($period->eq(CarbonPeriod::create('2010-01-01', '2010-02-01', CarbonPeriod::EXCLUDE_START_DATE)));
-        $this->assertTrue($period->eq(CarbonPeriod::create('2010-01-01', '2010-02-01')->setOptions(CarbonPeriod::EXCLUDE_START_DATE)));
+        $this->assertTrue($period->eq($periodClass::create('2010-01-01', '2010-02-01', $periodClass::EXCLUDE_START_DATE)));
+        $this->assertTrue($period->eq($periodClass::create('2010-01-01', '2010-02-01')->setOptions($periodClass::EXCLUDE_START_DATE)));
     }
 
     public function testEqualToFalse()
     {
-        $period = CarbonPeriod::create('2010-01-01', '2010-02-01');
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('2010-01-01', '2010-02-01');
 
-        $this->assertFalse($period->equalTo(CarbonPeriod::create('2010-01-02', '2010-02-01')));
-        $this->assertFalse($period->eq(CarbonPeriod::create('2010-01-02', '2010-02-01')));
-        $this->assertFalse($period->eq(CarbonPeriod::create('2010-01-01', '2010-02-02')));
-        $this->assertFalse($period->eq(CarbonPeriod::create('2010-01-01', '2010-02-02', 'P2D')));
-        $this->assertFalse($period->eq(CarbonPeriod::create('2010-01-01', '2010-02-02', CarbonPeriod::EXCLUDE_START_DATE)));
+        $this->assertFalse($period->equalTo($periodClass::create('2010-01-02', '2010-02-01')));
+        $this->assertFalse($period->eq($periodClass::create('2010-01-02', '2010-02-01')));
+        $this->assertFalse($period->eq($periodClass::create('2010-01-01', '2010-02-02')));
+        $this->assertFalse($period->eq($periodClass::create('2010-01-01', '2010-02-02', 'P2D')));
+        $this->assertFalse($period->eq($periodClass::create('2010-01-01', '2010-02-02', $periodClass::EXCLUDE_START_DATE)));
     }
 
     public function testNotEqualToTrue()
     {
-        $period = CarbonPeriod::create('2010-01-01', '2010-02-01');
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('2010-01-01', '2010-02-01');
 
-        $this->assertTrue($period->notEqualTo(CarbonPeriod::create('2010-01-02', '2010-02-01')));
-        $this->assertTrue($period->ne(CarbonPeriod::create('2010-01-02', '2010-02-01')));
-        $this->assertTrue($period->ne(CarbonPeriod::create('2010-01-01', '2010-02-02')));
-        $this->assertTrue($period->ne(CarbonPeriod::create('2010-01-01', '2010-02-02', 'P2D')));
-        $this->assertTrue($period->ne(CarbonPeriod::create('2010-01-01', '2010-02-02', CarbonPeriod::EXCLUDE_START_DATE)));
+        $this->assertTrue($period->notEqualTo($periodClass::create('2010-01-02', '2010-02-01')));
+        $this->assertTrue($period->ne($periodClass::create('2010-01-02', '2010-02-01')));
+        $this->assertTrue($period->ne($periodClass::create('2010-01-01', '2010-02-02')));
+        $this->assertTrue($period->ne($periodClass::create('2010-01-01', '2010-02-02', 'P2D')));
+        $this->assertTrue($period->ne($periodClass::create('2010-01-01', '2010-02-02', $periodClass::EXCLUDE_START_DATE)));
     }
 
     public function testNotEqualToFalse()
     {
-        $period = CarbonPeriod::create('2010-01-01', '2010-02-01');
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('2010-01-01', '2010-02-01');
 
         $this->assertFalse($period->notEqualTo($period));
         $this->assertFalse($period->ne($period));
-        $this->assertFalse($period->ne(CarbonPeriod::create('2010-01-01', '2010-02-01')));
-        $this->assertFalse($period->ne(CarbonPeriod::create('R3/2010-01-01/P1D/2010-02-01')));
+        $this->assertFalse($period->ne($periodClass::create('2010-01-01', '2010-02-01')));
+        $this->assertFalse($period->ne($periodClass::create('R3/2010-01-01/P1D/2010-02-01')));
         $this->assertFalse($period->ne(Carbon::parse('2010-01-01')->daysUntil('2010-02-01')));
         $this->assertFalse($period->ne(
             new DatePeriod(new DateTime('2010-01-01'), CarbonInterval::day(), new DateTime('2010-02-01'))
         ));
 
-        $period = CarbonPeriod::create('2010-01-01', '2010-02-01', 'P2D');
+        $period = $periodClass::create('2010-01-01', '2010-02-01', 'P2D');
 
-        $this->assertFalse($period->ne(CarbonPeriod::create('2010-01-01', '2010-02-01', 'P2D')));
-        $this->assertFalse($period->ne(CarbonPeriod::create('2010-01-01', '2010-02-01', CarbonInterval::day(2))));
-        $this->assertFalse($period->ne(CarbonPeriod::create('2010-01-01', '2010-02-01')->setDateInterval('P2D')));
-        $this->assertFalse($period->ne(CarbonPeriod::create('R3/2010-01-01/P2D/2010-02-01')));
+        $this->assertFalse($period->ne($periodClass::create('2010-01-01', '2010-02-01', 'P2D')));
+        $this->assertFalse($period->ne($periodClass::create('2010-01-01', '2010-02-01', CarbonInterval::day(2))));
+        $this->assertFalse($period->ne($periodClass::create('2010-01-01', '2010-02-01')->setDateInterval('P2D')));
+        $this->assertFalse($period->ne($periodClass::create('R3/2010-01-01/P2D/2010-02-01')));
 
-        $period = CarbonPeriod::create('2010-01-01', '2010-02-01', CarbonPeriod::EXCLUDE_START_DATE);
+        $period = $periodClass::create('2010-01-01', '2010-02-01', $periodClass::EXCLUDE_START_DATE);
 
-        $this->assertFalse($period->ne(CarbonPeriod::create('2010-01-01', '2010-02-01', CarbonPeriod::EXCLUDE_START_DATE)));
-        $this->assertFalse($period->ne(CarbonPeriod::create('2010-01-01', '2010-02-01')->setOptions(CarbonPeriod::EXCLUDE_START_DATE)));
+        $this->assertFalse($period->ne($periodClass::create('2010-01-01', '2010-02-01', $periodClass::EXCLUDE_START_DATE)));
+        $this->assertFalse($period->ne($periodClass::create('2010-01-01', '2010-02-01')->setOptions($periodClass::EXCLUDE_START_DATE)));
     }
 
     public function testStartComparisons()
     {
+        $periodClass = $this->periodClass;
         Carbon::setTestNow('2020-01-01');
+        CarbonImmutable::setTestNow('2020-01-01');
 
-        $this->assertFalse(CarbonPeriod::create('2020-01-05', '2020-02-01')->startsBefore(CarbonPeriod::create('2019-12-05', '2020-02-01')));
-        $this->assertTrue(CarbonPeriod::create('2020-01-05', '2020-02-01')->startsBefore(CarbonPeriod::create('2020-01-07', '2020-01-08')));
+        $this->assertFalse($periodClass::create('2020-01-05', '2020-02-01')->startsBefore($periodClass::create('2019-12-05', '2020-02-01')));
+        $this->assertTrue($periodClass::create('2020-01-05', '2020-02-01')->startsBefore($periodClass::create('2020-01-07', '2020-01-08')));
 
-        $this->assertFalse(CarbonPeriod::create('2020-01-05', '2020-02-01')->startsBefore(CarbonInterval::days(2)));
-        $this->assertFalse(CarbonPeriod::create('2020-01-05', '2020-02-01')->startsBefore(CarbonInterval::days(4)));
-        $this->assertTrue(CarbonPeriod::create('2020-01-05', '2020-02-01')->startsBeforeOrAt(CarbonInterval::days(4)));
-        $this->assertTrue(CarbonPeriod::create('2020-01-05', '2020-02-01')->startsBefore(CarbonInterval::days(5)));
+        $this->assertFalse($periodClass::create('2020-01-05', '2020-02-01')->startsBefore(CarbonInterval::days(2)));
+        $this->assertFalse($periodClass::create('2020-01-05', '2020-02-01')->startsBefore(CarbonInterval::days(4)));
+        $this->assertTrue($periodClass::create('2020-01-05', '2020-02-01')->startsBeforeOrAt(CarbonInterval::days(4)));
+        $this->assertTrue($periodClass::create('2020-01-05', '2020-02-01')->startsBefore(CarbonInterval::days(5)));
 
-        $this->assertTrue(CarbonPeriod::create('2020-01-05', '2020-02-01')->startsAfter(CarbonPeriod::create('2019-12-05', '2020-02-01')));
-        $this->assertFalse(CarbonPeriod::create('2020-01-05', '2020-02-01')->startsAfter(CarbonPeriod::create('2020-01-07', '2020-01-08')));
+        $this->assertTrue($periodClass::create('2020-01-05', '2020-02-01')->startsAfter($periodClass::create('2019-12-05', '2020-02-01')));
+        $this->assertFalse($periodClass::create('2020-01-05', '2020-02-01')->startsAfter($periodClass::create('2020-01-07', '2020-01-08')));
 
-        $this->assertTrue(CarbonPeriod::create('2020-01-05', '2020-02-01')->startsAfter(CarbonInterval::days(2)));
-        $this->assertFalse(CarbonPeriod::create('2020-01-05', '2020-02-01')->startsAfter(CarbonInterval::days(4)));
-        $this->assertTrue(CarbonPeriod::create('2020-01-05', '2020-02-01')->startsAfterOrAt(CarbonInterval::days(4)));
-        $this->assertFalse(CarbonPeriod::create('2020-01-05', '2020-02-01')->startsAfter(CarbonInterval::days(5)));
+        $this->assertTrue($periodClass::create('2020-01-05', '2020-02-01')->startsAfter(CarbonInterval::days(2)));
+        $this->assertFalse($periodClass::create('2020-01-05', '2020-02-01')->startsAfter(CarbonInterval::days(4)));
+        $this->assertTrue($periodClass::create('2020-01-05', '2020-02-01')->startsAfterOrAt(CarbonInterval::days(4)));
+        $this->assertFalse($periodClass::create('2020-01-05', '2020-02-01')->startsAfter(CarbonInterval::days(5)));
 
-        $this->assertFalse(CarbonPeriod::create('2020-01-05', '2020-02-01')->startsAt('2020-02-01'));
-        $this->assertTrue(CarbonPeriod::create('2020-01-05', '2020-02-01')->startsAt('2020-01-05'));
+        $this->assertFalse($periodClass::create('2020-01-05', '2020-02-01')->startsAt('2020-02-01'));
+        $this->assertTrue($periodClass::create('2020-01-05', '2020-02-01')->startsAt('2020-01-05'));
     }
 
     public function testEndComparisons()
     {
+        $periodClass = $this->periodClass;
         Carbon::setTestNow('2020-02-05');
+        CarbonImmutable::setTestNow('2020-02-05');
 
-        $this->assertFalse(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsBefore(CarbonPeriod::create('2019-12-05', '2020-02-01')));
-        $this->assertFalse(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsBefore(CarbonPeriod::create('2020-01-07', '2020-01-08')));
-        $this->assertFalse(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsBefore(CarbonPeriod::create('2020-02-01', '2020-02-08')));
-        $this->assertTrue(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsBeforeOrAt(CarbonPeriod::create('2020-02-01', '2020-02-08')));
-        $this->assertTrue(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsBefore(CarbonPeriod::create('2020-02-03', '2020-02-08')));
+        $this->assertFalse($periodClass::create('2020-01-05', '2020-02-01')->endsBefore($periodClass::create('2019-12-05', '2020-02-01')));
+        $this->assertFalse($periodClass::create('2020-01-05', '2020-02-01')->endsBefore($periodClass::create('2020-01-07', '2020-01-08')));
+        $this->assertFalse($periodClass::create('2020-01-05', '2020-02-01')->endsBefore($periodClass::create('2020-02-01', '2020-02-08')));
+        $this->assertTrue($periodClass::create('2020-01-05', '2020-02-01')->endsBeforeOrAt($periodClass::create('2020-02-01', '2020-02-08')));
+        $this->assertTrue($periodClass::create('2020-01-05', '2020-02-01')->endsBefore($periodClass::create('2020-02-03', '2020-02-08')));
 
-        $this->assertTrue(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsBefore(CarbonInterval::days(2)->invert()));
-        $this->assertFalse(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsBefore(CarbonInterval::days(4)->invert()));
-        $this->assertTrue(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsBeforeOrAt(CarbonInterval::days(4)->invert()));
-        $this->assertFalse(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsBefore(CarbonInterval::days(5)->invert()));
+        $this->assertTrue($periodClass::create('2020-01-05', '2020-02-01')->endsBefore(CarbonInterval::days(2)->invert()));
+        $this->assertFalse($periodClass::create('2020-01-05', '2020-02-01')->endsBefore(CarbonInterval::days(4)->invert()));
+        $this->assertTrue($periodClass::create('2020-01-05', '2020-02-01')->endsBeforeOrAt(CarbonInterval::days(4)->invert()));
+        $this->assertFalse($periodClass::create('2020-01-05', '2020-02-01')->endsBefore(CarbonInterval::days(5)->invert()));
 
-        $this->assertTrue(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsAfter(CarbonPeriod::create('2019-12-05', '2020-02-01')));
-        $this->assertTrue(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsAfter(CarbonPeriod::create('2020-01-07', '2020-01-08')));
-        $this->assertTrue(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsAfterOrAt(CarbonPeriod::create('2020-02-01', '2020-01-08')));
-        $this->assertFalse(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsAfter(CarbonPeriod::create('2020-02-01', '2020-01-08')));
-        $this->assertFalse(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsAfter(CarbonPeriod::create('2020-02-02', '2020-01-08')));
+        $this->assertTrue($periodClass::create('2020-01-05', '2020-02-01')->endsAfter($periodClass::create('2019-12-05', '2020-02-01')));
+        $this->assertTrue($periodClass::create('2020-01-05', '2020-02-01')->endsAfter($periodClass::create('2020-01-07', '2020-01-08')));
+        $this->assertTrue($periodClass::create('2020-01-05', '2020-02-01')->endsAfterOrAt($periodClass::create('2020-02-01', '2020-01-08')));
+        $this->assertFalse($periodClass::create('2020-01-05', '2020-02-01')->endsAfter($periodClass::create('2020-02-01', '2020-01-08')));
+        $this->assertFalse($periodClass::create('2020-01-05', '2020-02-01')->endsAfter($periodClass::create('2020-02-02', '2020-01-08')));
 
-        $this->assertFalse(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsAfter(CarbonInterval::days(2)->invert()));
-        $this->assertFalse(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsAfter(CarbonInterval::days(4)->invert()));
-        $this->assertTrue(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsAfterOrAt(CarbonInterval::days(4)->invert()));
-        $this->assertTrue(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsAfter(CarbonInterval::days(5)->invert()));
+        $this->assertFalse($periodClass::create('2020-01-05', '2020-02-01')->endsAfter(CarbonInterval::days(2)->invert()));
+        $this->assertFalse($periodClass::create('2020-01-05', '2020-02-01')->endsAfter(CarbonInterval::days(4)->invert()));
+        $this->assertTrue($periodClass::create('2020-01-05', '2020-02-01')->endsAfterOrAt(CarbonInterval::days(4)->invert()));
+        $this->assertTrue($periodClass::create('2020-01-05', '2020-02-01')->endsAfter(CarbonInterval::days(5)->invert()));
 
-        $this->assertTrue(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsAt('2020-02-01'));
-        $this->assertFalse(CarbonPeriod::create('2020-01-05', '2020-02-01')->endsAt('2020-01-05'));
+        $this->assertTrue($periodClass::create('2020-01-05', '2020-02-01')->endsAt('2020-02-01'));
+        $this->assertFalse($periodClass::create('2020-01-05', '2020-02-01')->endsAt('2020-01-05'));
     }
 
     public function testContains()
     {
-        $period = CarbonPeriod::create('2019-08-01', '2019-08-10');
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('2019-08-01', '2019-08-10');
 
         $this->assertFalse($period->contains('2019-07-31 23:59:59'));
         $this->assertTrue($period->contains('2019-08-01'));
@@ -162,7 +171,7 @@ class ComparisonTest extends AbstractTestCase
         $this->assertTrue($period->contains('2019-08-10'));
         $this->assertFalse($period->contains('2019-08-10 00:00:01'));
 
-        $period = CarbonPeriod::create('2019-08-01', '2019-08-10', CarbonPeriod::EXCLUDE_START_DATE | CarbonPeriod::EXCLUDE_END_DATE);
+        $period = $periodClass::create('2019-08-01', '2019-08-10', $periodClass::EXCLUDE_START_DATE | $periodClass::EXCLUDE_END_DATE);
 
         $this->assertFalse($period->contains('2019-08-01'));
         $this->assertTrue($period->contains('2019-08-01 00:00:01'));
@@ -173,8 +182,9 @@ class ComparisonTest extends AbstractTestCase
 
     public function testConsecutivePeriods()
     {
-        $july = CarbonPeriod::create('2019-07-29', '2019-07-31');
-        $august = CarbonPeriod::create('2019-08-01', '2019-08-12');
+        $periodClass = $this->periodClass;
+        $july = $periodClass::create('2019-07-29', '2019-07-31');
+        $august = $periodClass::create('2019-08-01', '2019-08-12');
 
         $this->assertFalse($july->follows($august));
         $this->assertTrue($august->follows($july));
@@ -214,8 +224,8 @@ class ComparisonTest extends AbstractTestCase
         $this->assertTrue($july->isConsecutiveWith($august2));
         $this->assertTrue($august->isConsecutiveWith($july2));
 
-        $july = CarbonPeriod::create('2019-07-29', '2019-08-01');
-        $august = CarbonPeriod::create('2019-08-01', '2019-08-12');
+        $july = $periodClass::create('2019-07-29', '2019-08-01');
+        $august = $periodClass::create('2019-08-01', '2019-08-12');
 
         $this->assertFalse($july->follows($august));
         $this->assertFalse($august->follows($july));
@@ -226,8 +236,8 @@ class ComparisonTest extends AbstractTestCase
         $this->assertFalse($july->isConsecutiveWith($august));
         $this->assertFalse($august->isConsecutiveWith($july));
 
-        $july = CarbonPeriod::create('2019-07-29', '2019-07-31', CarbonPeriod::EXCLUDE_END_DATE);
-        $august = CarbonPeriod::create('2019-08-01', '2019-08-12', CarbonPeriod::EXCLUDE_START_DATE);
+        $july = $periodClass::create('2019-07-29', '2019-07-31', $periodClass::EXCLUDE_END_DATE);
+        $august = $periodClass::create('2019-08-01', '2019-08-12', $periodClass::EXCLUDE_START_DATE);
 
         $this->assertFalse($july->follows($august));
         $this->assertFalse($august->follows($july));
@@ -241,8 +251,9 @@ class ComparisonTest extends AbstractTestCase
 
     public function testConsecutivePeriodsWithExclusion()
     {
-        $july = CarbonPeriod::create('2019-07-29', '2019-08-01', CarbonPeriod::EXCLUDE_END_DATE);
-        $august = CarbonPeriod::create('2019-07-31', '2019-08-12', CarbonPeriod::EXCLUDE_START_DATE);
+        $periodClass = $this->periodClass;
+        $july = $periodClass::create('2019-07-29', '2019-08-01', $periodClass::EXCLUDE_END_DATE);
+        $august = $periodClass::create('2019-07-31', '2019-08-12', $periodClass::EXCLUDE_START_DATE);
 
         $this->assertFalse($july->follows($august));
         $this->assertTrue($august->follows($july));
@@ -256,8 +267,9 @@ class ComparisonTest extends AbstractTestCase
 
     public function testConsecutivePeriodsWithDynamicEnd()
     {
-        $july = CarbonPeriod::create('2019-07-29', '1 day', 4);
-        $august = CarbonPeriod::create('2019-08-02', '2019-08-12');
+        $periodClass = $this->periodClass;
+        $july = $periodClass::create('2019-07-29', '1 day', 4);
+        $august = $periodClass::create('2019-08-02', '2019-08-12');
 
         $this->assertFalse($july->follows($august));
         $this->assertTrue($august->follows($july));

--- a/tests/CarbonPeriod/CreateTest.php
+++ b/tests/CarbonPeriod/CreateTest.php
@@ -18,6 +18,7 @@ use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterval;
 use Carbon\CarbonPeriod;
+use Carbon\CarbonPeriodImmutable;
 use Carbon\Exceptions\NotAPeriodException;
 use DateInterval;
 use DatePeriod;
@@ -34,9 +35,10 @@ class CreateTest extends AbstractTestCase
      */
     public function testCreateFromIso8601String($arguments, $expected)
     {
+        $periodClass = $this->periodClass;
         [$iso, $options] = array_pad($arguments, 2, null);
 
-        $period = CarbonPeriod::create($iso, $options);
+        $period = $periodClass::create($iso, $options);
 
         $this->assertSame(
             $this->standardizeDates($expected),
@@ -70,7 +72,8 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateFromIso8601StringWithUnboundedRecurrences()
     {
-        $period = CarbonPeriod::create('R/2012-07-01T00:00:00/P7D');
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('R/2012-07-01T00:00:00/P7D');
 
         $this->assertSame('2012-07-01', $period->getStartDate()->toDateString());
         $this->assertSame('P7D', $period->getDateInterval()->spec());
@@ -80,7 +83,8 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateFromIso8601StringWithInfiniteRecurrences()
     {
-        $period = CarbonPeriod::create('RINF/2012-07-01T00:00:00/P7D');
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('RINF/2012-07-01T00:00:00/P7D');
         $this->assertSame('2012-07-01', $period->getStartDate()->toDateString());
         $this->assertSame('P7D', $period->getDateInterval()->spec());
         $this->assertNull($period->getEndDate());
@@ -92,14 +96,15 @@ class CreateTest extends AbstractTestCase
      */
     public function testCreateFromPartialIso8601String($iso, $from, $to)
     {
-        $period = CarbonPeriod::create($iso);
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create($iso);
 
         $this->assertSame(
             $this->standardizeDates([$from, $to]),
             $this->standardizeDates([$period->getStartDate(), $period->getEndDate()])
         );
 
-        $period = new CarbonPeriod($iso);
+        $period = new $periodClass($iso);
 
         $this->assertSame(
             $this->standardizeDates([$from, $to]),
@@ -122,7 +127,8 @@ class CreateTest extends AbstractTestCase
             "Invalid ISO 8601 specification: $iso"
         ));
 
-        CarbonPeriod::create($iso);
+        $periodClass = $this->periodClass;
+        $periodClass::create($iso);
     }
 
     public static function dataForInvalidIso8601String(): Generator
@@ -140,12 +146,13 @@ class CreateTest extends AbstractTestCase
      */
     public function testCreateFromStartDateAndEndDate($arguments, $expected)
     {
+        $periodClass = $this->periodClass;
         [$start, $end, $options] = array_pad($arguments, 3, null);
 
         $start = Carbon::parse($start);
         $end = Carbon::parse($end);
 
-        $period = CarbonPeriod::create($start, $end, $options);
+        $period = $periodClass::create($start, $end, $options);
 
         $this->assertSame(
             $this->standardizeDates($expected),
@@ -194,13 +201,14 @@ class CreateTest extends AbstractTestCase
      */
     public function testCreateFromStartDateAndIntervalAndEndDate($arguments, $expected)
     {
+        $periodClass = $this->periodClass;
         [$start, $interval, $end, $options] = array_pad($arguments, 4, null);
 
         $start = Carbon::parse($start);
         $interval = CarbonInterval::create($interval);
         $end = Carbon::parse($end);
 
-        $period = CarbonPeriod::create($start, $interval, $end, $options);
+        $period = $periodClass::create($start, $interval, $end, $options);
 
         $this->assertSame(
             $this->standardizeDates($expected),
@@ -254,12 +262,13 @@ class CreateTest extends AbstractTestCase
      */
     public function testCreateFromStartDateAndIntervalAndRecurrences($arguments, $expected)
     {
+        $periodClass = $this->periodClass;
         [$start, $interval, $recurrences, $options] = array_pad($arguments, 4, null);
 
         $start = Carbon::parse($start);
         $interval = CarbonInterval::create($interval);
 
-        $period = CarbonPeriod::create($start, $interval, $recurrences, $options);
+        $period = $periodClass::create($start, $interval, $recurrences, $options);
 
         $this->assertSame(
             $this->standardizeDates($expected),
@@ -284,11 +293,12 @@ class CreateTest extends AbstractTestCase
      */
     public function testCreateFromStartDateAndRecurrences($arguments, $expected)
     {
+        $periodClass = $this->periodClass;
         [$start, $recurrences, $options] = array_pad($arguments, 4, null);
 
         $start = Carbon::parse($start);
 
-        $period = CarbonPeriod::create($start, $recurrences, $options);
+        $period = $periodClass::create($start, $recurrences, $options);
 
         $this->assertSame(
             $this->standardizeDates($expected),
@@ -318,7 +328,8 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateFromBaseClasses()
     {
-        $period = CarbonPeriod::create(
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create(
             new DateTime('2018-04-16'),
             new DateInterval('P1M'),
             new DateTime('2018-07-15')
@@ -343,7 +354,8 @@ class CreateTest extends AbstractTestCase
             'Invalid constructor parameters.'
         ));
 
-        CarbonPeriod::create(...$arguments);
+        $periodClass = $this->periodClass;
+        $periodClass::create(...$arguments);
     }
 
     public static function dataForInvalidParameters(): Generator
@@ -359,7 +371,8 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateOnDstForwardChange()
     {
-        $period = CarbonPeriod::create(
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create(
             '2018-03-25 1:30 Europe/Oslo',
             'PT30M',
             '2018-03-25 3:30 Europe/Oslo'
@@ -385,7 +398,8 @@ class CreateTest extends AbstractTestCase
      */
     public function testCreateOnDstBackwardChange()
     {
-        $period = CarbonPeriod::create(
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create(
             '2018-10-28 1:30 Europe/Oslo',
             'PT30M',
             '2018-10-28 3:30 Europe/Oslo'
@@ -407,7 +421,8 @@ class CreateTest extends AbstractTestCase
 
     public function testInternalVariablesCannotBeIndirectlyModified()
     {
-        $period = CarbonPeriod::create(
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create(
             $start = new DateTime('2018-04-16'),
             $interval = new DateInterval('P1M'),
             $end = new DateTime('2018-07-15')
@@ -421,7 +436,7 @@ class CreateTest extends AbstractTestCase
         $this->assertSame('P1M', $period->getDateInterval()->spec());
         $this->assertSame('2018-07-15', $period->getEndDate()->toDateString());
 
-        $period = CarbonPeriod::create(
+        $period = $periodClass::create(
             $start = new Carbon('2018-04-16'),
             $interval = new CarbonInterval('P1M'),
             $end = new Carbon('2018-07-15')
@@ -438,30 +453,33 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateFromArray()
     {
-        $period = CarbonPeriod::createFromArray([
-            '2018-03-25', 'P2D', '2018-04-01', CarbonPeriod::EXCLUDE_END_DATE,
+        $periodClass = $this->periodClass;
+        $period = $periodClass::createFromArray([
+            '2018-03-25', 'P2D', '2018-04-01', $periodClass::EXCLUDE_END_DATE,
         ]);
 
         $this->assertSame('2018-03-25', $period->getStartDate()->toDateString());
         $this->assertSame('P2D', $period->getDateInterval()->spec());
         $this->assertSame('2018-04-01', $period->getEndDate()->toDateString());
-        $this->assertSame(CarbonPeriod::EXCLUDE_END_DATE, $period->getOptions());
+        $this->assertSame($periodClass::EXCLUDE_END_DATE, $period->getOptions());
     }
 
     public function testCreateFromIso()
     {
-        $period = CarbonPeriod::createFromIso('R3/2018-03-25/P2D/2018-04-01', CarbonPeriod::EXCLUDE_END_DATE);
+        $periodClass = $this->periodClass;
+        $period = $periodClass::createFromIso('R3/2018-03-25/P2D/2018-04-01', $periodClass::EXCLUDE_END_DATE);
 
         $this->assertSame('2018-03-25', $period->getStartDate()->toDateString());
         $this->assertSame('P2D', $period->getDateInterval()->spec());
         $this->assertSame('2018-04-01', $period->getEndDate()->toDateString());
         $this->assertSame(3, $period->getRecurrences());
-        $this->assertSame(CarbonPeriod::EXCLUDE_END_DATE, $period->getOptions());
+        $this->assertSame($periodClass::EXCLUDE_END_DATE, $period->getOptions());
     }
 
     public function testCreateEmpty()
     {
-        $period = new CarbonPeriod();
+        $periodClass = $this->periodClass;
+        $period = new $periodClass();
 
         $this->assertEquals(new Carbon(), $period->getStartDate());
         $this->assertSame('P1D', $period->getDateInterval()->spec());
@@ -472,7 +490,8 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateFromDateStringsWithTimezones()
     {
-        $period = CarbonPeriod::create(
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create(
             $start = '2018-03-25 10:15:30 Europe/Oslo',
             $end = '2018-03-28 17:25:30 Asia/Kamchatka'
         );
@@ -483,7 +502,8 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateWithIntervalInFromStringFormat()
     {
-        $period = CarbonPeriod::create(
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create(
             '2018-03-25 12:00',
             '2 days 10 hours',
             '2018-04-01 13:30'
@@ -494,7 +514,7 @@ class CreateTest extends AbstractTestCase
             $this->standardizeDates($period)
         );
 
-        $period = CarbonPeriod::create(
+        $period = $periodClass::create(
             '2018-04-21',
             '3 days',
             '2018-04-27'
@@ -508,7 +528,8 @@ class CreateTest extends AbstractTestCase
 
     public function testCreateFromRelativeDates()
     {
-        $period = CarbonPeriod::create(
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create(
             $start = 'previous friday',
             $end = '+6 days'
         );
@@ -600,38 +621,39 @@ class CreateTest extends AbstractTestCase
 
     public function testInstance()
     {
+        $periodClass = $this->periodClass;
         $source = new DatePeriod(
             new DateTime('2012-07-01'),
             CarbonInterval::days(2),
             new DateTime('2012-07-07')
         );
 
-        $period = CarbonPeriod::instance($source);
+        $period = $periodClass::instance($source);
 
-        $this->assertInstanceOf(CarbonPeriod::class, $period);
+        $this->assertInstanceOf($periodClass, $period);
         $this->assertSame('2012-07-01', $period->getStartDate()->format('Y-m-d'));
         $this->assertSame(2, $period->getDateInterval()->d);
         $this->assertSame('2012-07-07', $period->getEndDate()->format('Y-m-d'));
 
-        $period2 = CarbonPeriod::instance($period);
+        $period2 = $periodClass::instance($period);
 
-        $this->assertInstanceOf(CarbonPeriod::class, $period2);
+        $this->assertInstanceOf($periodClass, $period2);
         $this->assertSame('2012-07-01', $period2->getStartDate()->format('Y-m-d'));
         $this->assertSame(2, $period2->getDateInterval()->d);
         $this->assertSame('2012-07-07', $period2->getEndDate()->format('Y-m-d'));
         $this->assertNotSame($period, $period2);
 
-        $period3 = new CarbonPeriod($source);
+        $period3 = new $periodClass($source);
 
-        $this->assertInstanceOf(CarbonPeriod::class, $period3);
+        $this->assertInstanceOf($periodClass, $period3);
         $this->assertSame('2012-07-01', $period3->getStartDate()->format('Y-m-d'));
         $this->assertSame(2, $period3->getDateInterval()->d);
         $this->assertSame('2012-07-07', $period3->getEndDate()->format('Y-m-d'));
         $this->assertNotSame($period, $period3);
 
-        $period4 = new CarbonPeriod($period);
+        $period4 = new $periodClass($period);
 
-        $this->assertInstanceOf(CarbonPeriod::class, $period4);
+        $this->assertInstanceOf($periodClass, $period4);
         $this->assertSame('2012-07-01', $period4->getStartDate()->format('Y-m-d'));
         $this->assertSame(2, $period4->getDateInterval()->d);
         $this->assertSame('2012-07-07', $period4->getEndDate()->format('Y-m-d'));
@@ -644,12 +666,18 @@ class CreateTest extends AbstractTestCase
             $this->markTestSkipped('This tests needs PHP 8 named arguments syntax.');
         }
 
-        $period = eval("return \Carbon\Carbon::create('2019-01-02')->daysUntil(endDate: '2019-02-05');");
+        $periodClass = $this->periodClass;
+        $carbonClass = $periodClass === CarbonPeriodImmutable::class
+            ? CarbonImmutable::class
+            : Carbon::class;
+        $period = eval("return \\$carbonClass::create('2019-01-02')->daysUntil(endDate: '2019-02-05');");
+        $this->assertInstanceOf($periodClass, $period);
         $this->assertSame('2019-01-02', $period->getStartDate()->format('Y-m-d'));
         $this->assertSame('2019-02-05', $period->getEndDate()->format('Y-m-d'));
         $this->assertSame('1 day', (string) $period->getDateInterval());
 
-        $period = eval("return \Carbon\Carbon::create('2019-01-02')->hoursUntil(endDate: '2019-02-05', factor: 12);");
+        $period = eval("return \\$carbonClass::create('2019-01-02')->hoursUntil(endDate: '2019-02-05', factor: 12);");
+        $this->assertInstanceOf($periodClass, $period);
         $this->assertSame('2019-01-02', $period->getStartDate()->format('Y-m-d'));
         $this->assertSame('2019-02-05', $period->getEndDate()->format('Y-m-d'));
         $this->assertSame('12 hours', (string) $period->getDateInterval());
@@ -657,22 +685,32 @@ class CreateTest extends AbstractTestCase
 
     public function testCast()
     {
-        $period = new class('2012-07-01', CarbonInterval::days(2), '2012-07-07') extends CarbonPeriod {
-            public function foo()
-            {
-                return $this->getStartDate()->format('j').' '.
-                    $this->getDateInterval()->format('%d').' '.
-                    $this->getEndDate()->format('j');
-            }
-        };
+        $periodClass = $this->periodClass;
+        $period = $periodClass === CarbonPeriodImmutable::class
+            ? (new class('2012-07-01', CarbonInterval::days(2), '2012-07-07') extends CarbonPeriodImmutable {
+                public function foo()
+                {
+                    return $this->getStartDate()->format('j').' '.
+                        $this->getDateInterval()->format('%d').' '.
+                        $this->getEndDate()->format('j');
+                }
+            })
+            : (new class('2012-07-01', CarbonInterval::days(2), '2012-07-07') extends CarbonPeriod {
+                public function foo()
+                {
+                    return $this->getStartDate()->format('j').' '.
+                        $this->getDateInterval()->format('%d').' '.
+                        $this->getEndDate()->format('j');
+                }
+            });
         $subClass = \get_class($period);
 
-        $this->assertInstanceOf(CarbonPeriod::class, $period);
-        $this->assertNotSame(CarbonPeriod::class, $subClass);
+        $this->assertInstanceOf($periodClass, $period);
+        $this->assertNotSame($periodClass, $subClass);
         $this->assertSame('1 2 7', $period->foo());
 
         /** @var object $period */
-        $period = CarbonPeriod::create('2010-08-24', CarbonInterval::weeks(2), '2012-07-19')
+        $period = $periodClass::create('2010-08-24', CarbonInterval::weeks(2), '2012-07-19')
             ->cast($subClass);
 
         $this->assertInstanceOf($subClass, $period);
@@ -685,34 +723,36 @@ class CreateTest extends AbstractTestCase
             'DateTime has not the instance() method needed to cast the date.'
         ));
 
-        CarbonPeriod::create('2010-08-24', CarbonInterval::weeks(2), '2012-07-19')
+        $periodClass = $this->periodClass;
+        $periodClass::create('2010-08-24', CarbonInterval::weeks(2), '2012-07-19')
             ->cast(DateTime::class);
     }
 
     public function testMake()
     {
-        $period = CarbonPeriod::make(new DatePeriod(
+        $periodClass = $this->periodClass;
+        $period = $periodClass::make(new DatePeriod(
             new DateTime('2012-07-01'),
             CarbonInterval::days(2),
             new DateTime('2012-07-07')
         ));
 
-        $this->assertInstanceOf(CarbonPeriod::class, $period);
+        $this->assertInstanceOf($periodClass, $period);
         $this->assertSame('2012-07-01', $period->getStartDate()->format('Y-m-d'));
         $this->assertSame(2, $period->getDateInterval()->d);
         $this->assertSame('2012-07-07', $period->getEndDate()->format('Y-m-d'));
 
-        $period2 = CarbonPeriod::make($period);
+        $period2 = $periodClass::make($period);
 
-        $this->assertInstanceOf(CarbonPeriod::class, $period2);
+        $this->assertInstanceOf($periodClass, $period2);
         $this->assertSame('2012-07-01', $period2->getStartDate()->format('Y-m-d'));
         $this->assertSame(2, $period2->getDateInterval()->d);
         $this->assertSame('2012-07-07', $period2->getEndDate()->format('Y-m-d'));
         $this->assertNotSame($period, $period2);
 
-        $period2 = CarbonPeriod::make('2012-07-01/P2D/2012-07-07');
+        $period2 = $periodClass::make('2012-07-01/P2D/2012-07-07');
 
-        $this->assertInstanceOf(CarbonPeriod::class, $period2);
+        $this->assertInstanceOf($periodClass, $period2);
         $this->assertSame('2012-07-01', $period2->getStartDate()->format('Y-m-d'));
         $this->assertSame(2, $period2->getDateInterval()->d);
         $this->assertSame('2012-07-07', $period2->getEndDate()->format('Y-m-d'));
@@ -725,7 +765,8 @@ class CreateTest extends AbstractTestCase
             'must be an instance of DatePeriod or Carbon\CarbonPeriod, string given.'
         ));
 
-        CarbonPeriod::instance('hello');
+        $periodClass = $this->periodClass;
+        $periodClass::instance('hello');
     }
 
     public function testInstanceInvalidInstance()
@@ -735,6 +776,7 @@ class CreateTest extends AbstractTestCase
             'must be an instance of DatePeriod or Carbon\CarbonPeriod, instance of Carbon\Carbon given.'
         ));
 
-        CarbonPeriod::instance(Carbon::now());
+        $periodClass = $this->periodClass;
+        $periodClass::instance(Carbon::now());
     }
 }

--- a/tests/CarbonPeriod/DynamicIntervalTest.php
+++ b/tests/CarbonPeriod/DynamicIntervalTest.php
@@ -14,13 +14,13 @@ declare(strict_types=1);
 namespace Tests\CarbonPeriod;
 
 use Carbon\Carbon;
-use Carbon\CarbonPeriod;
 use Tests\AbstractTestCase;
 
 class DynamicIntervalTest extends AbstractTestCase
 {
     public function testDynamicIntervalInPeriod()
     {
+        $periodClass = $this->periodClass;
         $weekDayStep = function (Carbon $date, bool $negated = false): Carbon {
             if ($negated) {
                 return $date->previousWeekDay();
@@ -28,7 +28,7 @@ class DynamicIntervalTest extends AbstractTestCase
 
             return $date->nextWeekDay();
         };
-        $period = CarbonPeriod::create('2020-06-01', $weekDayStep, '2020-06-14');
+        $period = $periodClass::create('2020-06-01', $weekDayStep, '2020-06-14');
         $dates = [];
 
         foreach ($period as $date) {

--- a/tests/CarbonPeriod/FilterTest.php
+++ b/tests/CarbonPeriod/FilterTest.php
@@ -34,7 +34,8 @@ class FilterTest extends AbstractTestCase
 
     public function testGetAndSetFilters()
     {
-        $period = new CarbonPeriod();
+        $periodClass = $this->periodClass;
+        $period = new $periodClass();
 
         $this->assertSame([], $period->getFilters());
         $this->assertSame($period, $period->setFilters($filters = [
@@ -45,7 +46,8 @@ class FilterTest extends AbstractTestCase
 
     public function testUpdateInternalStateWhenBuiltInFiltersAreRemoved()
     {
-        $period = new CarbonPeriod(
+        $periodClass = $this->periodClass;
+        $period = new $periodClass(
             $start = new DateTime('2018-04-16'),
             $end = new DateTime('2018-07-15')
         );
@@ -64,7 +66,8 @@ class FilterTest extends AbstractTestCase
 
     public function testResetFilters()
     {
-        $period = new CarbonPeriod(
+        $periodClass = $this->periodClass;
+        $period = new $periodClass(
             $start = new DateTime('2018-04-16'),
             $end = new DateTime('2018-07-15')
         );
@@ -75,13 +78,14 @@ class FilterTest extends AbstractTestCase
         $this->assertSame($period, $period->resetFilters());
 
         $this->assertSame([
-            [CarbonPeriod::END_DATE_FILTER, null],
+            [$periodClass::END_DATE_FILTER, null],
         ], $period->getFilters());
     }
 
     public function testAddAndPrependFilters()
     {
-        $period = new CarbonPeriod();
+        $periodClass = $this->periodClass;
+        $period = new $periodClass();
 
         $period->addFilter($filter1 = $this->dummyFilter())
             ->addFilter($filter2 = $this->dummyFilter())
@@ -96,7 +100,8 @@ class FilterTest extends AbstractTestCase
 
     public function testRemoveFilterByInstance()
     {
-        $period = new CarbonPeriod();
+        $periodClass = $this->periodClass;
+        $period = new $periodClass();
 
         $period->addFilter($filter1 = $this->dummyFilter())
             ->addFilter($filter2 = $this->dummyFilter())
@@ -112,7 +117,8 @@ class FilterTest extends AbstractTestCase
 
     public function testRemoveFilterByName()
     {
-        $period = new CarbonPeriod();
+        $periodClass = $this->periodClass;
+        $period = new $periodClass();
 
         $period->addFilter($filter1 = $this->dummyFilter())
             ->addFilter($filter2 = $this->dummyFilter(), 'foo')
@@ -131,12 +137,14 @@ class FilterTest extends AbstractTestCase
 
     public function testAcceptOnlyWeekdays()
     {
+        $periodClass = $this->periodClass;
+
         Carbon::setWeekendDays([
             Carbon::SATURDAY,
             Carbon::SUNDAY,
         ]);
 
-        $period = CarbonPeriod::create('R4/2018-04-14T00:00:00/P4D');
+        $period = $periodClass::create('R4/2018-04-14T00:00:00/P4D');
 
         $period->addFilter(function ($date) {
             return $date->isWeekday();
@@ -153,7 +161,8 @@ class FilterTest extends AbstractTestCase
      */
     public function testAcceptOnlySingleYear()
     {
-        $period = new CarbonPeriod(
+        $periodClass = $this->periodClass;
+        $period = new $periodClass(
             new DateTime('2017-04-16'),
             new DateInterval('P5M'),
             new DateTime('2019-07-15')
@@ -174,14 +183,15 @@ class FilterTest extends AbstractTestCase
      */
     public function testEndIteration()
     {
-        $period = new CarbonPeriod(
+        $periodClass = $this->periodClass;
+        $period = new $periodClass(
             new DateTime('2018-04-16'),
             new DateInterval('P3D'),
             new DateTime('2018-07-15')
         );
 
-        $period->addFilter(function ($date) {
-            return $date->month === 5 ? CarbonPeriod::END_ITERATION : true;
+        $period->addFilter(function ($date) use ($periodClass) {
+            return $date->month === 5 ? $periodClass::END_ITERATION : true;
         });
 
         $this->assertSame(
@@ -192,26 +202,27 @@ class FilterTest extends AbstractTestCase
 
     public function testRecurrences()
     {
-        $period = new CarbonPeriod(
+        $periodClass = $this->periodClass;
+        $period = new $periodClass(
             new DateTime('2018-04-16'),
             new DateTime('2018-07-15')
         );
 
-        $period->setRecurrences(2);
+        $period = $period->setRecurrences(2);
 
         $this->assertSame(
             $this->standardizeDates(['2018-04-16', '2018-04-17']),
             $this->standardizeDates($period)
         );
 
-        $period->setOptions(CarbonPeriod::EXCLUDE_START_DATE);
+        $period = $period->setOptions($periodClass::EXCLUDE_START_DATE);
 
         $this->assertSame(
             $this->standardizeDates(['2018-04-17', '2018-04-18']),
             $this->standardizeDates($period)
         );
 
-        $period->setOptions(CarbonPeriod::EXCLUDE_END_DATE);
+        $period = $period->setOptions($periodClass::EXCLUDE_END_DATE);
 
         $this->assertSame(
             $this->standardizeDates(['2018-04-16', '2018-04-17']),
@@ -221,12 +232,13 @@ class FilterTest extends AbstractTestCase
 
     public function testChangeNumberOfRecurrences()
     {
-        $period = new CarbonPeriod(
+        $periodClass = $this->periodClass;
+        $period = new $periodClass(
             new DateTime('2018-04-16'),
             new DateTime('2018-07-15')
         );
 
-        $period->setRecurrences(7)
+        $period = $period->setRecurrences(7)
             ->setRecurrences(1)
             ->setRecurrences(3);
 
@@ -238,7 +250,8 @@ class FilterTest extends AbstractTestCase
 
     public function testCallbackArguments()
     {
-        $period = new CarbonPeriod(
+        $periodClass = $this->periodClass;
+        $period = new $periodClass(
             new DateTime('2018-04-16'),
             1
         );
@@ -246,7 +259,7 @@ class FilterTest extends AbstractTestCase
         $wasCalled = false;
 
         $test = $this;
-        $period->addFilter(function ($current, $key, $iterator) use (&$wasCalled, $period, $test) {
+        $period = $period->addFilter(function ($current, $key, $iterator) use (&$wasCalled, $period, $test) {
             $test->assertInstanceOfCarbon($current);
             $test->assertIsInt($key);
             $test->assertSame($period, $iterator);
@@ -265,13 +278,14 @@ class FilterTest extends AbstractTestCase
             'Could not find next valid date.'
         ));
 
-        $period = CarbonPeriod::create(
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create(
             new Carbon('2000-01-01'),
             new CarbonInterval('PT1S'),
             new Carbon('2000-12-31')
         );
 
-        $period->addFilter(function () {
+        $period = $period->addFilter(function () {
             return false;
         });
 
@@ -280,7 +294,8 @@ class FilterTest extends AbstractTestCase
 
     public function testRemoveBuildInFilters()
     {
-        $period = CarbonPeriod::create(new DateTime('2018-04-16'), new DateTime('2018-07-15'))->setRecurrences(3);
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create(new DateTime('2018-04-16'), new DateTime('2018-07-15'))->setRecurrences(3);
 
         $period->setEndDate(null);
         $period->setRecurrences(null);
@@ -290,14 +305,15 @@ class FilterTest extends AbstractTestCase
 
     public function testAcceptEveryOther()
     {
-        $period = new CarbonPeriod(
+        $periodClass = $this->periodClass;
+        $period = new $periodClass(
             new DateTime('2018-04-16'),
             new DateTime('2018-04-20')
         );
 
         // Note: Without caching validation results the dates would be unpredictable
         // as we cannot know how many calls to the filter will occur per iteration.
-        $period->addFilter(function ($date) {
+        $period = $period->addFilter(function ($date) {
             static $accept;
 
             return $accept = !$accept;
@@ -311,16 +327,17 @@ class FilterTest extends AbstractTestCase
 
     public function testEndIterationFilter()
     {
-        $period = new CarbonPeriod('2018-04-16', 5);
+        $periodClass = $this->periodClass;
+        $period = new $periodClass('2018-04-16', 5);
 
-        $period->addFilter(CarbonPeriod::END_ITERATION);
+        $period->addFilter($periodClass::END_ITERATION);
 
         $this->assertEmpty($this->standardizeDates($period));
     }
 
     public function testAcceptOnlyEvenDays()
     {
-        $period = CarbonPeriodFactory::withEvenDaysFilter();
+        $period = CarbonPeriodFactory::withEvenDaysFilter($this->periodClass);
 
         $this->assertSame(
             $this->standardizeDates(['2012-07-04', '2012-07-10', '2012-07-16']),
@@ -330,7 +347,8 @@ class FilterTest extends AbstractTestCase
 
     public function testAddFilterFromCarbonMethod()
     {
-        $period = CarbonPeriod::create('2018-01-01', '2018-06-01');
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('2018-01-01', '2018-06-01');
 
         $period->addFilter('isLastOfMonth');
 
@@ -342,7 +360,8 @@ class FilterTest extends AbstractTestCase
 
     public function testAddFilterFromCarbonMacro()
     {
-        $period = CarbonPeriod::create('2018-01-01', '2018-06-01');
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('2018-01-01', '2018-06-01');
 
         Carbon::macro('isTenDay', function () {
             /** @var Carbon $date */

--- a/tests/CarbonPeriod/Fixtures/CarbonPeriodFactory.php
+++ b/tests/CarbonPeriod/Fixtures/CarbonPeriodFactory.php
@@ -18,77 +18,85 @@ use Carbon\CarbonPeriod;
 class CarbonPeriodFactory
 {
     /**
-     * @return CarbonPeriod
+     * @template T of CarbonPeriod
+     *
+     * @param class-string<T> $periodClass
+     *
+     * @return T
      */
-    public static function withStartIntervalEnd()
+    public static function withStartIntervalEnd(string $periodClass)
     {
-        $period = CarbonPeriod::create(
+        return $periodClass::create(
             '2012-07-01 17:30:00',
             'P3DT5H',
             '2012-07-15 11:15:00'
         );
-
-        return $period;
     }
 
     /**
-     * @return CarbonPeriod
+     * @template T of CarbonPeriod
+     *
+     * @param class-string<T> $periodClass
+     *
+     * @return T
      */
-    public static function withEvenDaysFilter()
+    public static function withEvenDaysFilter(string $periodClass)
     {
-        $period = CarbonPeriod::create(
+        $period = $periodClass::create(
             '2012-07-01',
             'P3D',
             '2012-07-22',
-            CarbonPeriod::EXCLUDE_END_DATE
+            $periodClass::EXCLUDE_END_DATE
         );
 
-        $period->addFilter(function ($date) {
+        return $period->addFilter(function ($date) {
             return $date->day % 2 == 0;
         });
-
-        return $period;
     }
 
     /**
-     * @return CarbonPeriod
+     * @template T of CarbonPeriod
+     *
+     * @param class-string<T> $periodClass
+     *
+     * @return T
      */
-    public static function withCounter(&$counter)
+    public static function withCounter(string $periodClass, &$counter)
     {
         $counter = 0;
 
-        $period = CarbonPeriod::create(
+        $period = $periodClass::create(
             '2012-10-01',
             3
         );
 
-        $period->addFilter(function () use (&$counter) {
+        return $period->addFilter(function () use (&$counter) {
             $counter++;
 
             return true;
         });
-
-        return $period;
     }
 
     /**
-     * @return CarbonPeriod
+     * @template T of CarbonPeriod
+     *
+     * @param class-string<T> $periodClass
+     *
+     * @return T
      */
-    public static function withStackFilter()
+    public static function withStackFilter(string $periodClass)
     {
-        $period = CarbonPeriod::create(
+        $period = $periodClass::create(
             '2001-01-01'
         );
 
         $stack = [
-            true, false, true, CarbonPeriod::END_ITERATION,
-            false, false, true, true, CarbonPeriod::END_ITERATION,
+            true, false, true, $periodClass::END_ITERATION,
+            false, false, true, true, $periodClass::END_ITERATION,
         ];
 
-        $period->addFilter(function () use (&$stack) {
+        return $period->addFilter(function () use (&$stack) {
             return array_shift($stack);
         });
-
-        return $period;
     }
 }

--- a/tests/CarbonPeriod/GettersTest.php
+++ b/tests/CarbonPeriod/GettersTest.php
@@ -27,7 +27,7 @@ class GettersTest extends AbstractTestCase
 {
     public function testGetStartDate()
     {
-        $period = CarbonPeriodFactory::withStartIntervalEnd();
+        $period = CarbonPeriodFactory::withStartIntervalEnd($this->periodClass);
 
         $date = $period->getStartDate();
 
@@ -38,7 +38,7 @@ class GettersTest extends AbstractTestCase
 
     public function testGetEndDate()
     {
-        $period = CarbonPeriodFactory::withStartIntervalEnd();
+        $period = CarbonPeriodFactory::withStartIntervalEnd($this->periodClass);
 
         $date = $period->getEndDate();
 
@@ -49,7 +49,7 @@ class GettersTest extends AbstractTestCase
 
     public function testGetDateInterval()
     {
-        $period = CarbonPeriodFactory::withStartIntervalEnd();
+        $period = CarbonPeriodFactory::withStartIntervalEnd($this->periodClass);
 
         $interval = $period->getDateInterval();
 
@@ -76,7 +76,7 @@ class GettersTest extends AbstractTestCase
 
     public function testModifyStartDate()
     {
-        $period = CarbonPeriodFactory::withStartIntervalEnd();
+        $period = CarbonPeriodFactory::withStartIntervalEnd($this->periodClass);
 
         $period->getStartDate()->subDays(3);
 
@@ -85,7 +85,7 @@ class GettersTest extends AbstractTestCase
 
     public function testModifyEndDate()
     {
-        $period = CarbonPeriodFactory::withStartIntervalEnd();
+        $period = CarbonPeriodFactory::withStartIntervalEnd($this->periodClass);
 
         $period->getEndDate()->addDays(3);
 
@@ -94,7 +94,7 @@ class GettersTest extends AbstractTestCase
 
     public function testModifyDateInterval()
     {
-        $period = CarbonPeriodFactory::withStartIntervalEnd();
+        $period = CarbonPeriodFactory::withStartIntervalEnd($this->periodClass);
 
         $period->getDateInterval()->days(5)->hours(0);
 

--- a/tests/CarbonPeriod/IteratorTest.php
+++ b/tests/CarbonPeriod/IteratorTest.php
@@ -26,7 +26,7 @@ class IteratorTest extends AbstractTestCase
 
     public function testKeyAndCurrentAreCorrectlyInstantiated()
     {
-        $period = CarbonPeriodFactory::withEvenDaysFilter();
+        $period = CarbonPeriodFactory::withEvenDaysFilter($this->periodClass);
 
         $this->assertSame(0, $period->key());
         $this->assertInstanceOfCarbon($period->current());
@@ -36,14 +36,14 @@ class IteratorTest extends AbstractTestCase
 
     public function testValidIsCorrectlyInstantiated()
     {
-        $period = CarbonPeriodFactory::withEvenDaysFilter();
+        $period = CarbonPeriodFactory::withEvenDaysFilter($this->periodClass);
 
         $this->assertTrue($period->valid());
     }
 
     public function testCurrentIsAlwaysCarbonInstance()
     {
-        $period = CarbonPeriodFactory::withEvenDaysFilter();
+        $period = CarbonPeriodFactory::withEvenDaysFilter($this->periodClass);
 
         foreach ($period as $key => $current) {
             $this->assertInstanceOfCarbon($current);
@@ -56,7 +56,7 @@ class IteratorTest extends AbstractTestCase
     {
         $keys = [];
 
-        $period = CarbonPeriodFactory::withEvenDaysFilter();
+        $period = CarbonPeriodFactory::withEvenDaysFilter($this->periodClass);
 
         foreach ($period as $key => $current) {
             $this->assertIsInt($keys[] = $key);
@@ -68,7 +68,7 @@ class IteratorTest extends AbstractTestCase
 
     public function testElementsInLoopAreAlwaysValid()
     {
-        $period = CarbonPeriodFactory::withEvenDaysFilter();
+        $period = CarbonPeriodFactory::withEvenDaysFilter($this->periodClass);
 
         foreach ($period as $key => $current) {
             $this->assertTrue($period->valid());
@@ -77,7 +77,7 @@ class IteratorTest extends AbstractTestCase
 
     public function testKeyAndCurrentAreCorrectlyIterated()
     {
-        $period = CarbonPeriodFactory::withEvenDaysFilter();
+        $period = CarbonPeriodFactory::withEvenDaysFilter($this->periodClass);
 
         $period->next();
 
@@ -88,7 +88,7 @@ class IteratorTest extends AbstractTestCase
 
     public function testKeyAndCurrentAreCorrectlyRewound()
     {
-        $period = CarbonPeriodFactory::withEvenDaysFilter();
+        $period = CarbonPeriodFactory::withEvenDaysFilter($this->periodClass);
 
         $period->next();
         $period->rewind();
@@ -100,7 +100,7 @@ class IteratorTest extends AbstractTestCase
 
     public function testKeyAndCurrentAreNullAfterIteration()
     {
-        $period = CarbonPeriodFactory::withEvenDaysFilter();
+        $period = CarbonPeriodFactory::withEvenDaysFilter($this->periodClass);
 
         foreach ($period as $key => $current) {
             //
@@ -116,12 +116,13 @@ class IteratorTest extends AbstractTestCase
      */
     public function testIterateBackwards($arguments, $expected)
     {
-        $period = CarbonPeriod::create(...$arguments);
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create(...$arguments);
 
         $interval = new CarbonInterval('P3D');
         $interval->invert = 1;
 
-        $period->setDateInterval($interval);
+        $period = $period->setDateInterval($interval);
 
         $this->assertSame(
             $this->standardizeDates($expected),
@@ -155,12 +156,13 @@ class IteratorTest extends AbstractTestCase
 
     public function testChangingParametersShouldNotCauseInfiniteLoop()
     {
-        $period = CarbonPeriod::create()
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create()
             ->setStartDate($start = '2012-07-01')
             ->setEndDate($end = '2012-07-20')
             ->setDateInterval($interval = 'P1D')
             ->setRecurrences($recurrences = 10)
-            ->setOptions($options = CarbonPeriod::EXCLUDE_START_DATE | CarbonPeriod::EXCLUDE_END_DATE)
+            ->setOptions($options = $periodClass::EXCLUDE_START_DATE | $periodClass::EXCLUDE_END_DATE)
             ->addFilter($filter = function () {
                 return true;
             });
@@ -190,7 +192,7 @@ class IteratorTest extends AbstractTestCase
 
     public function testChangeEndDateDuringIteration()
     {
-        $period = CarbonPeriodFactory::withEvenDaysFilter();
+        $period = CarbonPeriodFactory::withEvenDaysFilter($this->periodClass);
 
         $results = [];
 
@@ -198,7 +200,7 @@ class IteratorTest extends AbstractTestCase
             $results[] = sprintf('%s => %s', $key, $current->toDateString());
 
             if ($current->toDateString() === '2012-07-16') {
-                $period->setEndDate($current);
+                $period = $period->setEndDate($current);
 
                 // Note: Current is no longer valid, because it is now equal to end, which is excluded.
                 $this->assertNull($period->key());
@@ -307,7 +309,7 @@ class IteratorTest extends AbstractTestCase
 
     public function testValidateOncePerIteration()
     {
-        $period = CarbonPeriodFactory::withCounter($counter);
+        $period = CarbonPeriodFactory::withCounter($this->periodClass, $counter);
 
         $period->key();
         $period->current();
@@ -325,18 +327,19 @@ class IteratorTest extends AbstractTestCase
 
     public function testInvalidateCurrentAfterChangingParameters()
     {
-        $period = CarbonPeriod::create('2012-10-01');
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('2012-10-01');
 
         $this->assertInstanceOfCarbon($period->current());
 
-        $period->addFilter(CarbonPeriod::END_ITERATION);
+        $period = $period->addFilter($periodClass::END_ITERATION);
 
         $this->assertNull($period->current());
     }
 
     public function testTraversePeriodDynamically()
     {
-        $period = CarbonPeriodFactory::withEvenDaysFilter();
+        $period = CarbonPeriodFactory::withEvenDaysFilter($this->periodClass);
 
         $results = [];
 
@@ -358,7 +361,8 @@ class IteratorTest extends AbstractTestCase
 
     public function testExtendCompletedIteration()
     {
-        $period = CarbonPeriod::create('2018-10-10', '2018-10-11');
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('2018-10-10', '2018-10-11');
 
         $results = [];
 
@@ -368,7 +372,7 @@ class IteratorTest extends AbstractTestCase
             $period->next();
         }
 
-        $period->setEndDate('2018-10-13');
+        $period = $period->setEndDate('2018-10-13');
 
         while ($period->valid()) {
             $results[] = $period->current();
@@ -384,51 +388,54 @@ class IteratorTest extends AbstractTestCase
 
     public function testRevalidateCurrentAfterChangeOfParameters()
     {
-        $period = CarbonPeriod::create()->setStartDate($start = new Carbon('2018-10-28'));
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create()->setStartDate($start = new Carbon('2018-10-28'));
         $this->assertEquals($start, $period->current());
         $this->assertNotSame($start, $period->current());
 
-        $period->addFilter($excludeStart = function ($date) use ($start) {
+        $period = $period->addFilter($excludeStart = function ($date) use ($start) {
             return $date != $start;
         });
         $this->assertNull($period->current());
 
-        $period->removeFilter($excludeStart);
+        $period = $period->removeFilter($excludeStart);
         $this->assertEquals($start, $period->current());
         $this->assertNotSame($start, $period->current());
     }
 
     public function testRevalidateCurrentAfterEndOfIteration()
     {
-        $period = CarbonPeriod::create()->setStartDate($start = new Carbon('2018-10-28'));
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create()->setStartDate($start = new Carbon('2018-10-28'));
         $this->assertEquals($start, $period->current());
         $this->assertNotSame($start, $period->current());
 
-        $period->addFilter(CarbonPeriod::END_ITERATION);
+        $period = $period->addFilter($periodClass::END_ITERATION);
         $this->assertNull($period->current());
 
-        $period->removeFilter(CarbonPeriod::END_ITERATION);
+        $period = $period->removeFilter($periodClass::END_ITERATION);
         $this->assertEquals($start, $period->current());
         $this->assertNotSame($start, $period->current());
     }
 
     public function testChangeStartDateBeforeIteration()
     {
-        $period = CarbonPeriod::create(new Carbon('2018-10-05'), 3);
-
-        $period->setStartDate(new Carbon('2018-10-13'));
-        $period->toggleOptions(CarbonPeriod::EXCLUDE_START_DATE, true);
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create(new Carbon('2018-10-05'), 3)
+            ->setStartDate(new Carbon('2018-10-13'))
+            ->toggleOptions($periodClass::EXCLUDE_START_DATE, true);
 
         $this->assertEquals(new Carbon('2018-10-14'), $period->current());
     }
 
     public function testChangeStartDateAfterStartedIteration()
     {
-        $period = CarbonPeriod::create(new Carbon('2018-10-05'), 3);
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create(new Carbon('2018-10-05'), 3);
 
         $current = $period->current();
 
-        $period->toggleOptions(CarbonPeriod::EXCLUDE_START_DATE, true);
+        $period->toggleOptions($periodClass::EXCLUDE_START_DATE, true);
         $period->setStartDate(new Carbon('2018-10-13'));
 
         $this->assertEquals($current, $period->current());
@@ -436,7 +443,8 @@ class IteratorTest extends AbstractTestCase
 
     public function testInvertDateIntervalDuringIteration()
     {
-        $period = new CarbonPeriod('2018-04-11', 5);
+        $periodClass = $this->periodClass;
+        $period = new $periodClass('2018-04-11', 5);
 
         $results = [];
 
@@ -456,7 +464,7 @@ class IteratorTest extends AbstractTestCase
 
     public function testManualIteration()
     {
-        $period = CarbonPeriodFactory::withStackFilter();
+        $period = CarbonPeriodFactory::withStackFilter($this->periodClass);
         $period->rewind();
         $str = '';
         while ($period->valid()) {
@@ -472,7 +480,8 @@ class IteratorTest extends AbstractTestCase
 
     public function testSkip()
     {
-        $period = CarbonPeriod::create('2018-05-30', '2018-07-13');
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('2018-05-30', '2018-07-13');
         $output = [];
 
         foreach ($period as $day) {
@@ -522,7 +531,7 @@ class IteratorTest extends AbstractTestCase
     public function testLocale()
     {
         /** @var CarbonPeriod $period */
-        $period = CarbonPeriodFactory::withStackFilter()->locale('de');
+        $period = CarbonPeriodFactory::withStackFilter($this->periodClass)->locale('de');
         $str = '';
 
         foreach ($period as $key => $date) {
@@ -538,7 +547,7 @@ class IteratorTest extends AbstractTestCase
 
     public function testTimezone()
     {
-        $period = CarbonPeriodFactory::withStackFilter()->shiftTimezone('America/Toronto');
+        $period = CarbonPeriodFactory::withStackFilter($this->periodClass)->shiftTimezone('America/Toronto');
         $str = null;
 
         foreach ($period as $key => $date) {

--- a/tests/CarbonPeriod/RoundingTest.php
+++ b/tests/CarbonPeriod/RoundingTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Tests\CarbonPeriod;
 
 use Carbon\CarbonInterval;
-use Carbon\CarbonPeriod;
 use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
@@ -26,50 +25,52 @@ class RoundingTest extends AbstractTestCase
             'Rounding is only possible with single unit intervals.'
         ));
 
-        CarbonPeriod::days(2)->round('2 hours 50 minutes');
+        $periodClass = $this->periodClass;
+        $periodClass::days(2)->round('2 hours 50 minutes');
     }
 
     public function testFloor()
     {
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817')->floor();
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817')->floor();
 
         $this->assertSame('01 00:00:00.000000', $period->getDateInterval()->format('%D %H:%I:%S.%F'));
         $this->assertSame('2019-02-01 00:00:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 00:00:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '1 hour')->floor();
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '1 hour')->floor();
 
         $this->assertSame('2019-02-01 12:00:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 03:00:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '2 hours')->floor();
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '2 hours')->floor();
 
         $this->assertSame('2019-02-01 12:00:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 02:00:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817')->floor('hour');
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817')->floor('hour');
 
         $this->assertSame('01 00:00:00.000000', $period->getDateInterval()->format('%D %H:%I:%S.%F'));
         $this->assertSame('2019-02-01 12:00:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 03:00:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '140 minutes')->floor('hour');
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '140 minutes')->floor('hour');
 
         $this->assertSame('00 02:00:00.000000', $period->getDateInterval()->format('%D %H:%I:%S.%F'));
         $this->assertSame('2019-02-01 12:00:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 03:00:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '1 hour')->floor(CarbonInterval::minutes(15));
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '1 hour')->floor(CarbonInterval::minutes(15));
 
         $this->assertSame('2019-02-01 12:45:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 03:00:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '2 hours')->floorUnit('minute', 10);
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '2 hours')->floorUnit('minute', 10);
 
         $this->assertSame('2019-02-01 12:50:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 03:10:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '2 hours')->floorMinutes(10);
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '2 hours')->floorMinutes(10);
 
         $this->assertSame('2019-02-01 12:50:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 03:10:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
@@ -77,45 +78,46 @@ class RoundingTest extends AbstractTestCase
 
     public function testCeil()
     {
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817')->ceil();
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817')->ceil();
 
         $this->assertSame('01 00:00:00.000000', $period->getDateInterval()->format('%D %H:%I:%S.%F'));
         $this->assertSame('2019-02-02 00:00:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-13 00:00:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '1 hour')->ceil();
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '1 hour')->ceil();
 
         $this->assertSame('2019-02-01 13:00:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 04:00:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '2 hours')->ceil();
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '2 hours')->ceil();
 
         $this->assertSame('2019-02-01 14:00:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 04:00:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817')->ceil('hour');
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817')->ceil('hour');
 
         $this->assertSame('01 00:00:00.000000', $period->getDateInterval()->format('%D %H:%I:%S.%F'));
         $this->assertSame('2019-02-01 13:00:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 04:00:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '140 minutes')->ceil('hour');
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '140 minutes')->ceil('hour');
 
         $this->assertSame('00 03:00:00.000000', $period->getDateInterval()->format('%D %H:%I:%S.%F'));
         $this->assertSame('2019-02-01 13:00:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 04:00:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '1 hour')->ceil(CarbonInterval::minutes(15));
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '1 hour')->ceil(CarbonInterval::minutes(15));
 
         $this->assertSame('2019-02-01 13:00:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 03:15:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '2 hours')->ceilUnit('minute', 10);
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '2 hours')->ceilUnit('minute', 10);
 
         $this->assertSame('2019-02-01 13:00:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 03:20:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '2 hours')->ceilMinutes(10);
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '2 hours')->ceilMinutes(10);
 
         $this->assertSame('2019-02-01 13:00:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 03:20:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
@@ -123,45 +125,46 @@ class RoundingTest extends AbstractTestCase
 
     public function testRound()
     {
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817')->round();
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817')->round();
 
         $this->assertSame('01 00:00:00.000000', $period->getDateInterval()->format('%D %H:%I:%S.%F'));
         $this->assertSame('2019-02-02 00:00:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 00:00:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '1 hour')->round();
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '1 hour')->round();
 
         $this->assertSame('2019-02-01 13:00:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 03:00:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '2 hours')->round();
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '2 hours')->round();
 
         $this->assertSame('2019-02-01 12:00:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 04:00:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817')->round('hour');
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817')->round('hour');
 
         $this->assertSame('01 00:00:00.000000', $period->getDateInterval()->format('%D %H:%I:%S.%F'));
         $this->assertSame('2019-02-01 13:00:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 03:00:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '140 minutes')->round('hour');
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '140 minutes')->round('hour');
 
         $this->assertSame('00 02:00:00.000000', $period->getDateInterval()->format('%D %H:%I:%S.%F'));
         $this->assertSame('2019-02-01 13:00:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 03:00:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '1 hour')->round(CarbonInterval::minutes(15));
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '1 hour')->round(CarbonInterval::minutes(15));
 
         $this->assertSame('2019-02-01 12:45:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 03:15:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '2 hours')->roundUnit('minute', 10);
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '2 hours')->roundUnit('minute', 10);
 
         $this->assertSame('2019-02-01 12:50:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 03:10:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '2 hours')->roundMinutes(10);
+        $period = $periodClass::create('2019-02-01 12:52:23', '2019-12-12 03:12:44.817', '2 hours')->roundMinutes(10);
 
         $this->assertSame('2019-02-01 12:50:00.000000', $period->getStartDate()->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-12-12 03:10:00.000000', $period->getEndDate()->format('Y-m-d H:i:s.u'));
@@ -169,12 +172,13 @@ class RoundingTest extends AbstractTestCase
 
     public function testRoundCalculatedEnd()
     {
-        $period = CarbonPeriod::create('2019-02-01 12:52:23.123456', '3 hours')->setRecurrences(3);
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('2019-02-01 12:52:23.123456', '3 hours')->setRecurrences(3);
 
         $this->assertSame('2019-02-01 18:00:00.000000', $period->calculateEnd('round')->format('Y-m-d H:i:s.u'));
         $this->assertSame('2019-02-01 18:52:23.123456', $period->calculateEnd()->format('Y-m-d H:i:s.u'));
 
-        $period = CarbonPeriod::create('2019-02-01 12:52:23.123456', '3 hours')
+        $period = $periodClass::create('2019-02-01 12:52:23.123456', '3 hours')
             ->setRecurrences(3)
             ->addFilter(function ($date) {
                 return $date->hour % 2;

--- a/tests/CarbonPeriod/SettersTest.php
+++ b/tests/CarbonPeriod/SettersTest.php
@@ -16,7 +16,6 @@ namespace Tests\CarbonPeriod;
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterval;
-use Carbon\CarbonPeriod;
 use DateInterval;
 use DateTime;
 use InvalidArgumentException;
@@ -27,54 +26,60 @@ class SettersTest extends AbstractTestCase
 {
     public function testSetStartDate()
     {
-        $period = new CarbonPeriod();
+        $periodClass = $this->periodClass;
+        $period = new $periodClass();
 
-        $period->setStartDate('2018-03-25');
+        $period = $period->setStartDate('2018-03-25');
 
         $this->assertSame('2018-03-25', $period->getStartDate()->toDateString());
     }
 
     public function testSetEndDate()
     {
-        $period = new CarbonPeriod();
+        $periodClass = $this->periodClass;
+        $period = new $periodClass();
 
-        $period->setEndDate('2018-04-25');
+        $period = $period->setEndDate('2018-04-25');
 
         $this->assertSame('2018-04-25', $period->getEndDate()->toDateString());
     }
 
     public function testSetDateInterval()
     {
-        $period = new CarbonPeriod();
+        $periodClass = $this->periodClass;
+        $period = new $periodClass();
 
-        $period->setDateInterval('P3D');
+        $period = $period->setDateInterval('P3D');
 
         $this->assertSame('P3D', $period->getDateInterval()->spec());
     }
 
     public function testSetDateIntervalFromStringFormat()
     {
-        $period = new CarbonPeriod();
+        $periodClass = $this->periodClass;
+        $period = new $periodClass();
 
-        $period->setDateInterval('1w 3d 4h 32m 23s');
+        $period = $period->setDateInterval('1w 3d 4h 32m 23s');
 
         $this->assertSame('P10DT4H32M23S', $period->getDateInterval()->spec());
     }
 
     public function testSetRecurrences()
     {
-        $period = new CarbonPeriod();
+        $periodClass = $this->periodClass;
+        $period = new $periodClass();
 
-        $period->setRecurrences(5);
+        $period = $period->setRecurrences(5);
 
         $this->assertSame(5, $period->getRecurrences());
     }
 
     public function testSetDates()
     {
-        $period = new CarbonPeriod();
+        $periodClass = $this->periodClass;
+        $period = new $periodClass();
 
-        $period->setDates('2019-04-12', '2019-04-19');
+        $period = $period->setDates('2019-04-12', '2019-04-19');
 
         $this->assertSame('2019-04-12', $period->getStartDate()->toDateString());
         $this->assertSame('2019-04-19', $period->getEndDate()->toDateString());
@@ -82,36 +87,38 @@ class SettersTest extends AbstractTestCase
 
     public function testSetOptions()
     {
-        $period = new CarbonPeriod();
+        $periodClass = $this->periodClass;
+        $period = new $periodClass();
 
-        $period->setOptions($options = CarbonPeriod::EXCLUDE_START_DATE | CarbonPeriod::EXCLUDE_END_DATE);
+        $period = $period->setOptions($options = $periodClass::EXCLUDE_START_DATE | $periodClass::EXCLUDE_END_DATE);
 
         $this->assertSame($options, $period->getOptions());
     }
 
     public function testSetDateClass()
     {
-        $period = new CarbonPeriod('2001-01-01', '2001-01-02');
+        $periodClass = $this->periodClass;
+        $period = new $periodClass('2001-01-01', '2001-01-02');
 
-        $period->setDateClass(CarbonImmutable::class);
+        $period = $period->setDateClass(CarbonImmutable::class);
 
-        $this->assertNotSame(0, $period->getOptions() & CarbonPeriod::IMMUTABLE);
+        $this->assertNotSame(0, $period->getOptions() & $periodClass::IMMUTABLE);
         $this->assertInstanceOf(CarbonImmutable::class, $period->toArray()[0]);
 
-        $period->setDateClass(Carbon::class);
+        $period = $period->setDateClass(Carbon::class);
 
-        $this->assertSame(0, $period->getOptions() & CarbonPeriod::IMMUTABLE);
+        $this->assertSame(0, $period->getOptions() & $periodClass::IMMUTABLE);
         $this->assertInstanceOf(Carbon::class, $period->toArray()[0]);
 
-        $period->toggleOptions(CarbonPeriod::IMMUTABLE, true);
+        $period = $period->toggleOptions($periodClass::IMMUTABLE, true);
         $this->assertSame(CarbonImmutable::class, $period->getDateClass());
         $this->assertInstanceOf(CarbonImmutable::class, $period->toArray()[0]);
 
-        $period->toggleOptions(CarbonPeriod::IMMUTABLE, false);
+        $period = $period->toggleOptions($periodClass::IMMUTABLE, false);
         $this->assertSame(Carbon::class, $period->getDateClass());
         $this->assertInstanceOf(Carbon::class, $period->toArray()[0]);
 
-        $period->setDateClass(AbstractCarbon::class);
+        $period = $period->setDateClass(AbstractCarbon::class);
         $this->assertSame(AbstractCarbon::class, $period->getDateClass());
     }
 
@@ -121,7 +128,8 @@ class SettersTest extends AbstractTestCase
             'Given class does not implement Carbon\CarbonInterface: Carbon\CarbonInterval'
         ));
 
-        $period = new CarbonPeriod('2001-01-01', '2001-01-02');
+        $periodClass = $this->periodClass;
+        $period = new $periodClass('2001-01-01', '2001-01-02');
 
         $period->setDateClass(CarbonInterval::class);
     }
@@ -132,7 +140,8 @@ class SettersTest extends AbstractTestCase
             'Invalid interval.'
         ));
 
-        CarbonPeriod::create()->setDateInterval(new DateTime());
+        $periodClass = $this->periodClass;
+        $periodClass::create()->setDateInterval(new DateTime());
     }
 
     public function testEmptyInterval()
@@ -141,7 +150,8 @@ class SettersTest extends AbstractTestCase
             'Empty interval is not accepted.'
         ));
 
-        CarbonPeriod::create()->setDateInterval(new DateInterval('P0D'));
+        $periodClass = $this->periodClass;
+        $periodClass::create()->setDateInterval(new DateInterval('P0D'));
     }
 
     public function testInvalidNumberOfRecurrencesString()
@@ -150,7 +160,8 @@ class SettersTest extends AbstractTestCase
             'Invalid number of recurrences.'
         ));
 
-        CarbonPeriod::create()->setRecurrences('foo');
+        $periodClass = $this->periodClass;
+        $periodClass::create()->setRecurrences('foo');
     }
 
     public function testInvalidNegativeNumberOfRecurrences()
@@ -159,7 +170,8 @@ class SettersTest extends AbstractTestCase
             'Invalid number of recurrences.'
         ));
 
-        CarbonPeriod::create()->setRecurrences(-4);
+        $periodClass = $this->periodClass;
+        $periodClass::create()->setRecurrences(-4);
     }
 
     public function testInvalidOptions()
@@ -168,7 +180,8 @@ class SettersTest extends AbstractTestCase
             'Invalid options.'
         ));
 
-        CarbonPeriod::create()->setOptions('1');
+        $periodClass = $this->periodClass;
+        $periodClass::create()->setOptions('1');
     }
 
     public function testInvalidConstructorParameters()
@@ -177,7 +190,8 @@ class SettersTest extends AbstractTestCase
             'Invalid constructor parameters.'
         ));
 
-        CarbonPeriod::create([]);
+        $periodClass = $this->periodClass;
+        $periodClass::create([]);
     }
 
     public function testInvalidStartDate()
@@ -186,7 +200,8 @@ class SettersTest extends AbstractTestCase
             'Invalid start date.'
         ));
 
-        CarbonPeriod::create()->setStartDate(new DateInterval('P1D'));
+        $periodClass = $this->periodClass;
+        $periodClass::create()->setStartDate(new DateInterval('P1D'));
     }
 
     public function testInvalidEndDate()
@@ -195,95 +210,101 @@ class SettersTest extends AbstractTestCase
             'Invalid end date.'
         ));
 
-        CarbonPeriod::create()->setEndDate(new DateInterval('P1D'));
+        $periodClass = $this->periodClass;
+        $periodClass::create()->setEndDate(new DateInterval('P1D'));
     }
 
     public function testToggleOptions()
     {
-        $start = CarbonPeriod::EXCLUDE_START_DATE;
-        $end = CarbonPeriod::EXCLUDE_END_DATE;
+        $periodClass = $this->periodClass;
+        $start = $periodClass::EXCLUDE_START_DATE;
+        $end = $periodClass::EXCLUDE_END_DATE;
 
-        $period = new CarbonPeriod();
+        $period = new $periodClass();
 
-        $period->toggleOptions($start, true);
+        $period = $period->toggleOptions($start, true);
         $this->assertSame($start, $period->getOptions());
 
-        $period->toggleOptions($end, true);
+        $period = $period->toggleOptions($end, true);
         $this->assertSame($start | $end, $period->getOptions());
 
-        $period->toggleOptions($start, false);
+        $period = $period->toggleOptions($start, false);
         $this->assertSame($end, $period->getOptions());
 
-        $period->toggleOptions($end, false);
+        $period = $period->toggleOptions($end, false);
         $this->assertEmpty($period->getOptions());
     }
 
     public function testToggleOptionsOnAndOff()
     {
-        $start = CarbonPeriod::EXCLUDE_START_DATE;
-        $end = CarbonPeriod::EXCLUDE_END_DATE;
+        $periodClass = $this->periodClass;
+        $start = $periodClass::EXCLUDE_START_DATE;
+        $end = $periodClass::EXCLUDE_END_DATE;
 
-        $period = new CarbonPeriod();
+        $period = new $periodClass();
 
-        $period->toggleOptions($start);
+        $period = $period->toggleOptions($start);
         $this->assertSame($start, $period->getOptions());
 
-        $period->toggleOptions($start);
+        $period = $period->toggleOptions($start);
         $this->assertEmpty($period->getOptions());
 
-        $period->setOptions($start);
-        $period->toggleOptions($start | $end);
+        $period = $period->setOptions($start);
+        $period = $period->toggleOptions($start | $end);
         $this->assertSame($start | $end, $period->getOptions());
 
-        $period->toggleOptions($end);
+        $period = $period->toggleOptions($end);
         $this->assertSame($start, $period->getOptions());
 
-        $period->toggleOptions($end);
+        $period = $period->toggleOptions($end);
         $this->assertSame($start | $end, $period->getOptions());
 
-        $period->toggleOptions($start | $end);
+        $period = $period->toggleOptions($start | $end);
         $this->assertEmpty($period->getOptions());
     }
 
     public function testSetStartDateInclusiveOrExclusive()
     {
-        $period = new CarbonPeriod();
+        $periodClass = $this->periodClass;
+        $period = new $periodClass();
 
-        $period->setStartDate('2018-03-25');
+        $period = $period->setStartDate('2018-03-25');
         $this->assertFalse($period->isStartExcluded());
 
-        $period->setStartDate('2018-03-25', false);
+        $period = $period->setStartDate('2018-03-25', false);
         $this->assertTrue($period->isStartExcluded());
 
-        $period->setStartDate('2018-03-25', true);
+        $period = $period->setStartDate('2018-03-25', true);
         $this->assertFalse($period->isStartExcluded());
     }
 
     public function testSetEndDateInclusiveOrExclusive()
     {
-        $period = new CarbonPeriod();
+        $periodClass = $this->periodClass;
+        $period = new $periodClass();
 
-        $period->setEndDate('2018-04-25');
+        $period = $period->setEndDate('2018-04-25');
         $this->assertFalse($period->isEndExcluded());
 
-        $period->setEndDate('2018-04-25', false);
+        $period = $period->setEndDate('2018-04-25', false);
         $this->assertTrue($period->isEndExcluded());
 
-        $period->setEndDate('2018-04-25', true);
+        $period = $period->setEndDate('2018-04-25', true);
         $this->assertFalse($period->isEndExcluded());
     }
 
     public function testInvertDateInterval()
     {
-        $period = new CarbonPeriod();
+        $periodClass = $this->periodClass;
+        $period = new $periodClass();
 
-        $period->invertDateInterval();
+        $period = $period->invertDateInterval();
         $this->assertSame(1, $period->getDateInterval()->invert);
 
-        $period->invertDateInterval();
+        $period = $period->invertDateInterval();
         $this->assertSame(0, $period->getDateInterval()->invert);
 
-        $period = CarbonPeriod::create('2018-04-29', 7);
+        $period = $periodClass::create('2018-04-29', 7);
         $dates = [];
         foreach ($period as $key => $date) {
             if ($key === 3) {
@@ -299,37 +320,40 @@ class SettersTest extends AbstractTestCase
 
     public function testExcludeStartDate()
     {
-        $period = new CarbonPeriod();
+        $periodClass = $this->periodClass;
+        $period = new $periodClass();
 
-        $period->excludeStartDate();
-        $this->assertSame(CarbonPeriod::EXCLUDE_START_DATE, $period->getOptions());
+        $period = $period->excludeStartDate();
+        $this->assertSame($periodClass::EXCLUDE_START_DATE, $period->getOptions());
 
-        $period->excludeStartDate(true);
-        $this->assertSame(CarbonPeriod::EXCLUDE_START_DATE, $period->getOptions());
+        $period = $period->excludeStartDate(true);
+        $this->assertSame($periodClass::EXCLUDE_START_DATE, $period->getOptions());
 
-        $period->excludeStartDate(false);
+        $period = $period->excludeStartDate(false);
         $this->assertEmpty($period->getOptions());
     }
 
     public function testExcludeEndDate()
     {
-        $period = new CarbonPeriod();
+        $periodClass = $this->periodClass;
+        $period = new $periodClass();
 
-        $period->excludeEndDate();
-        $this->assertSame(CarbonPeriod::EXCLUDE_END_DATE, $period->getOptions());
+        $period = $period->excludeEndDate();
+        $this->assertSame($periodClass::EXCLUDE_END_DATE, $period->getOptions());
 
-        $period->excludeEndDate(true);
-        $this->assertSame(CarbonPeriod::EXCLUDE_END_DATE, $period->getOptions());
+        $period = $period->excludeEndDate(true);
+        $this->assertSame($periodClass::EXCLUDE_END_DATE, $period->getOptions());
 
-        $period->excludeEndDate(false);
+        $period = $period->excludeEndDate(false);
         $this->assertEmpty($period->getOptions());
     }
 
     public function testSetRelativeDates()
     {
-        $period = new CarbonPeriod();
+        $periodClass = $this->periodClass;
+        $period = new $periodClass();
 
-        $period->setDates('first monday of may 2018', 'last day of may 2018 noon');
+        $period = $period->setDates('first monday of may 2018', 'last day of may 2018 noon');
 
         $this->assertSame('2018-05-07 00:00:00', $period->getStartDate()->toDateTimeString());
         $this->assertSame('2018-05-31 12:00:00', $period->getEndDate()->toDateTimeString());
@@ -337,6 +361,7 @@ class SettersTest extends AbstractTestCase
 
     public function testFluentSetters()
     {
+        $periodClass = $this->periodClass;
         Carbon::setTestNowAndTimezone(Carbon::now('UTC'));
 
         $period = CarbonInterval::days(3)->toPeriod()->since('2018-04-21')->until('2018-04-27');
@@ -358,7 +383,7 @@ class SettersTest extends AbstractTestCase
         $someDateTime = new DateTime('2010-05-06 02:00:00');
         $someCarbon = new Carbon('2010-05-06 13:00:00');
 
-        $period = CarbonPeriod::every('2 hours')->between($someDateTime, $someCarbon)->options(CarbonPeriod::EXCLUDE_START_DATE);
+        $period = $periodClass::every('2 hours')->between($someDateTime, $someCarbon)->options($periodClass::EXCLUDE_START_DATE);
         $hours = [];
         foreach ($period as $date) {
             $hours[] = $date->format('H');
@@ -366,7 +391,7 @@ class SettersTest extends AbstractTestCase
 
         $this->assertSame(['04', '06', '08', '10', '12'], $hours);
 
-        $period = CarbonPeriod::options(CarbonPeriod::EXCLUDE_START_DATE)->stepBy(CarbonInterval::hours(2))->since('yesterday 19:00')->until('tomorrow 03:30');
+        $period = $periodClass::options($periodClass::EXCLUDE_START_DATE)->stepBy(CarbonInterval::hours(2))->since('yesterday 19:00')->until('tomorrow 03:30');
         $hours = [];
         foreach ($period as $date) {
             $hours[] = $date->format('j H');
@@ -394,33 +419,33 @@ class SettersTest extends AbstractTestCase
             "$d3 03",
         ], $hours);
 
-        $period = CarbonPeriod::between('first day of january this year', 'first day of next month')->interval('1 week');
+        $period = $periodClass::between('first day of january this year', 'first day of next month')->interval('1 week');
 
         $this->assertEquals(new Carbon('first day of january this year'), $period->getStartDate());
         $this->assertEquals(new Carbon('first day of next month'), $period->getEndDate());
         $this->assertSame('1 week', $period->getDateInterval()->forHumans());
 
-        $opt = CarbonPeriod::EXCLUDE_START_DATE;
+        $opt = $periodClass::EXCLUDE_START_DATE;
         $int = '20 days';
         $start = '2000-01-03';
         $end = '2000-03-15';
         $inclusive = false;
-        $period = CarbonPeriod::options($opt)->setDateInterval($int)->setStartDate($start, $inclusive)->setEndDate($end, $inclusive);
+        $period = $periodClass::options($opt)->setDateInterval($int)->setStartDate($start, $inclusive)->setEndDate($end, $inclusive);
 
         $this->assertSame($start, $period->getStartDate()->format('Y-m-d'));
         $this->assertSame($end, $period->getEndDate()->format('Y-m-d'));
         $this->assertSame(20, $period->getDateInterval()->dayz);
-        $this->assertSame(CarbonPeriod::EXCLUDE_START_DATE | CarbonPeriod::EXCLUDE_END_DATE, $period->getOptions());
+        $this->assertSame($periodClass::EXCLUDE_START_DATE | $periodClass::EXCLUDE_END_DATE, $period->getOptions());
 
         $inclusive = true;
-        $period = CarbonPeriod::options($opt)->setDateInterval($int)->setStartDate($start, $inclusive)->setEndDate($end, $inclusive);
+        $period = $periodClass::options($opt)->setDateInterval($int)->setStartDate($start, $inclusive)->setEndDate($end, $inclusive);
 
         $this->assertSame($start, $period->getStartDate()->format('Y-m-d'));
         $this->assertSame($end, $period->getEndDate()->format('Y-m-d'));
         $this->assertSame(20, $period->getDateInterval()->dayz);
         $this->assertSame(0, $period->getOptions());
 
-        $period = CarbonPeriod::options($opt)->setDateInterval($int)->setDates($start, $end);
+        $period = $periodClass::options($opt)->setDateInterval($int)->setDates($start, $end);
 
         $this->assertSame($start, $period->getStartDate()->format('Y-m-d'));
         $this->assertSame($end, $period->getEndDate()->format('Y-m-d'));
@@ -430,7 +455,8 @@ class SettersTest extends AbstractTestCase
 
     public function testSetTimezone(): void
     {
-        $period = CarbonPeriod::create(
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create(
             '2018-03-25 00:00 America/Toronto',
             'PT1H',
             '2018-03-25 12:00 Europe/London'
@@ -439,7 +465,7 @@ class SettersTest extends AbstractTestCase
         $this->assertSame('2018-03-25 06:00 Europe/Oslo', $period->getStartDate()->format('Y-m-d H:i e'));
         $this->assertSame('2018-03-25 13:00 Europe/Oslo', $period->getEndDate()->format('Y-m-d H:i e'));
 
-        $period = CarbonPeriod::create(
+        $period = $periodClass::create(
             '2018-03-25 00:00 America/Toronto',
             'PT1H',
             5
@@ -452,7 +478,8 @@ class SettersTest extends AbstractTestCase
 
     public function testShiftTimezone(): void
     {
-        $period = CarbonPeriod::create(
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create(
             '2018-03-25 00:00 America/Toronto',
             'PT1H',
             '2018-03-25 12:00 Europe/London'
@@ -461,7 +488,7 @@ class SettersTest extends AbstractTestCase
         $this->assertSame('2018-03-25 00:00 Europe/Oslo', $period->getStartDate()->format('Y-m-d H:i e'));
         $this->assertSame('2018-03-25 12:00 Europe/Oslo', $period->getEndDate()->format('Y-m-d H:i e'));
 
-        $period = CarbonPeriod::create(
+        $period = $periodClass::create(
             '2018-03-26 00:00 America/Toronto',
             'PT1H',
             5

--- a/tests/CarbonPeriod/StrictModeTest.php
+++ b/tests/CarbonPeriod/StrictModeTest.php
@@ -15,7 +15,6 @@ namespace Tests\CarbonPeriod;
 
 use BadMethodCallException;
 use Carbon\Carbon;
-use Carbon\CarbonPeriod;
 use Tests\AbstractTestCase;
 
 class StrictModeTest extends AbstractTestCase
@@ -26,16 +25,18 @@ class StrictModeTest extends AbstractTestCase
             'Method foobar does not exist.'
         ));
 
+        $periodClass = $this->periodClass;
         /** @var mixed $period */
-        $period = CarbonPeriod::create();
+        $period = $periodClass::create();
         $period->foobar();
     }
 
     public function testCallWithoutStrictMode()
     {
         Carbon::useStrictMode(false);
+        $periodClass = $this->periodClass;
         /** @var mixed $period */
-        $period = CarbonPeriod::create();
+        $period = $periodClass::create();
         $this->assertSame($period, $period->foobar());
     }
 }

--- a/tests/CarbonPeriod/ToArrayTest.php
+++ b/tests/CarbonPeriod/ToArrayTest.php
@@ -26,7 +26,7 @@ class ToArrayTest extends AbstractTestCase
 {
     public function testToArrayIsNotEmptyArray()
     {
-        $result = CarbonPeriodFactory::withEvenDaysFilter()->toArray();
+        $result = CarbonPeriodFactory::withEvenDaysFilter($this->periodClass)->toArray();
 
         $this->assertIsArray($result);
         $this->assertNotEmpty($result);
@@ -34,14 +34,14 @@ class ToArrayTest extends AbstractTestCase
 
     public function testToArrayHasCorrectCount()
     {
-        $period = CarbonPeriodFactory::withEvenDaysFilter();
+        $period = CarbonPeriodFactory::withEvenDaysFilter($this->periodClass);
 
         $this->assertCount(3, $period->toArray());
     }
 
     public function testToArrayValuesAreCarbonInstances()
     {
-        $result = CarbonPeriodFactory::withEvenDaysFilter()->toArray();
+        $result = CarbonPeriodFactory::withEvenDaysFilter($this->periodClass)->toArray();
 
         foreach ($result as $key => $current) {
             $this->assertInstanceOfCarbon($current);
@@ -50,14 +50,14 @@ class ToArrayTest extends AbstractTestCase
 
     public function testToArrayKeysAreSequential()
     {
-        $result = CarbonPeriodFactory::withEvenDaysFilter()->toArray();
+        $result = CarbonPeriodFactory::withEvenDaysFilter($this->periodClass)->toArray();
 
         $this->assertSame([0, 1, 2], array_keys($result));
     }
 
     public function testToArrayHasCorrectValues()
     {
-        $result = CarbonPeriodFactory::withEvenDaysFilter()->toArray();
+        $result = CarbonPeriodFactory::withEvenDaysFilter($this->periodClass)->toArray();
 
         $this->assertSame(
             $this->standardizeDates(['2012-07-04', '2012-07-10', '2012-07-16']),
@@ -67,13 +67,14 @@ class ToArrayTest extends AbstractTestCase
 
     public function testJsonSerialize()
     {
-        $result = json_encode(CarbonPeriodFactory::withEvenDaysFilter());
+        $result = json_encode(CarbonPeriodFactory::withEvenDaysFilter($this->periodClass));
 
         $this->assertSame('["2012-07-04T04:00:00.000000Z","2012-07-10T04:00:00.000000Z","2012-07-16T04:00:00.000000Z"]', $result);
     }
 
     public function testCountEmptyPeriod()
     {
+        $periodClass = $this->periodClass;
         $assertThrow = function (CarbonPeriod $period) {
             $message = null;
 
@@ -86,7 +87,7 @@ class ToArrayTest extends AbstractTestCase
             $this->assertSame("Endless period can't be converted to array nor counted.", $message);
         };
 
-        $period = new CarbonPeriod();
+        $period = new $periodClass();
         $this->assertTrue($period->isUnfilteredAndEndLess());
         $assertThrow($period);
         $this->assertSame(Carbon::now()->format('Y-m-d H:i:s'), $period->first()->format('Y-m-d H:i:s'));
@@ -98,36 +99,36 @@ class ToArrayTest extends AbstractTestCase
         $this->assertInstanceOfCarbon($date ?? null);
         $this->assertSame(Carbon::now()->format('Y-m-d H:i:s'), $date->format('Y-m-d H:i:s'));
 
-        $period = new CarbonPeriod(INF);
+        $period = new $periodClass(INF);
         $this->assertTrue($period->isUnfilteredAndEndLess());
         $assertThrow($period);
 
-        $period = new CarbonPeriod('2022-05-18', '1 day');
+        $period = new $periodClass('2022-05-18', '1 day');
         $this->assertTrue($period->isUnfilteredAndEndLess());
         $assertThrow($period);
 
-        $period = new CarbonPeriod('2022-05-18', '1 day', CarbonImmutable::endOfTime());
+        $period = new $periodClass('2022-05-18', '1 day', CarbonImmutable::endOfTime());
         $this->assertTrue($period->isUnfilteredAndEndLess());
         $assertThrow($period);
 
-        $period = new CarbonPeriod('2022-05-18', '1 day');
+        $period = new $periodClass('2022-05-18', '1 day');
         $period->setDateClass(CarbonImmutable::class);
         $period->setEndDate(CarbonImmutable::endOfTime());
         $this->assertTrue($period->isUnfilteredAndEndLess());
         $assertThrow($period);
 
-        $period = new CarbonPeriod(3);
+        $period = new $periodClass(3);
         $this->assertFalse($period->isUnfilteredAndEndLess());
         $this->assertSame(3, $period->count());
 
-        $period = new CarbonPeriod('2022-05-18', '2022-05-23');
+        $period = new $periodClass('2022-05-18', '2022-05-23');
         $this->assertFalse($period->isUnfilteredAndEndLess());
         $this->assertSame(6, $period->count());
 
-        $period = new CarbonPeriod('2022-05-18', INF);
-        $period->addFilter(static function (DateTimeInterface $date) {
+        $period = new $periodClass('2022-05-18', INF);
+        $period = $period->addFilter(static function (DateTimeInterface $date) use ($periodClass) {
             if ($date->format('Y-m-d') > '2022-05-20') {
-                return CarbonPeriod::END_ITERATION;
+                return $periodClass::END_ITERATION;
             }
 
             return true;
@@ -138,35 +139,36 @@ class ToArrayTest extends AbstractTestCase
 
     public function testCountByMethod()
     {
-        $period = CarbonPeriodFactory::withEvenDaysFilter();
+        $period = CarbonPeriodFactory::withEvenDaysFilter($this->periodClass);
 
         $this->assertSame(3, $period->count());
     }
 
     public function testCountByFunction()
     {
-        $period = CarbonPeriodFactory::withEvenDaysFilter();
+        $period = CarbonPeriodFactory::withEvenDaysFilter($this->periodClass);
 
         $this->assertCount(3, $period);
     }
 
     public function testFirst()
     {
-        $period = CarbonPeriodFactory::withEvenDaysFilter();
+        $period = CarbonPeriodFactory::withEvenDaysFilter($this->periodClass);
 
         $this->assertEquals(new Carbon('2012-07-04'), $period->first());
     }
 
     public function testLast()
     {
-        $period = CarbonPeriodFactory::withEvenDaysFilter();
+        $period = CarbonPeriodFactory::withEvenDaysFilter($this->periodClass);
 
         $this->assertEquals(new Carbon('2012-07-16'), $period->last());
     }
 
     public function testToArrayOfEmptyPeriod()
     {
-        $result = CarbonPeriod::create(0)->toArray();
+        $periodClass = $this->periodClass;
+        $result = $periodClass::create(0)->toArray();
 
         $this->assertIsArray($result);
         $this->assertEmpty($result);
@@ -174,14 +176,16 @@ class ToArrayTest extends AbstractTestCase
 
     public function testCountOfEmptyPeriod()
     {
-        $period = CarbonPeriod::create(0);
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create(0);
 
         $this->assertSame(0, $period->count());
     }
 
     public function testFirstOfEmptyPeriod()
     {
-        $period = CarbonPeriod::create(0);
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create(0);
 
         $this->assertNull($period->first());
 
@@ -197,14 +201,15 @@ class ToArrayTest extends AbstractTestCase
 
     public function testLastOfEmptyPeriod()
     {
-        $period = CarbonPeriod::create(0);
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create(0);
 
         $this->assertNull($period->last());
     }
 
     public function testRestoreIterationStateAfterCallingToArray()
     {
-        $period = CarbonPeriodFactory::withEvenDaysFilter();
+        $period = CarbonPeriodFactory::withEvenDaysFilter($this->periodClass);
 
         $key = $period->key();
         $current = $period->current();
@@ -230,7 +235,8 @@ class ToArrayTest extends AbstractTestCase
 
     public function testToArrayResultsAreInTheExpectedTimezone()
     {
-        $period = CarbonPeriod::create('2018-05-13 12:00 Asia/Kabul', 'PT1H', 3);
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('2018-05-13 12:00 Asia/Kabul', 'PT1H', 3);
 
         $expected = [
             '2018-05-13 12:00:00 +04:30',
@@ -243,14 +249,15 @@ class ToArrayTest extends AbstractTestCase
 
     public function testDebugInfo()
     {
-        $period = CarbonPeriod::create('2018-05-13 12:00 Asia/Kabul', 'PT1H', 3);
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('2018-05-13 12:00 Asia/Kabul', 'PT1H', 3);
 
         $expected = [
             'dateClass' => Carbon::class,
             'dateInterval' => CarbonInterval::hour(),
             'filters' => [
                 [
-                    CarbonPeriod::RECURRENCES_FILTER,
+                    $periodClass::RECURRENCES_FILTER,
                     null,
                 ],
             ],

--- a/tests/CarbonPeriod/ToDatePeriodTest.php
+++ b/tests/CarbonPeriod/ToDatePeriodTest.php
@@ -16,7 +16,6 @@ namespace Tests\CarbonPeriod;
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterval;
-use Carbon\CarbonPeriod;
 use Carbon\Translator;
 use DatePeriod;
 use DateTime;
@@ -28,7 +27,8 @@ class ToDatePeriodTest extends AbstractTestCase
 {
     public function testToArrayIsNotEmptyArray()
     {
-        $period = CarbonPeriod::create('2021-01-05', '2021-02-15');
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('2021-01-05', '2021-02-15');
         $result = $period->toDatePeriod();
 
         $this->assertFalse($period->isEndExcluded());
@@ -38,11 +38,11 @@ class ToDatePeriodTest extends AbstractTestCase
         // CarbonPeriod includes end date by default while DatePeriod will always exclude it
         $dates = iterator_to_array($result);
         $this->assertSame('2021-02-14', end($dates)->format('Y-m-d'));
-        $this->assertTrue($period->equalTo(CarbonPeriod::instance($result)));
+        $this->assertTrue($period->equalTo($periodClass::instance($result)));
 
-        $period = CarbonPeriod::create('2021-01-05', '2021-02-15', CarbonPeriod::EXCLUDE_END_DATE);
+        $period = $periodClass::create('2021-01-05', '2021-02-15', $periodClass::EXCLUDE_END_DATE);
         $result = $period->toDatePeriod();
-        $newInstance = CarbonPeriod::instance($result);
+        $newInstance = $periodClass::instance($result);
 
         $this->assertTrue($period->isEndExcluded());
         $this->assertSame(DatePeriod::class, \get_class($result));
@@ -53,9 +53,9 @@ class ToDatePeriodTest extends AbstractTestCase
         $this->assertSame('2021-01-05', $newInstance->getStartDate()->format('Y-m-d'));
         $this->assertSame('2021-02-14', $newInstance->getEndDate()->format('Y-m-d'));
 
-        $period = CarbonPeriod::create('2021-01-05', 3);
+        $period = $periodClass::create('2021-01-05', 3);
         $result = $period->toDatePeriod();
-        $newInstance = CarbonPeriod::instance($result);
+        $newInstance = $periodClass::instance($result);
 
         $this->assertSame(DatePeriod::class, \get_class($result));
         $this->assertSame('2021-01-05', $result->getStartDate()->format('Y-m-d'));
@@ -69,7 +69,8 @@ class ToDatePeriodTest extends AbstractTestCase
     public function testWithIntervalLocalized()
     {
         CarbonInterval::setLocale('fr');
-        $period = CarbonPeriod::create('2021-01-05', 3);
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create('2021-01-05', 3);
         $result = $period->floor()->toDatePeriod();
 
         $this->assertSame(DatePeriod::class, \get_class($result));
@@ -85,11 +86,12 @@ class ToDatePeriodTest extends AbstractTestCase
 
     public function testWithModifiedEnglish()
     {
+        $periodClass = $this->periodClass;
         $translator = Translator::get('en');
         $translator->setTranslations([
             'day' => ':count boring day|:count boring days',
         ]);
-        $period = CarbonPeriod::create('2021-01-05', 3);
+        $period = $periodClass::create('2021-01-05', 3);
         $result = $period->floor()->toDatePeriod();
 
         $this->assertSame(DatePeriod::class, \get_class($result));
@@ -105,8 +107,9 @@ class ToDatePeriodTest extends AbstractTestCase
 
     public function testRawDate()
     {
-        $period = new CarbonPeriod();
-        $method = new ReflectionMethod(CarbonPeriod::class, 'rawDate');
+        $periodClass = $this->periodClass;
+        $period = new $periodClass();
+        $method = new ReflectionMethod($periodClass, 'rawDate');
         $method->setAccessible(true);
 
         $this->assertNull($method->invoke($period, false));

--- a/tests/CarbonPeriod/ToStringTest.php
+++ b/tests/CarbonPeriod/ToStringTest.php
@@ -33,23 +33,24 @@ class ToStringTest extends AbstractTestCase
         );
     }
 
-    public static function dataForToString(): Generator
+    public function dataForToString(): Generator
     {
+        $periodClass = $this->periodClass;
         Carbon::setTestNowAndTimezone(new Carbon('2015-09-01', 'America/Toronto'));
 
         yield [
-                CarbonPeriod::create('R4/2012-07-01T12:00:00/P7D'),
+                $periodClass::create('R4/2012-07-01T12:00:00/P7D'),
                 '4 times every 1 week from 2012-07-01 12:00:00',
             ];
         yield [
-                CarbonPeriod::create(
+                $periodClass::create(
                     Carbon::parse('2015-09-30'),
                     Carbon::parse('2015-10-03')
                 ),
                 'Every 1 day from 2015-09-30 to 2015-10-03',
             ];
         yield [
-                CarbonPeriod::create(
+                $periodClass::create(
                     Carbon::parse('2015-09-30 12:50'),
                     CarbonInterval::days(3)->hours(5),
                     Carbon::parse('2015-10-03 19:00')
@@ -57,19 +58,19 @@ class ToStringTest extends AbstractTestCase
                 'Every 3 days and 5 hours from 2015-09-30 12:50:00 to 2015-10-03 19:00:00',
             ];
         yield [
-                CarbonPeriod::create('2015-09-30 17:30'),
+                $periodClass::create('2015-09-30 17:30'),
                 'Every 1 day from 2015-09-30 17:30:00',
             ];
         yield [
-                CarbonPeriod::create('P1M14D'),
+                $periodClass::create('P1M14D'),
                 'Every 1 month and 2 weeks from 2015-09-01',
             ];
         yield [
-                CarbonPeriod::create('2015-09-30 13:30', 'P17D')->setRecurrences(1),
+                $periodClass::create('2015-09-30 13:30', 'P17D')->setRecurrences(1),
                 'Once every 2 weeks and 3 days from 2015-09-30 13:30:00',
             ];
         yield [
-                CarbonPeriod::create('2015-10-01', '2015-10-05', 'PT30M'),
+                $periodClass::create('2015-10-01', '2015-10-05', 'PT30M'),
                 'Every 30 minutes from 2015-10-01 to 2015-10-05',
             ];
 
@@ -78,7 +79,8 @@ class ToStringTest extends AbstractTestCase
 
     public function testMagicToString()
     {
-        $period = CarbonPeriod::create(
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create(
             Carbon::parse('2015-09-30 12:50'),
             CarbonInterval::days(3)->hours(5),
             Carbon::parse('2015-10-03 19:00')
@@ -101,23 +103,24 @@ class ToStringTest extends AbstractTestCase
         );
     }
 
-    public static function dataForToIso8601String(): Generator
+    public function dataForToIso8601String(): Generator
     {
+        $periodClass = $this->periodClass;
         Carbon::setTestNowAndTimezone(new Carbon('2015-09-01', 'America/Toronto'));
 
         yield [
-                CarbonPeriod::create('R4/2012-07-01T00:00:00-04:00/P7D'),
+                $periodClass::create('R4/2012-07-01T00:00:00-04:00/P7D'),
                 'R4/2012-07-01T00:00:00-04:00/P7D',
             ];
         yield [
-                CarbonPeriod::create(
+                $periodClass::create(
                     Carbon::parse('2015-09-30', 'America/Toronto'),
                     Carbon::parse('2015-10-03', 'America/Toronto')
                 ),
                 '2015-09-30T00:00:00-04:00/P1D/2015-10-03T00:00:00-04:00',
             ];
         yield [
-                CarbonPeriod::create(
+                $periodClass::create(
                     Carbon::parse('2015-09-30 12:50', 'America/Toronto'),
                     CarbonInterval::days(3)->hours(5),
                     Carbon::parse('2015-10-03 19:00', 'America/Toronto')
@@ -125,21 +128,22 @@ class ToStringTest extends AbstractTestCase
                 '2015-09-30T12:50:00-04:00/P3DT5H/2015-10-03T19:00:00-04:00',
             ];
         yield [
-                CarbonPeriod::create(
+                $periodClass::create(
                     Carbon::parse('2015-09-30 12:50', 'America/Toronto'),
                     CarbonInterval::days(3)
                 ),
                 '2015-09-30T12:50:00-04:00/P3D',
             ];
         yield [
-                CarbonPeriod::create(),
+                $periodClass::create(),
                 '2015-09-01T00:00:00-04:00/P1D',
             ];
     }
 
     public function testSpec()
     {
-        $period = CarbonPeriod::create(
+        $periodClass = $this->periodClass;
+        $period = $periodClass::create(
             Carbon::parse('2015-09-30'),
             CarbonInterval::days(3)->hours(5),
             Carbon::parse('2015-10-03')
@@ -153,9 +157,10 @@ class ToStringTest extends AbstractTestCase
 
     public function testStartOfWeekForPeriod()
     {
+        $periodClass = $this->periodClass;
         $sunday = CarbonImmutable::parse('2019-12-01');
 
-        $period = CarbonPeriod::create($sunday->startOfWeek(), '1 week', $sunday->endOfWeek())->toArray();
+        $period = $periodClass::create($sunday->startOfWeek(), '1 week', $sunday->endOfWeek())->toArray();
 
         $formattedSunday = $sunday->startOfWeek()->format('Y-m-d H:i:s');
 
@@ -172,16 +177,17 @@ class ToStringTest extends AbstractTestCase
 
     public function testToStringCustomization()
     {
+        $periodClass = $this->periodClass;
         $sunday = CarbonImmutable::parse('2019-12-01');
 
-        $period = CarbonPeriod::create($sunday->startOfWeek(), '1 week', $sunday->endOfWeek());
+        $period = $periodClass::create($sunday->startOfWeek(), '1 week', $sunday->endOfWeek());
 
         $this->assertSame(
             'Every 1 week from 2019-11-25 00:00:00 to 2019-12-01 23:59:59!!',
             $period.'!!'
         );
 
-        CarbonPeriod::setToStringFormat('m/d');
+        $periodClass::setToStringFormat('m/d');
 
         $this->assertSame(
             'Every 1 week from 11/25 to 12/01!!',
@@ -197,6 +203,6 @@ class ToStringTest extends AbstractTestCase
             $period.'!!'
         );
 
-        CarbonPeriod::resetToStringFormat();
+        $periodClass::resetToStringFormat();
     }
 }

--- a/tests/CarbonPeriodImmutable/AliasTest.php
+++ b/tests/CarbonPeriodImmutable/AliasTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonPeriodImmutable;
+
+use Carbon\CarbonPeriodImmutable;
+
+class AliasTest extends \Tests\CarbonPeriod\AliasTest
+{
+    protected $periodClass = CarbonPeriodImmutable::class;
+}

--- a/tests/CarbonPeriodImmutable/CloneTest.php
+++ b/tests/CarbonPeriodImmutable/CloneTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonPeriodImmutable;
+
+use Carbon\CarbonPeriodImmutable;
+
+class CloneTest extends \Tests\CarbonPeriod\CloneTest
+{
+    protected $periodClass = CarbonPeriodImmutable::class;
+}

--- a/tests/CarbonPeriodImmutable/ComparisonTest.php
+++ b/tests/CarbonPeriodImmutable/ComparisonTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonPeriodImmutable;
+
+use Carbon\CarbonPeriodImmutable;
+
+class ComparisonTest extends \Tests\CarbonPeriod\ComparisonTest
+{
+    protected $periodClass = CarbonPeriodImmutable::class;
+}

--- a/tests/CarbonPeriodImmutable/CreateTest.php
+++ b/tests/CarbonPeriodImmutable/CreateTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonPeriodImmutable;
+
+use Carbon\CarbonPeriodImmutable;
+
+class CreateTest extends \Tests\CarbonPeriod\CreateTest
+{
+    protected $periodClass = CarbonPeriodImmutable::class;
+}

--- a/tests/CarbonPeriodImmutable/DynamicIntervalTest.php
+++ b/tests/CarbonPeriodImmutable/DynamicIntervalTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonPeriodImmutable;
+
+use Carbon\CarbonPeriodImmutable;
+
+class DynamicIntervalTest extends \Tests\CarbonPeriod\DynamicIntervalTest
+{
+    protected $periodClass = CarbonPeriodImmutable::class;
+}

--- a/tests/CarbonPeriodImmutable/FilterTest.php
+++ b/tests/CarbonPeriodImmutable/FilterTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonPeriodImmutable;
+
+use Carbon\CarbonPeriodImmutable;
+
+class FilterTest extends \Tests\CarbonPeriod\FilterTest
+{
+    protected $periodClass = CarbonPeriodImmutable::class;
+}

--- a/tests/CarbonPeriodImmutable/GettersTest.php
+++ b/tests/CarbonPeriodImmutable/GettersTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonPeriodImmutable;
+
+use Carbon\CarbonPeriodImmutable;
+
+class GettersTest extends \Tests\CarbonPeriod\GettersTest
+{
+    protected $periodClass = CarbonPeriodImmutable::class;
+}

--- a/tests/CarbonPeriodImmutable/IterationMethodsTest.php
+++ b/tests/CarbonPeriodImmutable/IterationMethodsTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonPeriodImmutable;
+
+use Carbon\CarbonPeriodImmutable;
+
+class IterationMethodsTest extends \Tests\CarbonPeriod\IterationMethodsTest
+{
+    protected $periodClass = CarbonPeriodImmutable::class;
+}

--- a/tests/CarbonPeriodImmutable/IteratorTest.php
+++ b/tests/CarbonPeriodImmutable/IteratorTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonPeriodImmutable;
+
+use Carbon\CarbonPeriodImmutable;
+
+class IteratorTest extends \Tests\CarbonPeriod\IteratorTest
+{
+    protected $periodClass = CarbonPeriodImmutable::class;
+}

--- a/tests/CarbonPeriodImmutable/MacroTest.php
+++ b/tests/CarbonPeriodImmutable/MacroTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonPeriodImmutable;
+
+use Carbon\CarbonPeriodImmutable;
+
+class MacroTest extends \Tests\CarbonPeriod\MacroTest
+{
+    protected $periodClass = CarbonPeriodImmutable::class;
+}

--- a/tests/CarbonPeriodImmutable/RoundingTest.php
+++ b/tests/CarbonPeriodImmutable/RoundingTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonPeriodImmutable;
+
+use Carbon\CarbonPeriodImmutable;
+
+class RoundingTest extends \Tests\CarbonPeriod\RoundingTest
+{
+    protected $periodClass = CarbonPeriodImmutable::class;
+}

--- a/tests/CarbonPeriodImmutable/SettersTest.php
+++ b/tests/CarbonPeriodImmutable/SettersTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonPeriodImmutable;
+
+use Carbon\CarbonPeriodImmutable;
+
+class SettersTest extends \Tests\CarbonPeriod\SettersTest
+{
+    protected $periodClass = CarbonPeriodImmutable::class;
+}

--- a/tests/CarbonPeriodImmutable/StrictModeTest.php
+++ b/tests/CarbonPeriodImmutable/StrictModeTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonPeriodImmutable;
+
+use Carbon\CarbonPeriodImmutable;
+
+class StrictModeTest extends \Tests\CarbonPeriod\StrictModeTest
+{
+    protected $periodClass = CarbonPeriodImmutable::class;
+}

--- a/tests/CarbonPeriodImmutable/ToArrayTest.php
+++ b/tests/CarbonPeriodImmutable/ToArrayTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonPeriodImmutable;
+
+use Carbon\CarbonPeriodImmutable;
+
+class ToArrayTest extends \Tests\CarbonPeriod\ToArrayTest
+{
+    protected $periodClass = CarbonPeriodImmutable::class;
+}

--- a/tests/CarbonPeriodImmutable/ToDatePeriodTest.php
+++ b/tests/CarbonPeriodImmutable/ToDatePeriodTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonPeriodImmutable;
+
+use Carbon\CarbonPeriodImmutable;
+
+class ToDatePeriodTest extends \Tests\CarbonPeriod\ToDatePeriodTest
+{
+    protected $periodClass = CarbonPeriodImmutable::class;
+}

--- a/tests/CarbonPeriodImmutable/ToStringTest.php
+++ b/tests/CarbonPeriodImmutable/ToStringTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\CarbonPeriodImmutable;
+
+use Carbon\CarbonPeriodImmutable;
+
+class ToStringTest extends \Tests\CarbonPeriod\ToStringTest
+{
+    protected $periodClass = CarbonPeriodImmutable::class;
+}


### PR DESCRIPTION
As for `CarbonImmutable`, `CarbonPeriodImmutable` create new instances when calling setters on it (setStartDate, setRecurrences, addFilter, removeFilter, etc.) it also use `CarbonImmutable` by default for the iteration and start/end dates if they ware passed as strings.

When creating a period from a `CarbonImmutable` (using `daysUntil()`, `range()`, `toPeriod()`, etc), it will now creates a `CarbonPeriodImmutable`

⚠️ This can be a breaking change in very rare case when not using chaining from end to end and relying on the mutated state of a `CarbonPeriod` obtained from a `CarbonImmutable`:

```php
$period = CarbonImmutable::parse('2023-01-01')
    ->daysUntil('2023-01-03');
$period->excludeEndDate();

echo $period->count();
```

Before, this returned `2`, now it returns `3` because `excludeEndDate()` returns an new object, this code should be turned into:

```php
$period = CarbonImmutable::parse('2023-01-01')
    ->daysUntil('2023-01-03');
$period = $period->excludeEndDate();

echo $period->count();
```
Or use chaining:

```php
$period = CarbonImmutable::parse('2023-01-01')
    ->daysUntil('2023-01-03')
    ->excludeEndDate();

echo $period->count();
```

Resolves #2755