### PR TITLE
new function minuteOfDay() added

### DIFF
--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -543,6 +543,7 @@ trait Date
     use Timestamp;
     use Units;
     use Week;
+    use Minute;
 
     /**
      * Names of days of the week.
@@ -1069,6 +1070,9 @@ trait Date
             case $name === 'locale':
                 return $this->getTranslatorLocale();
 
+            case $name === 'minuteOfDay':
+                return $this->minuteOfDay();
+
             default:
                 $macro = $this->getLocalMacro('get'.ucfirst($name));
 
@@ -1229,6 +1233,10 @@ trait Date
             case 'tz':
                 $this->setTimezone($value);
 
+                break;
+
+            case 'minuteOfDay':
+                $this->minuteOfDay($value);
                 break;
 
             default:

--- a/src/Carbon/Traits/Minute.php
+++ b/src/Carbon/Traits/Minute.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Carbon\Traits;
+
+use Carbon\CarbonInterface;
+
+/**
+ * Depends on the following properties:
+ *
+ * @property int $hour
+ * @property int $minute
+ *
+ * Depends on the following methods:
+ *
+ * @method set($name, $value = null)
+ */
+trait Minute
+{
+    /**
+     * Get/set minute of day from 0 to 1439 (00:00 to 23:59th minute).
+     * If set value is greater than 1439, then appropriate days will be added
+     * If set value is less than zero then, no update happens.
+     *
+     * @param null $val*
+     *
+     * @return int
+     */
+    public function minuteOfDay($val = null): int
+    {
+        if(is_numeric($val) && $val >= 0) {
+            $max = ((CarbonInterface::HOURS_PER_DAY * CarbonInterface::MINUTES_PER_HOUR) - 1);
+            if($val > $max) {
+                $days = (int) floor($val / ($max + 1));
+                $this->addDays($days);
+                $val = $val - (($max + 1) * $days);
+            }
+            $this->set('hour', (int) floor($val / CarbonInterface::MINUTES_PER_HOUR));
+            $this->set('minute', $val % CarbonInterface::MINUTES_PER_HOUR);
+        }
+
+        return ($this->hour * CarbonInterface::MINUTES_PER_HOUR) + $this->minute;
+    }
+}

