### PR TITLE
Update the names of timezones

### DIFF
--- a/tests/Carbon/SerializationTest.php
+++ b/tests/Carbon/SerializationTest.php
@@ -103,7 +103,7 @@ class SerializationTest extends AbstractTestCase
 
             @$reflection->date = '1990-01-17 10:28:07';
             @$reflection->timezone_type = 3;
-            @$reflection->timezone = 'US/Pacific';
+            @$reflection->timezone = 'America/Los_Angeles';
 
             $date = unserialize(serialize($reflection));
         } catch (Throwable $exception) {
@@ -118,7 +118,7 @@ class SerializationTest extends AbstractTestCase
 
         @$reflection->date = '1990-01-17 10:28:07';
         @$reflection->timezone_type = 3;
-        @$reflection->timezone = 'US/Pacific';
+        @$reflection->timezone = 'America/Los_Angeles';
 
         $date = unserialize(serialize($reflection));
 
@@ -146,7 +146,7 @@ class SerializationTest extends AbstractTestCase
 
         $setValue('date', '1990-01-17 10:28:07');
         $setValue('timezone_type', 3);
-        $setValue('timezone', 'US/Pacific');
+        $setValue('timezone', 'America/Los_Angeles');
 
         $date = unserialize(serialize($target));
 

--- a/tests/Carbon/TestingAidsTest.php
+++ b/tests/Carbon/TestingAidsTest.php
@@ -245,7 +245,7 @@ class TestingAidsTest extends AbstractTestCase
         $this->assertSame('2013-09-01T10:20:30-07:00', Carbon::createFromFormat('H:i:s', '10:20:30')->toIso8601String());
 
         // Custom timezone.
-        $this->assertSame('2013-09-01T10:20:00+03:00', Carbon::createFromFormat('H:i e', '10:20 Europe/Kiev')->toIso8601String());
+        $this->assertSame('2013-09-01T10:20:00+03:00', Carbon::createFromFormat('H:i e', '10:20 Europe/Kyiv')->toIso8601String());
         $this->assertSame('2013-09-01T10:20:00+01:00', Carbon::createFromFormat('H:i', '10:20', 'Europe/London')->toIso8601String());
         $this->assertSame('2013-09-01T11:30:00+07:00', Carbon::createFromFormat('H:i:s e', '11:30:00+07:00')->toIso8601String());
         $this->assertSame('2013-09-01T11:30:00+05:00', Carbon::createFromFormat('H:i:s', '11:30:00', '+05:00')->toIso8601String());
@@ -266,17 +266,17 @@ class TestingAidsTest extends AbstractTestCase
 
         // Resetting to epoch (timezone fun).
         $this->assertSame('1970-01-01T00:00:00-08:00', Carbon::createFromFormat('|', '')->toIso8601String());
-        $this->assertSame('1970-01-01T00:00:00+03:00', Carbon::createFromFormat('e|', 'Europe/Kiev')->toIso8601String());
+        $this->assertSame('1970-01-01T00:00:00+03:00', Carbon::createFromFormat('e|', 'Europe/Kyiv')->toIso8601String());
         $this->assertSame('1970-01-01T00:00:00+01:00', Carbon::createFromFormat('|', '', 'Europe/London')->toIso8601String());
         $this->assertSame('1970-01-01T00:00:00-08:00', Carbon::createFromFormat('!', '')->toIso8601String());
-        $this->assertSame('1970-01-01T00:00:00+03:00', Carbon::createFromFormat('!e', 'Europe/Kiev')->toIso8601String());
+        $this->assertSame('1970-01-01T00:00:00+03:00', Carbon::createFromFormat('!e', 'Europe/Kyiv')->toIso8601String());
         $this->assertSame('1970-01-01T00:00:00+01:00', Carbon::createFromFormat('!', '', 'Europe/London')->toIso8601String());
-        $this->assertSame('1970-01-01T00:00:00-08:00', Carbon::createFromFormat('e!', 'Europe/Kiev')->toIso8601String());
+        $this->assertSame('1970-01-01T00:00:00-08:00', Carbon::createFromFormat('e!', 'Europe/Kyiv')->toIso8601String());
 
         // Escaped epoch resets.
         $this->assertSame('2013-09-01T05:10:15-07:00', Carbon::createFromFormat('\|', '|')->toIso8601String());
         $this->assertSame('2013-09-01T05:10:15-07:00', Carbon::createFromFormat('\!', '!')->toIso8601String());
-        $this->assertSame('2013-09-01T05:10:15+03:00', Carbon::createFromFormat('e \!', 'Europe/Kiev !')->toIso8601String());
+        $this->assertSame('2013-09-01T05:10:15+03:00', Carbon::createFromFormat('e \!', 'Europe/Kyiv !')->toIso8601String());
     }
 
     public function testCreateFromPartialFormatWithMicroseconds()

