### PR TITLE
Add diffCalendarMonths to difference, date trait

### DIFF
--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -2904,7 +2904,7 @@ trait Date
         return $this->get($name);
     }
 
-    private function diffCalenderMonths(mixed $fromDate, mixed $toDate){
+    private function diffCalendarMonths(mixed $fromDate, mixed $toDate){
      
         if (empty($fromDate) || empty($toDate)){
             return null;

--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -2903,4 +2903,13 @@ trait Date
 
         return $this->get($name);
     }
+
+    private function diffCalenderMonths(mixed $fromDate, mixed $toDate){
+     
+        if (empty($fromDate) || empty($toDate)){
+            return null;
+        }
+
+        return $this->diffCalenderMonths($fromDate, $toDate);
+    }
 }

--- a/src/Carbon/Traits/Difference.php
+++ b/src/Carbon/Traits/Difference.php
@@ -825,16 +825,15 @@ trait Difference
 
     /**
      * Returns difference between two dates using calender months,
-     * (e.g. diffCalenderMonths(2023-12-25, 2024-02-10) = 2) (from Dec Until January and from January until February)).
-     *
-     * Language, date and time formats will change according to the current locale.
+     * (e.g. diffCalendarMonths(2023-12-25, 2024-02-10) = 2) (from Dec Until January and from January until February)).
      *
      * @param Carbon|\DateTimeInterface|string|null $fromDate
      * @param Carbon|\DateTimeInterface|string|null $toDate
      *
      * @return integer
      */
-    private static function diffCalendarMonths(mixed $fromDate, mixed $toDate){
+    private static function diffCalendarMonths(mixed $fromDate, mixed $toDate)
+    {
         $fromDate = Carbon::parse($fromDate)->startOfMonth();
         $toDate = Carbon::parse($toDate)->startOfMonth();
         return $fromDate->diffInMonths($toDate);

--- a/src/Carbon/Traits/Difference.php
+++ b/src/Carbon/Traits/Difference.php
@@ -834,7 +834,7 @@ trait Difference
      *
      * @return integer
      */
-    private static function diffCalenderMonths(mixed $fromDate, mixed $toDate){
+    private static function diffCalendarMonths(mixed $fromDate, mixed $toDate){
         $fromDate = Carbon::parse($fromDate)->startOfMonth();
         $toDate = Carbon::parse($toDate)->startOfMonth();
         return $fromDate->diffInMonths($toDate);

--- a/src/Carbon/Traits/Difference.php
+++ b/src/Carbon/Traits/Difference.php
@@ -821,4 +821,22 @@ trait Difference
 
         return $daysDiff * $sign;
     }
+
+
+    /**
+     * Returns difference between two dates using calender months,
+     * (e.g. diffCalenderMonths(2023-12-25, 2024-02-10) = 2) (from Dec Until January and from January until February)).
+     *
+     * Language, date and time formats will change according to the current locale.
+     *
+     * @param Carbon|\DateTimeInterface|string|null $fromDate
+     * @param Carbon|\DateTimeInterface|string|null $toDate
+     *
+     * @return integer
+     */
+    private static function diffCalenderMonths(mixed $fromDate, mixed $toDate){
+        $fromDate = Carbon::parse($fromDate)->startOfMonth();
+        $toDate = Carbon::parse($toDate)->startOfMonth();
+        return $fromDate->diffInMonths($toDate);
+    }
 }


### PR DESCRIPTION
**The diffCalendarMonths() method is used when checking the difference in calendar months for two financial dates.**

```
$fromDate = Carbon::parse("2023-12-25");
$toDate = Carbon::parse("2024-02-10");

// this will use days to check for months difference
dd($toDate->diffInMonths($fromDate)); // = 1 month

// unlike the above method, we will use calendar months difference (from Dec until Jan and from Jan until Feb) 
// this method will be used more in the financial fields
dd(diffCalendarMonths($fromDate, $toDate)); // = 2 months
```
