### PR TITLE
Allow Symfony 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "psr/clock": "^1.0",
         "symfony/polyfill-mbstring": "^1.0",
         "symfony/polyfill-php80": "^1.16",
-        "symfony/translation": "^3.4 || ^4.0 || ^5.0 || ^6.0"
+        "symfony/translation": "^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "doctrine/dbal": "^2.0 || ^3.1.4 || ^4.0",

--- a/lazy/Carbon/TranslatorImmutableStrongType.php
+++ b/lazy/Carbon/TranslatorImmutableStrongType.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Carbon;
+
+use Symfony\Component\Config\ConfigCacheFactoryInterface;
+use Symfony\Component\Translation\Exception\InvalidArgumentException;
+
+if (!class_exists(LazyTranslatorImmutable::class, false)) {
+    class LazyTranslatorImmutable extends AbstractTranslatorImmutable
+    {
+        /**
+         * @throws InvalidArgumentException
+         */
+        public function setLocale(string $locale): void
+        {
+            $this->setLocaleIdentifier($locale);
+        }
+
+        public function setConfigCacheFactory(ConfigCacheFactoryInterface $configCacheFactory): void
+        {
+            $this->setConfigCacheFactoryObject($configCacheFactory);
+        }
+
+        public function setFallbackLocales(array $locales): void
+        {
+            $this->setFallbackLocalesArray($locales);
+        }
+    }
+}

--- a/lazy/Carbon/TranslatorImmutableWeakType.php
+++ b/lazy/Carbon/TranslatorImmutableWeakType.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Carbon;
+
+use Symfony\Component\Config\ConfigCacheFactoryInterface;
+
+if (!class_exists(LazyTranslatorImmutable::class, false)) {
+    class LazyTranslatorImmutable extends AbstractTranslatorImmutable
+    {
+        public function setLocale($locale)
+        {
+            $this->setLocaleIdentifier($locale);
+        }
+
+        public function setConfigCacheFactory(ConfigCacheFactoryInterface $configCacheFactory)
+        {
+            $this->setConfigCacheFactoryObject($configCacheFactory);
+        }
+
+        public function setFallbackLocales(array $locales)
+        {
+            $this->setFallbackLocalesArray($locales);
+        }
+    }
+}

--- a/lazy/Carbon/TranslatorStrongType.php
+++ b/lazy/Carbon/TranslatorStrongType.php
@@ -11,6 +11,7 @@
 
 namespace Carbon;
 
+use Symfony\Component\Translation\Exception\InvalidArgumentException;
 use Symfony\Component\Translation\MessageCatalogueInterface;
 
 if (!class_exists(LazyTranslator::class, false)) {
@@ -47,6 +48,14 @@ if (!class_exists(LazyTranslator::class, false)) {
             return (function (string $field) {
                 return $this->$field;
             })->call($instance, $field);
+        }
+
+        /**
+         * @throws InvalidArgumentException
+         */
+        public function setLocale(string $locale): void
+        {
+            parent::setLocaleIdentifier($locale);
         }
     }
 }

--- a/lazy/Carbon/TranslatorWeakType.php
+++ b/lazy/Carbon/TranslatorWeakType.php
@@ -11,6 +11,8 @@
 
 namespace Carbon;
 