--- a/tests/Carbon/MinuteTest.php
+++ b/tests/Carbon/MinuteTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Carbon;
+
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
+use Tests\AbstractTestCase;
+
+class MinuteTest extends AbstractTestCase
+{
+    public function testMinuteOfDayGetter()
+    {
+        $cases = [
+            ['2023-10-23 00:00:00',0],
+            ['2023-10-23 04:00:00',4 * CarbonInterface::MINUTES_PER_HOUR],
+            ['2023-10-23 12:00:00',12 * CarbonInterface::MINUTES_PER_HOUR],
+            ['2023-10-23 17:00:00',17 * CarbonInterface::MINUTES_PER_HOUR],
+            ['2023-10-23 23:00:00',23 * CarbonInterface::MINUTES_PER_HOUR],
+            ['2023-10-23 00:01:00',(0 * CarbonInterface::MINUTES_PER_HOUR) + 1],
+            ['2023-10-23 00:02:00',(0 * CarbonInterface::MINUTES_PER_HOUR) + 2],
+            ['2023-10-23 00:05:00',(0 * CarbonInterface::MINUTES_PER_HOUR) + 5],
+            ['2023-10-23 00:30:00',(0 * CarbonInterface::MINUTES_PER_HOUR) + 30],
+            ['2023-10-23 00:45:00',(0 * CarbonInterface::MINUTES_PER_HOUR) + 45],
+            ['2023-10-23 00:59:00',(0 * CarbonInterface::MINUTES_PER_HOUR) + 59],
+            ['2023-10-23 04:01:00',(4 * CarbonInterface::MINUTES_PER_HOUR) + 1],
+            ['2023-10-23 04:02:00',(4 * CarbonInterface::MINUTES_PER_HOUR) + 2],
+            ['2023-10-23 04:05:00',(4 * CarbonInterface::MINUTES_PER_HOUR) + 5],
+            ['2023-10-23 04:30:00',(4 * CarbonInterface::MINUTES_PER_HOUR) + 30],
+            ['2023-10-23 04:45:00',(4 * CarbonInterface::MINUTES_PER_HOUR) + 45],
+            ['2023-10-23 04:59:00',(4 * CarbonInterface::MINUTES_PER_HOUR) + 59],
+            ['2023-10-23 12:01:00',(12 * CarbonInterface::MINUTES_PER_HOUR) + 1],
+            ['2023-10-23 12:02:00',(12 * CarbonInterface::MINUTES_PER_HOUR) + 2],
+            ['2023-10-23 12:05:00',(12 * CarbonInterface::MINUTES_PER_HOUR) + 5],
+            ['2023-10-23 12:30:00',(12 * CarbonInterface::MINUTES_PER_HOUR) + 30],
+            ['2023-10-23 12:45:00',(12 * CarbonInterface::MINUTES_PER_HOUR) + 45],
+            ['2023-10-23 12:59:00',(12 * CarbonInterface::MINUTES_PER_HOUR) + 59],
+            ['2023-10-23 23:01:00',(23 * CarbonInterface::MINUTES_PER_HOUR) + 1],
+            ['2023-10-23 23:02:00',(23 * CarbonInterface::MINUTES_PER_HOUR) + 2],
+            ['2023-10-23 23:05:00',(23 * CarbonInterface::MINUTES_PER_HOUR) + 5],
+            ['2023-10-23 23:30:00',(23 * CarbonInterface::MINUTES_PER_HOUR) + 30],
+            ['2023-10-23 23:45:00',(23 * CarbonInterface::MINUTES_PER_HOUR) + 45],
+            ['2023-10-23 23:59:00',(23 * CarbonInterface::MINUTES_PER_HOUR) + 59],
+        ];
+        foreach ($cases as $case) {
+            $date = Carbon::parse($case[0]);
+            $this->assertSame($case[1], $date->minuteOfDay());
+        }
+    }
+
+    public function testMinuteOfDaySetter()
+    {
+        $cases = [
+            ['2023-10-23 00:00:00',0,'2023-10-23 00:00:00'],
+            ['2023-10-23 00:00:00',10,'2023-10-23 00:10:00'],
+            ['2023-10-23 12:20:00',755,'2023-10-23 12:35:00'],
+            ['2023-10-23 12:20:00',840,'2023-10-23 14:00:00'],
+            ['2023-10-23 23:59:00',1461,'2023-10-24 00:21:00'],
+            ['2023-10-23 23:00:00',4321,'2023-10-26 00:01:00'],
+            ['2023-10-23 12:20:00',-100,'2023-10-23 12:20:00'],
+            ['2023-10-23 12:20:00','aa','2023-10-23 12:20:00'],
+        ];
+        foreach ($cases as $case) {
+            $date = Carbon::parse($case[0]);
+            $date->minuteOfDay($case[1]);
+            $this->assertSame(Carbon::parse($case[2])->toDateTimeString(), $date->toDateTimeString());
+        }
+    }
+}


### PR DESCRIPTION
Added a new function called minuteOfDay. This function represents how many minute passed for the day for a given Carbon instance.

For eg:

00:00:00 => 0th minute of day
00:04:00 => 4th minute of day
00:12:00 => 720th minute of day
23:59:00 => 1439th minute of day.

This function act as both getter and setter.

Getter
=====
Also works as property of the object Eg: 
```php
$date = Carbon::now();
// Both are equivalent
$date->minuteOfDay
$date->minuteOfDay()
```

Setter 
=====
```php
$date = Carbon::now(); // Say: 2023-10-23 14:23:00
$date->minuteOfDay(0) // $date becomes 2023-10-23 00:00:00
```