### PR TITLE
Cap to carbon-doctrine-types v2 by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "require": {
         "php": "^7.1.8 || ^8.0",
         "ext-json": "*",
-        "carbonphp/carbon-doctrine-types": "*",
+        "carbonphp/carbon-doctrine-types": "^1.0 || ^2.0",
         "psr/clock": "^1.0",
         "symfony/polyfill-mbstring": "^1.0",
         "symfony/polyfill-php80": "^1.16",


### PR DESCRIPTION
We are investigating why `composer` is not automatically resolving this when using `composer require doctrine/dbal` on a fresh Laravel project.

Anyone needing carbon-doctrine-types v3 (for dbal v4) can use:
```
composer require "carbonphp/carbon-doctrine-types:3.1.0 as 2.99.99"
```
for the moment.

Fix #2905