### PR TITLE
Upgrade codecov V1 => V3 and switch to pcov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Run test suite
         run: |
           if [[ "${{ matrix.laravel }}" != 'true' && "${{ matrix.coverage }}" = 'true' ]]; then
-            php -d memory_limit=-1 -d zend.enable_gc=0 -d error_reporting=-1 vendor/phpunit/phpunit/phpunit --coverage-clover=clover.xml;
+            php -d memory_limit=-1 -d zend.enable_gc=0 -d error_reporting=-1 vendor/phpunit/phpunit/phpunit --coverage-clover=clover.xml --coverage-text;
           fi;
           if [[ "${{ matrix.laravel }}" != 'true' && "${{ matrix.coverage }}" != 'true' ]]; then
             php -d memory_limit=-1 -d zend.enable_gc=0 -d error_reporting=-1 vendor/phpunit/phpunit/phpunit;

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,7 +108,7 @@ jobs:
           extensions: json, msgpack${{ matrix.laravel && ', dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, redis-phpredis/phpredis@5.3.5, igbinary, msgpack, lzf, zstd, lz4, memcached, gmp' || '' }}
           ini-values: error_reporting=${{ (matrix.setup != 'lowest') && '32767' || '8191' }}
           tools: composer:v2
-          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          coverage: ${{ matrix.coverage && 'pcov' || 'none' }}
         env:
           REDIS_CONFIGURE_OPTS: --enable-redis --enable-redis-igbinary --enable-redis-msgpack --enable-redis-lzf --with-liblzf --enable-redis-zstd --with-libzstd --enable-redis-lz4 --with-liblz4
           REDIS_LIBS: liblz4-dev, liblzf-dev, libzstd-dev
@@ -153,7 +153,7 @@ jobs:
       - name: Run test suite
         run: |
           if [[ "${{ matrix.laravel }}" != 'true' && "${{ matrix.coverage }}" = 'true' ]]; then
-            php -d memory_limit=-1 -d zend.enable_gc=0 -d error_reporting=-1 vendor/phpunit/phpunit/phpunit --coverage-clover=coverage.xml --coverage-text;
+            php -d memory_limit=-1 -d zend.enable_gc=0 -d error_reporting=-1 vendor/phpunit/phpunit/phpunit --coverage-clover=clover.xml;
           fi;
           if [[ "${{ matrix.laravel }}" != 'true' && "${{ matrix.coverage }}" != 'true' ]]; then
             php -d memory_limit=-1 -d zend.enable_gc=0 -d error_reporting=-1 vendor/phpunit/phpunit/phpunit;
@@ -179,7 +179,7 @@ jobs:
         continue-on-error: true
 
       - name: Coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         if: matrix.coverage
 
   windows:

--- a/src/Carbon/MessageFormatter/MessageFormatterMapper.php
+++ b/src/Carbon/MessageFormatter/MessageFormatterMapper.php
@@ -15,11 +15,13 @@ use ReflectionMethod;
 use Symfony\Component\Translation\Formatter\MessageFormatter;
 use Symfony\Component\Translation\Formatter\MessageFormatterInterface;
 
+// @codeCoverageIgnoreStart
 $transMethod = new ReflectionMethod(MessageFormatterInterface::class, 'format');
 
 require $transMethod->getParameters()[0]->hasType()
     ? __DIR__.'/../../../lazy/Carbon/MessageFormatter/MessageFormatterMapperStrongType.php'
     : __DIR__.'/../../../lazy/Carbon/MessageFormatter/MessageFormatterMapperWeakType.php';
+// @codeCoverageIgnoreEnd
 
 final class MessageFormatterMapper extends LazyMessageFormatter
 {

--- a/src/Carbon/Traits/Localization.php
+++ b/src/Carbon/Traits/Localization.php
@@ -23,6 +23,7 @@ use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Symfony\Contracts\Translation\TranslatorInterface as ContractsTranslatorInterface;
 
+// @codeCoverageIgnoreStart
 if (interface_exists('Symfony\\Contracts\\Translation\\TranslatorInterface') &&
     !interface_exists('Symfony\\Component\\Translation\\TranslatorInterface')
 ) {
@@ -31,6 +32,7 @@ if (interface_exists('Symfony\\Contracts\\Translation\\TranslatorInterface') &&
         'Symfony\\Component\\Translation\\TranslatorInterface'
     );
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * Trait Localization.


### PR DESCRIPTION
… Climate Test Reporter

fix ci deprecation for codecov V1 => V3
https://github.com/marketplace/actions/codecov

The change from xdebug to pcov (and only one coverage output file) speed the coverage run up from > 8:32 minutes to  1:15 minutes
Example of xdebug: https://github.com/briannesbitt/Carbon/actions/runs/6021629511/job/16336221316

Example of pcov: https://github.com/Chris53897/Carbon/actions/runs/6024021872/job/16341911483


But needs testing if CodeCov works correct and Code Climate starts to work.
@kylekatarnls This can only be done from maintainers. As i got the warning/error for the missing secret ;)

Code climate does not work in the past, if we can trust the warning, that it could not find the clover.xml (because it was coverage.xml before). And it it not possible to set the filename in code climate acction.

```
Coverage - PHP 8.2 - stable - ubuntu
Command failed: cc-test-reporter after-build -t clover
time="2023-08-26T21:07:20Z" level=error msg="could not find coverage file \ncould not find any files in search paths for clover. search paths were: , build/logs/clover.xml, clover.xml" 
Error: could not find any files in search paths for clover. search paths were: , build/logs/clover.xml, clover.xml```

