### PR TITLE
[PHP 8.4] Fixes for implicit nullability deprecation

### DIFF
--- a/src/Carbon/AbstractTranslator.php
+++ b/src/Carbon/AbstractTranslator.php
@@ -86,7 +86,7 @@ abstract class AbstractTranslator extends Translation\Translator
         return static::$singletons[$key];
     }
 
-    public function __construct($locale, MessageFormatterInterface $formatter = null, $cacheDir = null, $debug = false)
+    public function __construct($locale, ?MessageFormatterInterface $formatter = null, $cacheDir = null, $debug = false)
     {
         parent::setLocale($locale);
         $this->initializing = true;

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -925,7 +925,7 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
      *
      * @return static
      */
-    public function toggleOptions(int $options, bool $state = null): static
+    public function toggleOptions(int $options, ?bool $state = null): static
     {
         if ($state === null) {
             $state = ($this->options & $options) !== $options;
@@ -1216,7 +1216,7 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
      *
      * @return static
      */
-    public function setStartDate(mixed $date, bool $inclusive = null): static
+    public function setStartDate(mixed $date, ?bool $inclusive = null): static
     {
         if (!$this->isInfiniteDate($date) && !($date = ([$this->dateClass, 'make'])($date))) {
             throw new InvalidPeriodDateException('Invalid start date.');

--- a/src/Carbon/Exceptions/BadComparisonUnitException.php
+++ b/src/Carbon/Exceptions/BadComparisonUnitException.php
@@ -31,7 +31,7 @@ class BadComparisonUnitException extends UnitException
      * @param int            $code
      * @param Throwable|null $previous
      */
-    public function __construct($unit, $code = 0, Throwable $previous = null)
+    public function __construct($unit, $code = 0, ?Throwable $previous = null)
     {
         $this->unit = $unit;
 

--- a/src/Carbon/Exceptions/BadFluentConstructorException.php
+++ b/src/Carbon/Exceptions/BadFluentConstructorException.php
@@ -32,7 +32,7 @@ class BadFluentConstructorException extends BaseBadMethodCallException implement
      * @param int            $code
      * @param Throwable|null $previous
      */
-    public function __construct($method, $code = 0, Throwable $previous = null)
+    public function __construct($method, $code = 0, ?Throwable $previous = null)
     {
         $this->method = $method;
 

--- a/src/Carbon/Exceptions/BadFluentSetterException.php
+++ b/src/Carbon/Exceptions/BadFluentSetterException.php
@@ -32,7 +32,7 @@ class BadFluentSetterException extends BaseBadMethodCallException implements Bad
      * @param int            $code
      * @param Throwable|null $previous
      */
-    public function __construct($setter, $code = 0, Throwable $previous = null)
+    public function __construct($setter, $code = 0, ?Throwable $previous = null)
     {
         $this->setter = $setter;
 

--- a/src/Carbon/Exceptions/ImmutableException.php
+++ b/src/Carbon/Exceptions/ImmutableException.php
@@ -32,7 +32,7 @@ class ImmutableException extends BaseRuntimeException implements RuntimeExceptio
      * @param int            $code
      * @param Throwable|null $previous
      */
-    public function __construct($value, $code = 0, Throwable $previous = null)
+    public function __construct($value, $code = 0, ?Throwable $previous = null)
     {
         $this->value = $value;
         parent::__construct("$value is immutable.", $code, $previous);

--- a/src/Carbon/Exceptions/InvalidDateException.php
+++ b/src/Carbon/Exceptions/InvalidDateException.php
@@ -40,7 +40,7 @@ class InvalidDateException extends BaseInvalidArgumentException implements Inval
      * @param int            $code
      * @param Throwable|null $previous
      */
-    public function __construct($field, $value, $code = 0, Throwable $previous = null)
+    public function __construct($field, $value, $code = 0, ?Throwable $previous = null)
     {
         $this->field = $field;
         $this->value = $value;

--- a/src/Carbon/Exceptions/NotACarbonClassException.php
+++ b/src/Carbon/Exceptions/NotACarbonClassException.php
@@ -33,7 +33,7 @@ class NotACarbonClassException extends BaseInvalidArgumentException implements I
      * @param int            $code
      * @param Throwable|null $previous
      */
-    public function __construct($className, $code = 0, Throwable $previous = null)
+    public function __construct($className, $code = 0, ?Throwable $previous = null)
     {
         $this->className = $className;
 

--- a/src/Carbon/Exceptions/NotLocaleAwareException.php
+++ b/src/Carbon/Exceptions/NotLocaleAwareException.php
@@ -25,7 +25,7 @@ class NotLocaleAwareException extends BaseInvalidArgumentException implements In
      * @param int            $code
      * @param Throwable|null $previous
      */
-    public function __construct($object, $code = 0, Throwable $previous = null)
+    public function __construct($object, $code = 0, ?Throwable $previous = null)
     {
         $dump = \is_object($object) ? \get_class($object) : \gettype($object);
 

--- a/src/Carbon/Exceptions/OutOfRangeException.php
+++ b/src/Carbon/Exceptions/OutOfRangeException.php
@@ -59,7 +59,7 @@ class OutOfRangeException extends BaseInvalidArgumentException implements Invali
      * @param int            $code
      * @param Throwable|null $previous
      */
-    public function __construct($unit, $min, $max, $value, $code = 0, Throwable $previous = null)
+    public function __construct($unit, $min, $max, $value, $code = 0, ?Throwable $previous = null)
     {
         $this->unit = $unit;
         $this->min = $min;

--- a/src/Carbon/Exceptions/ParseErrorException.php
+++ b/src/Carbon/Exceptions/ParseErrorException.php
@@ -47,7 +47,7 @@ class ParseErrorException extends BaseInvalidArgumentException implements Invali
      * @param int            $code
      * @param Throwable|null $previous
      */
-    public function __construct($expected, $actual, $help = '', $code = 0, Throwable $previous = null)
+    public function __construct($expected, $actual, $help = '', $code = 0, ?Throwable $previous = null)
     {
         $this->expected = $expected;
         $this->actual = $actual;

--- a/src/Carbon/Exceptions/UnitNotConfiguredException.php
+++ b/src/Carbon/Exceptions/UnitNotConfiguredException.php
@@ -31,7 +31,7 @@ class UnitNotConfiguredException extends UnitException
      * @param int            $code
      * @param Throwable|null $previous
      */
-    public function __construct($unit, $code = 0, Throwable $previous = null)
+    public function __construct($unit, $code = 0, ?Throwable $previous = null)
     {
         $this->unit = $unit;
 

--- a/src/Carbon/Exceptions/UnknownGetterException.php
+++ b/src/Carbon/Exceptions/UnknownGetterException.php
@@ -32,7 +32,7 @@ class UnknownGetterException extends BaseInvalidArgumentException implements Inv
      * @param int            $code
      * @param Throwable|null $previous
      */
-    public function __construct($getter, $code = 0, Throwable $previous = null)
+    public function __construct($getter, $code = 0, ?Throwable $previous = null)
     {
         $this->getter = $getter;
 

--- a/src/Carbon/Exceptions/UnknownMethodException.php
+++ b/src/Carbon/Exceptions/UnknownMethodException.php
@@ -32,7 +32,7 @@ class UnknownMethodException extends BaseBadMethodCallException implements BadMe
      * @param int            $code
      * @param Throwable|null $previous
      */
-    public function __construct($method, $code = 0, Throwable $previous = null)
+    public function __construct($method, $code = 0, ?Throwable $previous = null)
     {
         $this->method = $method;
 

--- a/src/Carbon/Exceptions/UnknownSetterException.php
+++ b/src/Carbon/Exceptions/UnknownSetterException.php
@@ -32,7 +32,7 @@ class UnknownSetterException extends BaseInvalidArgumentException implements Bad
      * @param int            $code
      * @param Throwable|null $previous
      */
-    public function __construct($setter, $code = 0, Throwable $previous = null)
+    public function __construct($setter, $code = 0, ?Throwable $previous = null)
     {
         $this->setter = $setter;
 

--- a/src/Carbon/Exceptions/UnknownUnitException.php
+++ b/src/Carbon/Exceptions/UnknownUnitException.php
@@ -31,7 +31,7 @@ class UnknownUnitException extends UnitException
      * @param int            $code
      * @param Throwable|null $previous
      */
-    public function __construct($unit, $code = 0, Throwable $previous = null)
+    public function __construct($unit, $code = 0, ?Throwable $previous = null)
     {
         $this->unit = $unit;
 

--- a/src/Carbon/Exceptions/UnsupportedUnitException.php
+++ b/src/Carbon/Exceptions/UnsupportedUnitException.php
@@ -20,7 +20,7 @@ use Exception;
  */
 class UnsupportedUnitException extends UnitException
 {
-    public function __construct(string $unit, int $code = 0, Exception $previous = null)
+    public function __construct(string $unit, int $code = 0, ?Exception $previous = null)
     {
         parent::__construct("Unsupported unit '$unit'", $code, $previous);
     }

--- a/src/Carbon/Factory.php
+++ b/src/Carbon/Factory.php
@@ -251,7 +251,7 @@ class Factory
         return $this;
     }
 
-    public function className(string $className = null): self|string
+    public function className(?string $className = null): self|string
     {
         return $className === null ? $this->getClassName() : $this->setClassName($className);
     }
@@ -268,7 +268,7 @@ class Factory
         return $this;
     }
 
-    public function settings(array $settings = null): self|array
+    public function settings(?array $settings = null): self|array
     {
         return $settings === null ? $this->getSettings() : $this->setSettings($settings);
     }

--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -1380,7 +1380,7 @@ trait Date
      *
      * @return $this
      */
-    public function set(Unit|array|string $name, DateTimeZone|Month|string|int|float $value = null): static
+    public function set(Unit|array|string $name, DateTimeZone|Month|string|int|float|null $value = null): static
     {
         if ($this->isImmutable()) {
             throw new ImmutableException(sprintf('%s class', static::class));
@@ -2503,7 +2503,7 @@ trait Date
      * @param string    $unit  year, month, day, hour, minute, second or microsecond
      * @param Month|int $value new value for given unit
      */
-    public function setUnit(string $unit, Month|int|float $value = null): static
+    public function setUnit(string $unit, Month|int|float|null $value = null): static
     {
         if (\is_float($value)) {
             $int = (int) $value;

--- a/src/Carbon/Traits/Localization.php
+++ b/src/Carbon/Traits/Localization.php
@@ -347,7 +347,7 @@ trait Localization
      *
      * @return $this|string
      */
-    public function locale(string $locale = null, string ...$fallbackLocales): static|string
+    public function locale(?string $locale = null, string ...$fallbackLocales): static|string
     {
         if ($locale === null) {
             return $this->getTranslatorLocale();

--- a/src/Carbon/TranslatorImmutable.php
+++ b/src/Carbon/TranslatorImmutable.php
@@ -21,7 +21,7 @@ class TranslatorImmutable extends Translator
 {
     private bool $constructed = false;
 
-    public function __construct($locale, MessageFormatterInterface $formatter = null, $cacheDir = null, $debug = false)
+    public function __construct($locale, ?MessageFormatterInterface $formatter = null, $cacheDir = null, $debug = false)
     {
         parent::__construct($locale, $formatter, $cacheDir, $debug);
         $this->constructed = true;

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -225,7 +225,7 @@ abstract class AbstractTestCase extends TestCase
         $this->assertInstanceOf(CarbonInterval::class, $d);
     }
 
-    public function wrapWithTestNow(Closure $func, CarbonInterface $dt = null): void
+    public function wrapWithTestNow(Closure $func, ?CarbonInterface $dt = null): void
     {
         $test = Carbon::getTestNow();
         $immutableTest = CarbonImmutable::getTestNow();

--- a/tests/Carbon/DiffTest.php
+++ b/tests/Carbon/DiffTest.php
@@ -26,7 +26,7 @@ use TypeError;
 
 class DiffTest extends AbstractTestCase
 {
-    public function wrapWithTestNow(Closure $func, CarbonInterface $dt = null): void
+    public function wrapWithTestNow(Closure $func, ?CarbonInterface $dt = null): void
     {
         parent::wrapWithTestNow($func, $dt ?: Carbon::createMidnightDate(2012, 1, 1));
     }

--- a/tests/Carbon/Fixtures/NoLocaleTranslator.php
+++ b/tests/Carbon/Fixtures/NoLocaleTranslator.php
@@ -28,7 +28,7 @@ $transMethod = new ReflectionMethod(
 if ($transMethod->hasReturnType()) {
     class NoLocaleTranslator implements TranslatorInterface
     {
-        public function trans(string $id, array $parameters = [], string $domain = null, string $locale = null): string
+        public function trans(string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string
         {
             return $id;
         }

--- a/tests/Carbon/MacroTest.php
+++ b/tests/Carbon/MacroTest.php
@@ -334,7 +334,7 @@ class MacroTest extends AbstractTestCaseWithOldNow
 
         $subCarbon = new SubCarbon('2024-01-24 00:00');
 
-        SubCarbon::macro('diffInDecades', function (SubCarbon|string $dt = null, $abs = true) {
+        SubCarbon::macro('diffInDecades', function (SubCarbon|string|null $dt = null, $abs = true) {
             return (int) ($this->diffInYears($dt, $abs) / 10);
         });
 

--- a/tests/CarbonImmutable/DiffTest.php
+++ b/tests/CarbonImmutable/DiffTest.php
@@ -23,7 +23,7 @@ use TypeError;
 
 class DiffTest extends AbstractTestCase
 {
-    public function wrapWithTestNow(Closure $func, CarbonInterface $dt = null): void
+    public function wrapWithTestNow(Closure $func, ?CarbonInterface $dt = null): void
     {
         parent::wrapWithTestNow($func, $dt ?: Carbon::createMidnightDate(2012, 1, 1));
     }

--- a/tests/CarbonImmutable/MacroTest.php
+++ b/tests/CarbonImmutable/MacroTest.php
@@ -163,7 +163,7 @@ class MacroTest extends AbstractTestCaseWithOldNow
 
         $subCarbon = new SubCarbonImmutable('2024-01-24 00:00');
 
-        SubCarbonImmutable::macro('diffInDecades', function (SubCarbonImmutable|string $dt = null, $abs = true) {
+        SubCarbonImmutable::macro('diffInDecades', function (SubCarbonImmutable|string|null $dt = null, $abs = true) {
             return (int) ($this->diffInYears($dt, $abs) / 10);
         });
 

--- a/tests/CarbonImmutable/TestingAidsTest.php
+++ b/tests/CarbonImmutable/TestingAidsTest.php
@@ -24,7 +24,7 @@ use Tests\AbstractTestCase;
 
 class TestingAidsTest extends AbstractTestCase
 {
-    public function wrapWithTestNow(Closure $func, CarbonInterface $dt = null): void
+    public function wrapWithTestNow(Closure $func, ?CarbonInterface $dt = null): void
     {
         Carbon::setTestNow($dt ?: Carbon::now());
         $func();


### PR DESCRIPTION
Fixes all issues that emit deprecation notices on PHP 8.4 for implicit nullable parameter type declarations.

See:
 - [RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)
 - [PHP 8.4: Implicitly nullable parameter declarations deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)