### PR TITLE
Fix PHPUnit 10 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12.99 || ^1.7.14",
         "phpunit/php-file-iterator": "^2.0.5 || ^3.0.6",
-        "phpunit/phpunit": "^7.5.20 || ^8.5.26 || ^9.5.20",
+        "phpunit/phpunit": "^7.5.20 || ^8.5.26 || ^9.5.20 || ^10.2.6",
         "squizlabs/php_codesniffer": "^3.4"
     },
     "provide": {

--- a/src/Carbon/Doctrine/CarbonTypeConverter.php
+++ b/src/Carbon/Doctrine/CarbonTypeConverter.php
@@ -34,7 +34,7 @@ trait CarbonTypeConverter
     /**
      * @return string
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         $precision = $fieldDeclaration['precision'] ?: 10;
 
@@ -66,7 +66,7 @@ trait CarbonTypeConverter
      *
      * @return T|null
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateTimeInterface
     {
         $class = $this->getCarbonClassName();
 
@@ -104,7 +104,7 @@ trait CarbonTypeConverter
      *
      * @return string|null
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
     {
         if ($value === null) {
             return $value;

--- a/src/Carbon/Doctrine/DateTimeImmutableType.php
+++ b/src/Carbon/Doctrine/DateTimeImmutableType.php
@@ -7,12 +7,17 @@
 namespace Carbon\Doctrine;
 
 use Carbon\CarbonImmutable;
+use DateTimeImmutable;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\VarDateTimeImmutableType;
 
 class DateTimeImmutableType extends VarDateTimeImmutableType implements CarbonDoctrineType
 {
     /** @use CarbonTypeConverter<CarbonImmutable> */
-    use CarbonTypeConverter;
+    use CarbonTypeConverter
+    {
+        convertToPHPValue as private baseConvertToPHPValue;
+    }
 
     /**
      * @return class-string<CarbonImmutable>
@@ -20,5 +25,15 @@ class DateTimeImmutableType extends VarDateTimeImmutableType implements CarbonDo
     protected function getCarbonClassName(): string
     {
         return CarbonImmutable::class;
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @return T|null
+     */
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateTimeImmutable
+    {
+        return $this->baseConvertToPHPValue($value, $platform);
     }
 }

--- a/tests/Carbon/ObjectsTest.php
+++ b/tests/Carbon/ObjectsTest.php
@@ -28,40 +28,40 @@ class ObjectsTest extends AbstractTestCase
 
         $this->assertInstanceOf(stdClass::class, $dtToObject);
 
-        $this->assertObjectHasAttribute('year', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'year'));
         $this->assertSame($dt->year, $dtToObject->year);
 
-        $this->assertObjectHasAttribute('month', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'month'));
         $this->assertSame($dt->month, $dtToObject->month);
 
-        $this->assertObjectHasAttribute('day', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'day'));
         $this->assertSame($dt->day, $dtToObject->day);
 
-        $this->assertObjectHasAttribute('dayOfWeek', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'dayOfWeek'));
         $this->assertSame($dt->dayOfWeek, $dtToObject->dayOfWeek);
 
-        $this->assertObjectHasAttribute('dayOfYear', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'dayOfYear'));
         $this->assertSame($dt->dayOfYear, $dtToObject->dayOfYear);
 
-        $this->assertObjectHasAttribute('hour', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'hour'));
         $this->assertSame($dt->hour, $dtToObject->hour);
 
-        $this->assertObjectHasAttribute('minute', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'minute'));
         $this->assertSame($dt->minute, $dtToObject->minute);
 
-        $this->assertObjectHasAttribute('second', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'second'));
         $this->assertSame($dt->second, $dtToObject->second);
 
-        $this->assertObjectHasAttribute('micro', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'micro'));
         $this->assertSame($dt->micro, $dtToObject->micro);
 
