### PR TITLE
fix(Rounding): apply rounding changes to result before applying unit

### DIFF
--- a/src/Carbon/Traits/Rounding.php
+++ b/src/Carbon/Traits/Rounding.php
@@ -130,11 +130,13 @@ trait Rounding
         $normalizedValue = floor($function(($value - $minimum) / $precision) * $precision + $minimum);
 
         /** @var CarbonInterface $result */
-        $result = $this->$normalizedUnit($normalizedValue);
+        $result = $this;
 
         foreach ($changes as $unit => $value) {
             $result = $result->$unit($value);
         }
+
+        $result = $result->$normalizedUnit($normalizedValue);
 
         return $normalizedUnit === 'month' && $precision <= 1 && abs($result->month - $initialMonth) === 2
             // Re-run the change in case an overflow occurred

--- a/src/Carbon/Traits/Rounding.php
+++ b/src/Carbon/Traits/Rounding.php
@@ -136,12 +136,7 @@ trait Rounding
             $result = $result->$unit($value);
         }
 
-        $result = $result->$normalizedUnit($normalizedValue);
-
-        return $normalizedUnit === 'month' && $precision <= 1 && abs($result->month - $initialMonth) === 2
-            // Re-run the change in case an overflow occurred
-            ? $result->$normalizedUnit($normalizedValue)
-            : $result;
+        return $result->$normalizedUnit($normalizedValue);
     }
 
     /**

--- a/src/Carbon/Traits/Rounding.php
+++ b/src/Carbon/Traits/Rounding.php
@@ -57,7 +57,6 @@ trait Rounding
             'microsecond' => [0, 999999],
         ]);
         $factor = 1;
-        $initialMonth = $this->month;
 
         if ($normalizedUnit === 'week') {
             $normalizedUnit = 'day';

--- a/tests/Carbon/RoundTest.php
+++ b/tests/Carbon/RoundTest.php
@@ -202,6 +202,11 @@ class RoundTest extends AbstractTestCase
         $this->assertCarbon(Carbon::parse('2021-12-17')->ceilMonth(), 2022, 1, 1, 0, 0, 0);
     }
 
+    public function testFloorMonth()
+    {
+        $this->assertCarbon(Carbon::parse('2021-05-31')->floorMonth(3), 2021, 4, 1, 0, 0, 0);
+    }
+
     public function testRoundInvalidArgument()
     {
         $this->expectExceptionObject(new InvalidArgumentException(

--- a/tests/CarbonImmutable/RoundTest.php
+++ b/tests/CarbonImmutable/RoundTest.php
@@ -133,6 +133,11 @@ class RoundTest extends AbstractTestCase
         $this->assertCarbon(Carbon::parse('2021-12-17')->ceilMonth(), 2022, 1, 1, 0, 0, 0);
     }
 
+    public function testFloorMonth()
+    {
+        $this->assertCarbon(Carbon::parse('2021-05-31')->floorMonth(3), 2021, 4, 1, 0, 0, 0);
+    }
+
     public function testRoundInvalidArgument()
     {
         $this->expectExceptionObject(new InvalidArgumentException(


### PR DESCRIPTION
I was having a problem that looked a bit like #2268.

When rounding down to quarters, the month overflows when a date is after a possible date of the rounded month. This PR causes the changes to be applied before the main unit is changed, so the day is set before the month.

You can see an example in the tests. When rounding down months by a precision of 3, the 31st of may now becomes the 1st of april, instead of the 1st of may.