--- a/tests/CarbonImmutable/SerializationTest.php
+++ b/tests/CarbonImmutable/SerializationTest.php
@@ -100,7 +100,7 @@ class SerializationTest extends AbstractTestCase
 
             @$reflection->date = '1990-01-17 10:28:07';
             @$reflection->timezone_type = 3;
-            @$reflection->timezone = 'US/Pacific';
+            @$reflection->timezone = 'America/Los_Angeles';
 
             $date = unserialize(serialize($reflection));
         } catch (Throwable $exception) {
@@ -115,7 +115,7 @@ class SerializationTest extends AbstractTestCase
 
         @$reflection->date = '1990-01-17 10:28:07';
         @$reflection->timezone_type = 3;
-        @$reflection->timezone = 'US/Pacific';
+        @$reflection->timezone = 'America/Los_Angeles';
 
         $date = unserialize(serialize($reflection));
 
@@ -143,7 +143,7 @@ class SerializationTest extends AbstractTestCase
 
         $setValue('date', '1990-01-17 10:28:07');
         $setValue('timezone_type', 3);
-        $setValue('timezone', 'US/Pacific');
+        $setValue('timezone', 'America/Los_Angeles');
 
         $date = unserialize(serialize($target));
 
@@ -214,12 +214,12 @@ class SerializationTest extends AbstractTestCase
 
         @$date->date = '1990-01-17 10:28:07';
         @$date->timezone_type = 3;
-        @$date->timezone = 'US/Pacific';
+        @$date->timezone = 'America/Los_Angeles';
         @$date->dumpLocale = 'es';
 
         $date->__wakeup();
 
-        $this->assertSame('1990-01-17 10:28:07 US/Pacific', $date->format('Y-m-d H:i:s e'));
+        $this->assertSame('1990-01-17 10:28:07 America/Los_Angeles', $date->format('Y-m-d H:i:s e'));
         $this->assertSame('es', $date->locale);
     }
 

--- a/tests/CarbonImmutable/TestingAidsTest.php
+++ b/tests/CarbonImmutable/TestingAidsTest.php
@@ -219,7 +219,7 @@ class TestingAidsTest extends AbstractTestCase
         $this->assertSame('2013-09-01T10:20:30-07:00', Carbon::createFromFormat('H:i:s', '10:20:30')->toIso8601String());
 
         // Custom timezone.
-        $this->assertSame('2013-09-01T10:20:00+03:00', Carbon::createFromFormat('H:i e', '10:20 Europe/Kiev')->toIso8601String());
+        $this->assertSame('2013-09-01T10:20:00+03:00', Carbon::createFromFormat('H:i e', '10:20 Europe/Kyiv')->toIso8601String());
         $this->assertSame('2013-09-01T10:20:00+01:00', Carbon::createFromFormat('H:i', '10:20', 'Europe/London')->toIso8601String());
         $this->assertSame('2013-09-01T11:30:00+07:00', Carbon::createFromFormat('H:i:s e', '11:30:00+07:00')->toIso8601String());
         $this->assertSame('2013-09-01T11:30:00+05:00', Carbon::createFromFormat('H:i:s', '11:30:00', '+05:00')->toIso8601String());
