### PR TITLE
Options - `@method` shiftTimezone returns `static`

### DIFF
--- a/src/Carbon/Traits/Options.php
+++ b/src/Carbon/Traits/Options.php
@@ -22,7 +22,7 @@ use Throwable;
  *
  * Depends on the following methods:
  *
- * @method \Carbon\Carbon|\Carbon\CarbonImmutable shiftTimezone($timezone) Set the timezone
+ * @method static shiftTimezone($timezone) Set the timezone
  */
 trait Options
 {


### PR DESCRIPTION
The original return type confuses PHPStan. All the methods in trait-using classes return `static` so it's correct to return `static` in `@method` PHPDoc too.

Thanks.