### PR TITLE
Fix fatal error with php 8.2+

### DIFF
--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -104,7 +104,9 @@ trait Creator
 
         $this->constructedObjectId = spl_object_hash($this);
 
-        self::setLastErrors(parent::getLastErrors());
+        if (parent::getLastErrors()) {
+        	self::setLastErrors(parent::getLastErrors());
+        }
     }
 
     /**


### PR DESCRIPTION
When there is no error, we try to set "false" inside the error string generating a fatal error with PHP8.2 and some setup, when everything is ok. This broke for exemple the use of PHP-IMAP library on php8.2

Exemple or error returned:

[Mon Mar 04 20:03:55.333427 2024] [php:error] [pid 563] [client 172.17.0.1:56398] PHP Fatal error: Uncaught TypeError: Carbon\Carbon::setLastErrors(): Argument # 1 ($lastErrors) must be of type array, bool given, called in /var/www/html/includes/webklex/php-imap/vendor/nesbot/carbon/src/Carbon/Traits/Creator.php on line 98 and defined in /var/www/html/includes/webklex/php-imap/vendor/nesbot/carbon/src/Carbon/Traits/Creator.php:928\nStack trace:\n#0 /var/www/html/includes/webklex/php-imap/vendor/nesbot/carbon/src/Carbon/Traits/Creator.php(98): Carbon\Carbon::setLastErrors()\n#1 /var/www/html/includes/webklex/php-imap/vendor/nesbot/carbon/src/Carbon/Traits/Creator.php(185): Carbon\Carbon->__construct()\n#2 /var/www/html/includes/webklex/php-imap/vendor/nesbot/carbon/src/Carbon/Traits/Creator.php(216): Carbon\Carbon::rawParse()\n#3 /var/www/html/includes/webklex/php-imap/src/Header.php(716): Carbon\Carbon::parse()\n#4 /var/www/html/includes/webklex/php-imap/src/Header.php(215): Webklex\PHPIMAP\Header->parseDate()\n#5 /var/www/html/includes/webklex/php-imap/src/Header.php(73): Webklex\PHPIMAP\Header->parse()\n#6 /var/www/html/includes/webklex/php-imap/src/Message.php(420): Webklex\PHPIMAP\Header->__construct()\n#7 /var/www/html/includes/webklex/php-imap/src/Message.php(270): Webklex\PHPIMAP\Message->parseRawHeader()\n#8 /var/www/html/includes/webklex/php-imap/src/Query/Query.php(252): Webklex\PHPIMAP\Message::make()\n#9 /var/www/html/includes/webklex/php-imap/src/Query/Query.php(321): Webklex\PHPIMAP\Query\Query->make()\n#10 /var/www/html/includes/webklex/php-imap/src/Query/Query.php(343): Webklex\PHPIMAP\Query\Query->populate()\n#11 /var/www/html/emailcollector/class/emailcollector.class.php(1588): Webklex\PHPIMAP\Query\Query->get()\n#12 /var/www/html/admin/emailcollector_card.php(254): EmailCollector->doCollectOneCollector()\n#13 {main}\n thrown in /var/www/html/includes/webklex/php-imap/vendor/nesbot/carbon/src/Carbon/Traits/Creator.php on line 928, referer: http://...
172.17.0.1 - - [04/Mar/2024:20:03:47 +0400] “GET /admin/emailcollector_card.php?id=4&action=confirm_collect&confirm=yes&token=d123229af9ae032a0324d4657e95de50 HTTP/1.1” 500 304 “http://...” “Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36”