### PR TITLE
Remove unnecessary suffix to Taiwan name

### DIFF
--- a/src/Carbon/List/regions.php
+++ b/src/Carbon/List/regions.php
@@ -242,7 +242,7 @@ return [
     'TR' => 'Turkey',
     'TT' => 'Trinidad and Tobago',
     'TV' => 'Tuvalu',
-    'TW' => 'Taiwan, Province of China',
+    'TW' => 'Taiwan',
     'TZ' => 'Tanzania, United Republic of',
     'UA' => 'Ukraine',
     'UG' => 'Uganda',


### PR DESCRIPTION
Fix #2956

Note for people needing custom region names: you can still use the previous name or any other and you can more generally choose your own name for any code

```php
$locale = new Language('zh_TW');

$region = match ($locale->getRegion()) {
    // Here you can override whatever code
    'TW' => 'The name you want for TW in your app',
    'US' => 'The name you want for US in your app',
    //...
    default => $locale->getRegionName(),
};
```

One more note: Carbon and its contributor are not siding neither against nor for the unification and do not intent to give any political opinion on the Taiwan government matter. We genuinely intend to provide an unambiguous and respectful name to locate the ISO code "TW" and to keep it short if possible cutting anything not strictly necessary to serve this purpose.

https://github.com/briannesbitt/Carbon/issues/2956#issuecomment-1981342704