### PR TITLE
Adds the T modifier to getFormatsToIsoReplacements

### DIFF
--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -2310,6 +2310,7 @@ trait Date
                 'c' => true,
                 'r' => true,
                 'U' => true,
+                'T' => true,
             ];
         }
 


### PR DESCRIPTION
`->format()` works to correctly return the timezone, however `translatedFormat()` does not allow the use of 'T'