### PR TITLE
Use static values for enums until dropping PHP 8.1

### DIFF
--- a/src/Carbon/Month.php
+++ b/src/Carbon/Month.php
@@ -17,18 +17,19 @@ use Carbon\Exceptions\InvalidFormatException;
 
 enum Month: int
 {
-    case January = CarbonInterface::JANUARY;
-    case February = CarbonInterface::FEBRUARY;
-    case March = CarbonInterface::MARCH;
-    case April = CarbonInterface::APRIL;
-    case May = CarbonInterface::MAY;
-    case June = CarbonInterface::JUNE;
-    case July = CarbonInterface::JULY;
-    case August = CarbonInterface::AUGUST;
-    case September = CarbonInterface::SEPTEMBER;
-    case October = CarbonInterface::OCTOBER;
-    case November = CarbonInterface::NOVEMBER;
-    case December = CarbonInterface::DECEMBER;
+    // Using constants is only safe starting from PHP 8.2
+    case January = 1; // CarbonInterface::JANUARY
+    case February = 2; // CarbonInterface::FEBRUARY
+    case March = 3; // CarbonInterface::MARCH
+    case April = 4; // CarbonInterface::APRIL
+    case May = 5; // CarbonInterface::MAY
+    case June = 6; // CarbonInterface::JUNE
+    case July = 7; // CarbonInterface::JULY
+    case August = 8; // CarbonInterface::AUGUST
+    case September = 9; // CarbonInterface::SEPTEMBER
+    case October = 10; // CarbonInterface::OCTOBER
+    case November = 11; // CarbonInterface::NOVEMBER
+    case December = 12; // CarbonInterface::DECEMBER
 
     public static function int(self|int|null $value): ?int
     {

--- a/src/Carbon/WeekDay.php
+++ b/src/Carbon/WeekDay.php
@@ -17,13 +17,14 @@ use Carbon\Exceptions\InvalidFormatException;
 
 enum WeekDay: int
 {
-    case Sunday = CarbonInterface::SUNDAY;
-    case Monday = CarbonInterface::MONDAY;
-    case Tuesday = CarbonInterface::TUESDAY;
-    case Wednesday = CarbonInterface::WEDNESDAY;
-    case Thursday = CarbonInterface::THURSDAY;
-    case Friday = CarbonInterface::FRIDAY;
-    case Saturday = CarbonInterface::SATURDAY;
+    // Using constants is only safe starting from PHP 8.2
+    case Sunday = 0; // CarbonInterface::SUNDAY
+    case Monday = 1; // CarbonInterface::MONDAY
+    case Tuesday = 2; // CarbonInterface::TUESDAY
+    case Wednesday = 3; // CarbonInterface::WEDNESDAY
+    case Thursday = 4; // CarbonInterface::THURSDAY
+    case Friday = 5; // CarbonInterface::FRIDAY
+    case Saturday = 6; // CarbonInterface::SATURDAY
 
     public static function int(self|int|null $value): ?int
     {


### PR DESCRIPTION
Fix #2934