### PR TITLE
Fix dual for month in Slovenian language

### DIFF
--- a/src/Carbon/Lang/sl.php
+++ b/src/Carbon/Lang/sl.php
@@ -51,7 +51,7 @@ return [
 
     'year_ago' => ':count letom|:count letoma|:count leti|:count leti',
     'y_ago' => ':count letom|:count letoma|:count leti|:count leti',
-    'month_ago' => ':count mesecem|:count meseci|:count meseci|:count meseci',
+    'month_ago' => ':count mesecem|:count mesecema|:count meseci|:count meseci',
     'week_ago' => ':count tednom|:count tednoma|:count tedni|:count tedni',
     'day_ago' => ':count dnem|:count dnevoma|:count dnevi|:count dnevi',
     'd_ago' => ':count dnem|:count dnevoma|:count dnevi|:count dnevi',

--- a/tests/Localization/SlSiTest.php
+++ b/tests/Localization/SlSiTest.php
@@ -315,7 +315,7 @@ class SlSiTest extends LocalizationTestCase
 
         // Carbon::now()->subMonths(2)->diffForHumans()
         // '2 months ago'
-        'pred 2 meseci',
+        'pred 2 mesecema',
 
         // Carbon::now()->subMonths(2)->diffForHumans(null, false, true)
         // '2mos ago'

--- a/tests/Localization/SlTest.php
+++ b/tests/Localization/SlTest.php
@@ -315,7 +315,7 @@ class SlTest extends LocalizationTestCase
 
         // Carbon::now()->subMonths(2)->diffForHumans()
         // '2 months ago'
-        'pred 2 meseci',
+        'pred 2 mesecema',
 
         // Carbon::now()->subMonths(2)->diffForHumans(null, false, true)
         // '2mos ago'


### PR DESCRIPTION
Dual for month was wrong.

Reference: https://www.leemeta.si/blog/jezikovne-dileme/5-najpogostejsih-napak-pri-rabi-dvojine