@@ -240,17 +240,17 @@ class TestingAidsTest extends AbstractTestCase
 
         // Resetting to epoch (timezone fun).
         $this->assertSame('1970-01-01T00:00:00-08:00', Carbon::createFromFormat('|', '')->toIso8601String());
-        $this->assertSame('1970-01-01T00:00:00+03:00', Carbon::createFromFormat('e|', 'Europe/Kiev')->toIso8601String());
+        $this->assertSame('1970-01-01T00:00:00+03:00', Carbon::createFromFormat('e|', 'Europe/Kyiv')->toIso8601String());
         $this->assertSame('1970-01-01T00:00:00+01:00', Carbon::createFromFormat('|', '', 'Europe/London')->toIso8601String());
         $this->assertSame('1970-01-01T00:00:00-08:00', Carbon::createFromFormat('!', '')->toIso8601String());
-        $this->assertSame('1970-01-01T00:00:00+03:00', Carbon::createFromFormat('!e', 'Europe/Kiev')->toIso8601String());
+        $this->assertSame('1970-01-01T00:00:00+03:00', Carbon::createFromFormat('!e', 'Europe/Kyiv')->toIso8601String());
         $this->assertSame('1970-01-01T00:00:00+01:00', Carbon::createFromFormat('!', '', 'Europe/London')->toIso8601String());
-        $this->assertSame('1970-01-01T00:00:00-08:00', Carbon::createFromFormat('e!', 'Europe/Kiev')->toIso8601String());
+        $this->assertSame('1970-01-01T00:00:00-08:00', Carbon::createFromFormat('e!', 'Europe/Kyiv')->toIso8601String());
 
         // Escaped epoch resets.
         $this->assertSame('2013-09-01T05:10:15-07:00', Carbon::createFromFormat('\|', '|')->toIso8601String());
         $this->assertSame('2013-09-01T05:10:15-07:00', Carbon::createFromFormat('\!', '!')->toIso8601String());
-        $this->assertSame('2013-09-01T05:10:15+03:00', Carbon::createFromFormat('e \!', 'Europe/Kiev !')->toIso8601String());
+        $this->assertSame('2013-09-01T05:10:15+03:00', Carbon::createFromFormat('e \!', 'Europe/Kyiv !')->toIso8601String());
 
         Carbon::setTestNow('2023-12-05 21:09:54');
         $this->assertSame('2023-12-05 15:00:00.000000', Carbon::createFromFormat('H', '15')->format('Y-m-d H:i:s.u'));

--- a/tests/CarbonTimeZone/ConversionsTest.php
+++ b/tests/CarbonTimeZone/ConversionsTest.php
@@ -112,7 +112,7 @@ class ConversionsTest extends AbstractTestCaseWithOldNow
         $summer = Carbon::parse('2020-06-15');
         $winter = Carbon::parse('2018-12-20');
         $this->assertSame('+02:00', (new CarbonTimeZone('Europe/Paris'))->toOffsetName());
-        $this->assertSame('+05:30', (new CarbonTimeZone('Asia/Calcutta'))->toOffsetName());
+        $this->assertSame('+05:30', (new CarbonTimeZone('Asia/Kolkata'))->toOffsetName());
         $this->assertSame('+13:45', CarbonTimeZone::create('Pacific/Chatham')->toOffsetName($winter));
         $this->assertSame('+12:00', CarbonTimeZone::create('Pacific/Auckland')->toOffsetName($summer));
         $this->assertSame('-05:15', CarbonTimeZone::createFromHourOffset(-5.25)->toOffsetName());


### PR DESCRIPTION
Some timezones have had their names changed. The newer names are recommended in newer versions of PHP [1].

    Asia/Calcutta -> Asia/Kolkata
    Europe/Kiev   -> Europe/Kyiv
    US/Pacific    -> America/Los_Angeles

[1] https://www.php.net/manual/en/timezones.others.php

---

The old names cause test failures on systems where legacy time zone data is not installed.