### PR TITLE
Narrow phpstan types in assertInstanceOf* AbstractTestCase methods

### DIFF
--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -181,6 +181,9 @@ abstract class AbstractTestCase extends TestCase
         $this->assertSame($expected, $actual);
     }
 
+    /**
+     * @phpstan-assert CarbonInterface $d
+     */
     public function assertInstanceOfCarbon($d)
     {
         $this->assertInstanceOf(CarbonInterface::class, $d);
@@ -229,6 +232,9 @@ abstract class AbstractTestCase extends TestCase
         }
     }
 
+    /**
+     * @phpstan-assert CarbonInterval $d
+     */
     public function assertInstanceOfCarbonInterval($d)
     {
         $this->assertInstanceOf(CarbonInterval::class, $d);


### PR DESCRIPTION
before this PR, PHPStan did not narrow the type of the arg given to e.g. `assertInstanceOfCarbon`

example taken from [ToArrayTest](https://github.com/briannesbitt/Carbon/blob/77eb7b390ba15b05d201c657c080280cbcf6780c/tests/CarbonPeriod/ToArrayTest.php#L99C1-L99C1):

```php
        \PHPStan\dumpType($date); // line 100
        $this->assertInstanceOfCarbon($date ?? null);
        \PHPStan\dumpType($date); // line 102
```

before this PR
```
------ ------------------------------------------ 
  Line   ToArrayTest.php                           
 ------ ------------------------------------------ 
  100    Dumped type: Carbon\CarbonInterface|null  
  102    Dumped type: Carbon\CarbonInterface|null  
 ------ ------------------------------------------ 
```

after this PR
```
------ ------------------------------------------ 
  Line   ToArrayTest.php                           
 ------ ------------------------------------------ 
  100    Dumped type: Carbon\CarbonInterface|null  
  102    Dumped type: Carbon\CarbonInterface
 ------ ------------------------------------------ 
```

PHPStan now can narrow the non-null part in line 102, which will help preventing false-positives on higher PHPStan levels