### PR TITLE
Allow to remove macro by passing null value

### DIFF
--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -3146,6 +3146,8 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
     /**
      * Register a custom macro.
      *
+     * Pass null macro to remove it.
+     *
      * @example
      * ```
      * $userSettings = [
@@ -3157,13 +3159,8 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
      * });
      * echo Carbon::yesterday()->hours(11)->userFormat();
      * ```
-     *
-     * @param string          $name
-     * @param object|callable $macro
-     *
-     * @return void
      */
-    public static function macro(string $name, callable|object $macro): void;
+    public static function macro(string $name, callable|object|null $macro): void;
 
     /**
      * Make a Carbon instance from given variable if possible.

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -1469,6 +1469,8 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
     /**
      * Register a custom macro.
      *
+     * Pass null macro to remove it.
+     *
      * @example
      * ```
      * CarbonInterval::macro('twice', function () {
@@ -1476,13 +1478,8 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
      * });
      * echo CarbonInterval::hours(2)->twice();
      * ```
-     *
-     * @param string          $name
-     * @param object|callable $macro
-     *
-     * @return void
      */
-    public static function macro(string $name, $macro): void
+    public static function macro(string $name, object|callable|null $macro): void
     {
         static::$macros[$name] = $macro;
     }

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -514,6 +514,8 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
     /**
      * Register a custom macro.
      *
+     * Pass null macro to remove it.
+     *
      * @example
      * ```
      * CarbonPeriod::macro('middle', function () {
@@ -521,13 +523,8 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
      * });
      * echo CarbonPeriod::since('2011-05-12')->until('2011-06-03')->middle();
      * ```
-     *
-     * @param string          $name
-     * @param object|callable $macro
-     *
-     * @return void
      */
-    public static function macro(string $name, $macro): void
+    public static function macro(string $name, object|callable|null $macro): void
     {
         static::$macros[$name] = $macro;
     }

--- a/src/Carbon/Factory.php
+++ b/src/Carbon/Factory.php
@@ -305,19 +305,21 @@ class Factory
     /**
      * Register a custom macro.
      *
+     * Pass null macro to remove it.
+     *
      * @example
      * ```
      * $userSettings = [
      *   'locale' => 'pt',
      *   'timezone' => 'America/Sao_Paulo',
      * ];
-     * Carbon::macro('userFormat', function () use ($userSettings) {
+     * $factory->macro('userFormat', function () use ($userSettings) {
      *   return $this->copy()->locale($userSettings['locale'])->tz($userSettings['timezone'])->calendar();
      * });
-     * echo Carbon::yesterday()->hours(11)->userFormat();
+     * echo $factory->yesterday()->hours(11)->userFormat();
      * ```
      */
-    public function macro(string $name, object|callable $macro): void
+    public function macro(string $name, object|callable|null $macro): void
     {
         $macros = $this->getSettings()['macros'] ?? [];
         $macros[$name] = $macro;

--- a/src/Carbon/Traits/Macro.php
+++ b/src/Carbon/Traits/Macro.php
@@ -39,12 +39,9 @@ trait Macro
      * echo Carbon::yesterday()->hours(11)->userFormat();
      * ```
      *
-     * @param string          $name
-     * @param object|callable $macro
-     *
-     * @return void
+     * Pass null macro to remove it.
      */
-    public static function macro(string $name, object|callable $macro): void
+    public static function macro(string $name, object|callable|null $macro): void
     {
         FactoryImmutable::getDefaultInstance()->macro($name, $macro);
     }


### PR DESCRIPTION
Re-enable macro-removal feature from 2.x.