+use Symfony\Component\Translation\Exception\InvalidArgumentException;
+
 if (!class_exists(LazyTranslator::class, false)) {
     class LazyTranslator extends AbstractTranslator
     {
@@ -27,6 +29,17 @@ if (!class_exists(LazyTranslator::class, false)) {
         public function trans($id, array $parameters = [], $domain = null, $locale = null)
         {
             return $this->translate($id, $parameters, $domain, $locale);
+        }
+
+        public function setLocale($locale)
+        {
+            try {
+                parent::setLocaleIdentifier($locale);
+            } catch (InvalidArgumentException $e) {
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -62,5 +62,6 @@
 
     <php>
         <ini name="max_execution_time" value="0"/>
+        <ini name="memory_limit" value="256M"/>
     </php>
 </phpunit>

--- a/src/Carbon/AbstractTranslator.php
+++ b/src/Carbon/AbstractTranslator.php
@@ -300,13 +300,14 @@ abstract class AbstractTranslator extends Translation\Translator
     }
 
     /**
+     * @internal
      * Set the current translator locale and indicate if the source locale file exists
      *
      * @param string $locale locale ex. en
      *
      * @return bool
      */
-    public function setLocale($locale)
+    protected function setLocaleIdentifier($locale)
     {
         $locale = preg_replace_callback('/[-_]([a-z]{2,}|\d{2,})/', function ($matches) {
             // _2-letters or YUE is a region, _3+-letters is a variant

--- a/src/Carbon/AbstractTranslatorImmutable.php
+++ b/src/Carbon/AbstractTranslatorImmutable.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Carbon;
+
+use Carbon\Exceptions\ImmutableException;
+use Symfony\Component\Config\ConfigCacheFactoryInterface;
+use Symfony\Component\Translation\Formatter\MessageFormatterInterface;
+
+class AbstractTranslatorImmutable extends Translator
+{
+    /** @var bool */
+    private $constructed = false;
+
+    public function __construct($locale, MessageFormatterInterface $formatter = null, $cacheDir = null, $debug = false)
+    {
+        parent::__construct($locale, $formatter, $cacheDir, $debug);
+        $this->constructed = true;
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function setDirectories(array $directories)
+    {
+        $this->disallowMutation(__METHOD__);
+
+        return parent::setDirectories($directories);
+    }
+
+    /**
+     * @internal
+     */
+    protected function setLocaleIdentifier($locale)
+    {
+        $this->disallowMutation(__METHOD__);
+
+        parent::setLocale($locale);
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function setMessages($locale, $messages)
+    {
+        $this->disallowMutation(__METHOD__);
+
+        return parent::setMessages($locale, $messages);
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function setTranslations($messages)
+    {
+        $this->disallowMutation(__METHOD__);
+
+        return parent::setTranslations($messages);
+    }
+
+    /**
+     * @internal
+     * @codeCoverageIgnore
+     */
+    protected function setConfigCacheFactoryObject(ConfigCacheFactoryInterface $configCacheFactory)
+    {
+        $this->disallowMutation(__METHOD__);
+
+        parent::setConfigCacheFactory($configCacheFactory);
+    }
+
+    public function resetMessages($locale = null)
+    {
+        $this->disallowMutation(__METHOD__);
+
+        return parent::resetMessages($locale);
+    }
+
+    /**
+     * @internal
+     * @codeCoverageIgnore
+     */
+    protected function setFallbackLocalesArray(array $locales)
+    {
+        $this->disallowMutation(__METHOD__);
+
+        parent::setFallbackLocales($locales);
+    }
+
+    private function disallowMutation($method)
+    {
+        if ($this->constructed) {
+            throw new ImmutableException($method.' not allowed on '.static::class);
+        }
+    }
+}

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -2319,7 +2319,7 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
     public function round($precision = null, $function = 'round')
     {
         return $this->roundWith(
-            $precision ?? $this->getDateInterval()->setLocalTranslator(TranslatorImmutable::get('en'))->forHumans(),
+            $precision ?? $this->getDateInterval()->setLocalTranslator(AbstractTranslatorImmutable::get('en'))->forHumans(),
             $function
         );
     }

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -2319,7 +2319,7 @@ class CarbonPeriod implements Iterator, Countable, JsonSerializable
     public function round($precision = null, $function = 'round')
     {
         return $this->roundWith(
-            $precision ?? $this->getDateInterval()->setLocalTranslator(AbstractTranslatorImmutable::get('en'))->forHumans(),
+            $precision ?? $this->getDateInterval()->setLocalTranslator(TranslatorImmutable::get('en'))->forHumans(),
             $function
         );
     }

--- a/src/Carbon/TranslatorImmutable.php
+++ b/src/Carbon/TranslatorImmutable.php
@@ -11,89 +11,22 @@
 
 namespace Carbon;
 
-use Carbon\Exceptions\ImmutableException;
-use Symfony\Component\Config\ConfigCacheFactoryInterface;
-use Symfony\Component\Translation\Formatter\MessageFormatterInterface;
+use ReflectionMethod;
+use Symfony\Component\Translation;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
-class TranslatorImmutable extends Translator
+$transMethod = new ReflectionMethod(
+    class_exists(TranslatorInterface::class)
+        ? TranslatorInterface::class
+        : Translation\Translator::class,
+    'trans'
+);
+
+require $transMethod->hasReturnType()
+    ? __DIR__.'/../../lazy/Carbon/TranslatorImmutableStrongType.php'
+    : __DIR__.'/../../lazy/Carbon/TranslatorImmutableWeakType.php';
+
+class TranslatorImmutable extends LazyTranslatorImmutable
 {
-    /** @var bool */
-    private $constructed = false;
-
-    public function __construct($locale, MessageFormatterInterface $formatter = null, $cacheDir = null, $debug = false)
-    {
-        parent::__construct($locale, $formatter, $cacheDir, $debug);
-        $this->constructed = true;
-    }
-
-    /**
-     * @codeCoverageIgnore
-     */
-    public function setDirectories(array $directories)
-    {
-        $this->disallowMutation(__METHOD__);
-
-        return parent::setDirectories($directories);
-    }
-
-    public function setLocale($locale)
-    {
-        $this->disallowMutation(__METHOD__);
-
-        return parent::setLocale($locale);
-    }
-
-    /**
-     * @codeCoverageIgnore
-     */
-    public function setMessages($locale, $messages)
-    {
-        $this->disallowMutation(__METHOD__);
-
-        return parent::setMessages($locale, $messages);
-    }
-
-    /**
-     * @codeCoverageIgnore
-     */
-    public function setTranslations($messages)
-    {
-        $this->disallowMutation(__METHOD__);
-
-        return parent::setTranslations($messages);
-    }
-
-    /**
-     * @codeCoverageIgnore
-     */
-    public function setConfigCacheFactory(ConfigCacheFactoryInterface $configCacheFactory)
-    {
-        $this->disallowMutation(__METHOD__);
-
-        parent::setConfigCacheFactory($configCacheFactory);
-    }
-
-    public function resetMessages($locale = null)
-    {
-        $this->disallowMutation(__METHOD__);
-
-        return parent::resetMessages($locale);
-    }
-
-    /**
-     * @codeCoverageIgnore
-     */
-    public function setFallbackLocales(array $locales)
-    {
-        $this->disallowMutation(__METHOD__);
-
-        parent::setFallbackLocales($locales);
-    }
-
-    private function disallowMutation($method)
-    {
-        if ($this->constructed) {
-            throw new ImmutableException($method.' not allowed on '.static::class);
-        }
-    }
+    // Proxy dynamically loaded LazyTranslator in a static way
 }

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -23,9 +23,14 @@ use Carbon\Translator;
 use Closure;
 use DateTime;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 use ReflectionProperty;
+use Symfony\Component\Translation;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Tests\PHPUnit\AssertObjectHasPropertyTrait;
 use Throwable;
+
+use function class_exists;
 
 /**
  * @SuppressWarnings(PHPMD.NumberOfChildren)
@@ -343,5 +348,20 @@ abstract class AbstractTestCase extends TestCase
         }
 
         throw $firstError;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function translatorHasReturnType()
+    {
+        $transMethod = new ReflectionMethod(
+            class_exists(TranslatorInterface::class)
+                ? TranslatorInterface::class
+                : Translation\Translator::class,
+            'trans'
+        );
+
+        return $transMethod->hasReturnType();
     }
 }

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -30,8 +30,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 use Tests\PHPUnit\AssertObjectHasPropertyTrait;
 use Throwable;
 
-use function class_exists;
-
 /**
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  */

--- a/tests/Carbon/LocalizationTest.php
+++ b/tests/Carbon/LocalizationTest.php
@@ -375,16 +375,28 @@ class LocalizationTest extends AbstractTestCase
      */
     public function testSetLocaleWithMalformedLocale($malformedLocale)
     {
+        if ($this->translatorHasReturnType()) {
+            $this->markTestSkipped('Translator::setLocale returns void');
+        }
+
         $this->assertTrue(Carbon::setLocale($malformedLocale));
     }
 
     public function testSetLocaleWithNonExistingLocale()
     {
+        if ($this->translatorHasReturnType()) {
+            $this->markTestSkipped('Translator::setLocale returns void');
+        }
+
         $this->assertFalse(Carbon::setLocale('pt-XX'));
     }
 
     public function testSetLocaleWithUnknownLocale()
     {
+        if ($this->translatorHasReturnType()) {
+            $this->markTestSkipped('Translator::setLocale returns void');
+        }
+
         $this->assertFalse(Carbon::setLocale('zz'));
     }
 
@@ -526,24 +538,42 @@ class LocalizationTest extends AbstractTestCase
         $translator = Carbon::getTranslator();
         Carbon::setLocale('en');
 
-        $this->assertFalse(Carbon::setLocale('foo'));
+        $setLocale = Carbon::setLocale('foo');
+        if (!$this->translatorHasReturnType()) {
+            $this->assertFalse($setLocale);
+        }
+
         $this->assertSame('Saturday', Carbon::parse('2018-07-07 00:00:00')->isoFormat('dddd'));
 
         $translator->addDirectory($directory);
 
-        $this->assertTrue(Carbon::setLocale('foo'));
+        $setLocale = Carbon::setLocale('foo');
+        if (!$this->translatorHasReturnType()) {
+            $this->assertTrue($setLocale);
+        }
+
         $this->assertSame('samedi', Carbon::parse('2018-07-07 00:00:00')->isoFormat('dddd'));
 
         Carbon::setLocale('en');
         $translator->removeDirectory($directory);
 
-        $this->assertFalse(Carbon::setLocale('bar'));
+        $setLocale = Carbon::setLocale('bar');
+        if (!$this->translatorHasReturnType()) {
+            $this->assertFalse($setLocale);
+        }
+
         $this->assertSame('Saturday', Carbon::parse('2018-07-07 00:00:00')->isoFormat('dddd'));
 
-        $this->assertTrue(Carbon::setLocale('foo'));
+        $setLocale = Carbon::setLocale('foo');
+        if (!$this->translatorHasReturnType()) {
+            $this->assertTrue($setLocale);
+        }
+
         $this->assertSame('samedi', Carbon::parse('2018-07-07 00:00:00')->isoFormat('dddd'));
 
-        $this->assertTrue(Carbon::setLocale('en'));
+        if (!$this->translatorHasReturnType()) {
+            $this->assertTrue(Carbon::setLocale('en'));
+        }
     }
 
     public function testLocaleHasShortUnits()
@@ -587,6 +617,10 @@ class LocalizationTest extends AbstractTestCase
 
     public function testLocaleHasDiffSyntax()
     {
+        if ($this->translatorHasReturnType()) {
+            $this->markTestSkipped('Translator::setLocale returns void');
+        }
+
         $withDiffSyntax = [
             'year' => 'foo',
             'ago' => ':time ago',

--- a/tests/CarbonImmutable/LocalizationTest.php
+++ b/tests/CarbonImmutable/LocalizationTest.php
@@ -377,16 +377,28 @@ class LocalizationTest extends AbstractTestCase
      */
     public function testSetLocaleWithMalformedLocale($malformedLocale)
     {
+        if ($this->translatorHasReturnType()) {
+            $this->markTestSkipped('Translator::setLocale returns void');
+        }
+
         $this->assertTrue(Carbon::setLocale($malformedLocale));
     }
 
     public function testSetLocaleWithNonExistingLocale()
     {
+        if ($this->translatorHasReturnType()) {
+            $this->markTestSkipped('Translator::setLocale returns void');
+        }
+
         $this->assertFalse(Carbon::setLocale('pt-XX'));
     }
 
     public function testSetLocaleWithUnknownLocale()
     {
+        if ($this->translatorHasReturnType()) {
+            $this->markTestSkipped('Translator::setLocale returns void');
+        }
+
         $this->assertFalse(Carbon::setLocale('zz'));
     }
 
@@ -498,24 +510,42 @@ class LocalizationTest extends AbstractTestCase
         $translator = Carbon::getTranslator();
         Carbon::setLocale('en');
 
-        $this->assertFalse(Carbon::setLocale('foo'));
+        $setLocale = Carbon::setLocale('foo');
+        if (!$this->translatorHasReturnType()) {
+            $this->assertFalse($setLocale);
+        }
+
         $this->assertSame('Saturday', Carbon::parse('2018-07-07 00:00:00')->isoFormat('dddd'));
 
         $translator->addDirectory($directory);
 
-        $this->assertTrue(Carbon::setLocale('foo'));
+        $setLocale = Carbon::setLocale('foo');
+        if (!$this->translatorHasReturnType()) {
+            $this->assertTrue($setLocale);
+        }
+
         $this->assertSame('samedi', Carbon::parse('2018-07-07 00:00:00')->isoFormat('dddd'));
 
         Carbon::setLocale('en');
         $translator->removeDirectory($directory);
 
-        $this->assertFalse(Carbon::setLocale('bar'));
+        $setLocale = Carbon::setLocale('bar');
+        if (!$this->translatorHasReturnType()) {
+            $this->assertFalse($setLocale);
+        }
+
         $this->assertSame('Saturday', Carbon::parse('2018-07-07 00:00:00')->isoFormat('dddd'));
 
-        $this->assertTrue(Carbon::setLocale('foo'));
+        $setLocale = Carbon::setLocale('foo');
+        if (!$this->translatorHasReturnType()) {
+            $this->assertTrue($setLocale);
+        }
+
         $this->assertSame('samedi', Carbon::parse('2018-07-07 00:00:00')->isoFormat('dddd'));
 
-        $this->assertTrue(Carbon::setLocale('en'));
+        if (!$this->translatorHasReturnType()) {
+            $this->assertTrue(Carbon::setLocale('en'));
+        }
     }
 
     public function testLocaleHasShortUnits()
@@ -559,6 +589,10 @@ class LocalizationTest extends AbstractTestCase
 
     public function testLocaleHasDiffSyntax()
     {
+        if ($this->translatorHasReturnType()) {
+            $this->markTestSkipped('Translator::setLocale returns void');
+        }
+
         $withDiffSyntax = [
             'year' => 'foo',
             'ago' => ':time ago',
@@ -577,11 +611,19 @@ class LocalizationTest extends AbstractTestCase
         $translator->setMessages($withDiffSyntaxLocale, $withDiffSyntax);
         $translator->setMessages($withoutDiffSyntaxLocale, $withoutDiffSyntax);
 
-        $this->assertTrue(Carbon::localeHasDiffSyntax($withDiffSyntaxLocale));
-        $this->assertFalse(Carbon::localeHasDiffSyntax($withoutDiffSyntaxLocale));
+        if ($this->translatorHasReturnType()) {
+            $this->expectException(Symfony\Component\Translation\Exception\InvalidArgumentException::class);
+            Carbon::localeHasDiffSyntax($withoutDiffSyntaxLocale);
 
-        $this->assertTrue(Carbon::localeHasDiffSyntax('ka'));
-        $this->assertFalse(Carbon::localeHasDiffSyntax('foobar'));
+            $this->expectException(Symfony\Component\Translation\Exception\InvalidArgumentException::class);
+            Carbon::localeHasDiffSyntax('foobar');
+        } else {
+            $this->assertTrue(Carbon::localeHasDiffSyntax($withDiffSyntaxLocale));
+            $this->assertFalse(Carbon::localeHasDiffSyntax($withoutDiffSyntaxLocale));
+
+            $this->assertTrue(Carbon::localeHasDiffSyntax('ka'));
+            $this->assertFalse(Carbon::localeHasDiffSyntax('foobar'));
+        }
     }
 
     public function testLocaleHasDiffOneDayWords()

--- a/tests/Language/TranslatorTest.php
+++ b/tests/Language/TranslatorTest.php
@@ -18,7 +18,7 @@ use Carbon\Carbon;
 use Carbon\Exceptions\ImmutableException;
 use Carbon\Exceptions\NotLocaleAwareException;
 use Carbon\Translator;
-use Carbon\TranslatorImmutable;
+use Carbon\AbstractTranslatorImmutable;
 use ReflectionMethod;
 use Tests\AbstractTestCase;
 
@@ -83,8 +83,8 @@ class TranslatorTest extends AbstractTestCase
     public function testTranslatorImmutable()
     {
         $this->expectExceptionObject(
-            new ImmutableException('setTranslations not allowed on '.TranslatorImmutable::class)
+            new ImmutableException('setTranslations not allowed on '.AbstractTranslatorImmutable::class)
         );
-        TranslatorImmutable::get('en')->setTranslations([]);
+        AbstractTranslatorImmutable::get('en')->setTranslations([]);
     }
 }

--- a/tests/Language/TranslatorTest.php
+++ b/tests/Language/TranslatorTest.php
@@ -13,12 +13,11 @@ declare(strict_types=1);
 
 namespace Tests\Language;
 
-use Carbon\AbstractTranslator;
 use Carbon\Carbon;
 use Carbon\Exceptions\ImmutableException;
 use Carbon\Exceptions\NotLocaleAwareException;
 use Carbon\Translator;
-use Carbon\AbstractTranslatorImmutable;
+use Carbon\TranslatorImmutable;
 use ReflectionMethod;
 use Tests\AbstractTestCase;
 
@@ -62,7 +61,7 @@ class TranslatorTest extends AbstractTestCase
 
     public function testCompareChunkLists()
     {
-        $method = new ReflectionMethod(AbstractTranslator::class, 'compareChunkLists');
+        $method = new ReflectionMethod(Translator::class, 'compareChunkLists');
         $method->setAccessible(true);
         $this->assertSame(20, $method->invoke(null, ['a', 'b'], ['a', 'b']));
         $this->assertSame(10, $method->invoke(null, ['a', 'b'], ['a', 'c']));
@@ -83,8 +82,8 @@ class TranslatorTest extends AbstractTestCase
     public function testTranslatorImmutable()
     {
         $this->expectExceptionObject(
-            new ImmutableException('setTranslations not allowed on '.AbstractTranslatorImmutable::class)
+            new ImmutableException('setTranslations not allowed on '.TranslatorImmutable::class)
         );
-        AbstractTranslatorImmutable::get('en')->setTranslations([]);
+        TranslatorImmutable::get('en')->setTranslations([]);
     }
 }


### PR DESCRIPTION
Tried to make the library compatible with Symfony 7

- Followed the same setup using the `Lazy` implementation already used for the `Translator` class, to handle the incompatible return types and type hinted arguments.
- Not sure how to cope with the change of `Translator::setLocale` returning `void` (throwing `\Symfony\Component\Translation\Exception\InvalidArgumentException`) instead of `bool`. As I have the feeling it's just a BC break? It's getting more and more quirky to keep supporting older versions (of Symfony). Symfony `5.4` is the lowest LTS version atm, see https://symfony.com/releases
  - For now added skipping tests when the return type is `void`

Thoughts?