### PR TITLE
Make start and end period properties correct when created from Carbon object

### DIFF
--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -595,8 +595,21 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
      */
     public function __construct(...$arguments)
     {
+        $raw = ['R1/2000-01-01T00:00:00Z/P1D'];
+
+        if (isset($arguments['raw'])) {
+            $raw = $arguments['raw'];
+            $this->isDefaultInterval = $arguments['isDefaultInterval'] ?? false;
+
+            if (isset($arguments['dateClass'])) {
+                $this->dateClass = $arguments['dateClass'];
+            }
+
+            $arguments = $raw;
+        }
+
         // Dummy construct, as properties are completely overridden
-        parent::__construct('R1/2000-01-01T00:00:00Z/P1D');
+        parent::__construct(...$raw);
 
         if (is_a($this->dateClass, DateTimeImmutable::class, true)) {
             $this->options = static::IMMUTABLE;

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -595,7 +595,7 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
      */
     public function __construct(...$arguments)
     {
-        $raw = ['R1/2000-01-01T00:00:00Z/P1D'];
+        $raw = null;
 
         if (isset($arguments['raw'])) {
             $raw = $arguments['raw'];
@@ -606,13 +606,6 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
             }
 
             $arguments = $raw;
-        }
-
-        // Dummy construct, as properties are completely overridden
-        parent::__construct(...$raw);
-
-        if (is_a($this->dateClass, DateTimeImmutable::class, true)) {
-            $this->options = static::IMMUTABLE;
         }
 
         // Parse and assign arguments one by one. First argument may be an ISO 8601 spec,
@@ -642,14 +635,19 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
             }
         }
 
+        if (is_a($this->dateClass, DateTimeImmutable::class, true)) {
+            $this->options = static::IMMUTABLE;
+        }
+
         $optionsSet = false;
+        $sortedArguments = [];
 
         foreach ($arguments as $argument) {
             $parsedDate = null;
 
             if ($argument instanceof DateTimeZone) {
                 $this->setTimezone($argument);
-            } elseif ($this->dateInterval === null &&
+            } elseif (!isset($sortedArguments['interval']) &&
                 (
                     (\is_string($argument) && preg_match(
                         '/^(-?\d(\d(?![\/-])|[^\d\/-]([\/-])?)*|P[T\d].*|(?:\h*\d+(?:\.\d+)?\h*[a-z]+)+)$/i',
@@ -661,23 +659,66 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
                 ) &&
                 $parsedInterval = self::makeInterval($argument)
             ) {
-                $this->setDateInterval($parsedInterval);
-            } elseif ($this->startDate === null && $parsedDate = $this->makeDateTime($argument)) {
-                $this->setStartDate($parsedDate);
-            } elseif ($this->endDate === null && ($parsedDate = $parsedDate ?? $this->makeDateTime($argument))) {
-                $this->setEndDate($parsedDate);
-            } elseif ($this->carbonRecurrences === null &&
-                $this->endDate === null &&
+                $sortedArguments['interval'] = $parsedInterval;
+            } elseif (!isset($sortedArguments['start']) && $parsedDate = $this->makeDateTime($argument)) {
+                $sortedArguments['start'] = $parsedDate;
+            } elseif (!isset($sortedArguments['end']) && ($parsedDate = $parsedDate ?? $this->makeDateTime($argument))) {
+                $sortedArguments['end'] = $parsedDate;
+            } elseif (!isset($sortedArguments['recurrences']) &&
+                !isset($sortedArguments['end']) &&
                 (\is_int($argument) || \is_float($argument))
                 && $argument >= 0
             ) {
-                $this->setRecurrences($argument);
+                $sortedArguments['recurrences'] = $argument;
             } elseif (!$optionsSet && (\is_int($argument) || $argument === null)) {
                 $optionsSet = true;
-                $this->setOptions(((int) $this->options) | ((int) $argument));
+                $sortedArguments['options'] = (((int) $this->options) | ((int) $argument));
             } else {
                 throw new InvalidPeriodParameterException('Invalid constructor parameters.');
             }
+        }
+
+        if ($raw === null && isset($sortedArguments['start'])) {
+            $end = $sortedArguments['end'] ?? max(1, $sortedArguments['recurrences'] ?? 1);
+
+            if (\is_float($end)) {
+                $end = $end === INF ? PHP_INT_MAX : (int) round($end);
+            }
+
+            $raw = [
+                $sortedArguments['start'],
+                $sortedArguments['interval'] ?? CarbonInterval::day(),
+                $end,
+            ];
+        }
+
+        if ($raw === null && \is_string($arguments[0] ?? null) && substr_count($arguments[0], '/') >= 1) {
+            $raw = [$arguments[0]];
+        }
+
+        $raw ??= ['R1/2000-01-01T00:00:00Z/P1D'];
+
+        // Dummy construct, as properties are completely overridden
+        parent::__construct(...$raw);
+
+        if (isset($sortedArguments['start'])) {
+            $this->setStartDate($sortedArguments['start']);
+        }
+
+        if (isset($sortedArguments['end'])) {
+            $this->setEndDate($sortedArguments['end']);
+        }
+
+        if (isset($sortedArguments['recurrences'])) {
+            $this->setRecurrences($sortedArguments['recurrences']);
+        }
+
+        if (isset($sortedArguments['interval'])) {
+            $this->setDateInterval($sortedArguments['interval']);
+        }
+
+        if (isset($sortedArguments['options'])) {
+            $this->setOptions($sortedArguments['options']);
         }
 
         if ($this->startDate === null) {

--- a/tests/CarbonPeriod/CreateTest.php
+++ b/tests/CarbonPeriod/CreateTest.php
@@ -856,4 +856,15 @@ class CreateTest extends AbstractTestCase
 
         $this->assertSame(2, $period->count());
     }
+
+    public function testStartAndEndFallback()
+    {
+        $this->assertSame([
+            '2024-09-01',
+            '2024-09-30',
+        ], [
+            Carbon::parse('Sep 1')->toPeriod('Sep 30')->start->format('Y-m-d'),
+            Carbon::parse('Sep 1')->toPeriod('Sep 30')->end->format('Y-m-d'),
+        ]);
+    }
 }

--- a/tests/CarbonPeriod/CreateTest.php
+++ b/tests/CarbonPeriod/CreateTest.php
@@ -866,5 +866,26 @@ class CreateTest extends AbstractTestCase
             Carbon::parse('Sep 1')->toPeriod('Sep 30')->start->format('Y-m-d'),
             Carbon::parse('Sep 1')->toPeriod('Sep 30')->end->format('Y-m-d'),
         ]);
+
+        $periodClass = static::$periodClass;
+        $period = new $periodClass('Sep 1', 'Sep 30');
+
+        $this->assertSame([
+            '2024-09-01',
+            '2024-09-30',
+        ], [
+            $period->start->format('Y-m-d'),
+            $period->end->format('Y-m-d'),
+        ]);
+
+        $period = new $periodClass('Sep 1');
+
+        $this->assertSame([
+            '2024-09-01',
+            null,
+        ], [
+            $period->start->format('Y-m-d'),
+            $period->end?->format('Y-m-d'),
+        ]);
     }
 }


### PR DESCRIPTION
Fix #2982