-        $this->assertObjectHasAttribute('timestamp', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'timestamp'));
         $this->assertSame($dt->timestamp, $dtToObject->timestamp);
 
-        $this->assertObjectHasAttribute('timezone', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'timezone'));
         $this->assertEquals($dt->timezone, $dtToObject->timezone);
 
-        $this->assertObjectHasAttribute('formatted', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'formatted'));
         $this->assertSame($dt->format(Carbon::DEFAULT_TO_STRING_FORMAT), $dtToObject->formatted);
     }
 

--- a/tests/CarbonImmutable/ObjectsTest.php
+++ b/tests/CarbonImmutable/ObjectsTest.php
@@ -28,40 +28,40 @@ class ObjectsTest extends AbstractTestCase
 
         $this->assertInstanceOf(stdClass::class, $dtToObject);
 
-        $this->assertObjectHasAttribute('year', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'year'));
         $this->assertSame($dt->year, $dtToObject->year);
 
-        $this->assertObjectHasAttribute('month', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'month'));
         $this->assertSame($dt->month, $dtToObject->month);
 
-        $this->assertObjectHasAttribute('day', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'day'));
         $this->assertSame($dt->day, $dtToObject->day);
 
-        $this->assertObjectHasAttribute('dayOfWeek', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'dayOfWeek'));
         $this->assertSame($dt->dayOfWeek, $dtToObject->dayOfWeek);
 
-        $this->assertObjectHasAttribute('dayOfYear', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'dayOfYear'));
         $this->assertSame($dt->dayOfYear, $dtToObject->dayOfYear);
 
-        $this->assertObjectHasAttribute('hour', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'hour'));
         $this->assertSame($dt->hour, $dtToObject->hour);
 
-        $this->assertObjectHasAttribute('minute', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'minute'));
         $this->assertSame($dt->minute, $dtToObject->minute);
 
-        $this->assertObjectHasAttribute('second', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'second'));
         $this->assertSame($dt->second, $dtToObject->second);
 
-        $this->assertObjectHasAttribute('micro', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'micro'));
         $this->assertSame($dt->micro, $dtToObject->micro);
 
-        $this->assertObjectHasAttribute('timestamp', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'timestamp'));
         $this->assertSame($dt->timestamp, $dtToObject->timestamp);
 
-        $this->assertObjectHasAttribute('timezone', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'timezone'));
         $this->assertEquals($dt->timezone, $dtToObject->timezone);
 
-        $this->assertObjectHasAttribute('formatted', $dtToObject);
+        $this->assertTrue(property_exists($dtToObject, 'formatted'));
         $this->assertSame($dt->format(Carbon::DEFAULT_TO_STRING_FORMAT), $dtToObject->formatted);
     }
 


### PR DESCRIPTION
* Adds type hints to tests to deal with errors like:

> .PHP Fatal error:  Declaration of Carbon\Doctrine\CarbonTypeConverter::getSQLDeclaration(array $fieldDeclaration, Doctrine\DBAL\Platforms\AbstractPlatform $platform) must be compatible with Doctrine\DBAL\Types\DateTimeType::getSQLDeclaration(array $column, Doctrine\DBAL\Platforms\AbstractPlatform $platform): string in src/Carbon/Doctrine/CarbonTypeConverter.php on line 37

* Adds a workaround for a type mismatch in a trait shared between two classes in need of different return type signatures.

> .PHP Fatal error:  Declaration of Carbon\Doctrine\CarbonTypeConverter::convertToPHPValue(mixed $value, Doctrine\DBAL\Platforms\AbstractPlatform $platform): ?DateTimeInterface must be compatible with Doctrine\DBAL\Types\VarDateTimeImmutableType::convertToPHPValue(mixed $value, Doctrine\DBAL\Platforms\AbstractPlatform $platform): ?DateTimeImmutable in src/Carbon/Doctrine/CarbonTypeConverter.php on line 69

* Replaces the removed `assertObjectHasAttribute` method.