### PR TITLE
Fix: Allow carbon instance to be rounded by a CarbonInterval, which is not in default language

### DIFF
--- a/src/Carbon/Traits/IntervalRounding.php
+++ b/src/Carbon/Traits/IntervalRounding.php
@@ -42,7 +42,7 @@ trait IntervalRounding
         $unit = 'second';
 
         if ($precision instanceof DateInterval) {
-            $precision = (string) CarbonInterval::instance($precision, [], true);
+            $precision = (string) CarbonInterval::instance($precision)->locale('');
         }
 
         if (\is_string($precision) && preg_match('/^\s*(?<precision>\d+)?\s*(?<unit>\w+)(?<other>\W.*)?$/', $precision, $match)) {

--- a/tests/CarbonInterval/ConstructTest.php
+++ b/tests/CarbonInterval/ConstructTest.php
@@ -289,6 +289,13 @@ class ConstructTest extends AbstractTestCase
         $this->assertFalse($ci->days);
     }
 
+    public function testInstanceWithSkipCopy()
+    {
+        $ci = CarbonInterval::instance(new DateInterval('P2Y1M5DT22H33M44S'));
+        $copy = CarbonInterval::instance($ci, [], true);
+        $this->assertSame($ci, $copy);
+    }
+
     public function testInstanceWithNegativeDateInterval()
     {
         $di = new DateInterval('P2Y1M5DT22H33M44S');

--- a/tests/CarbonInterval/RoundingTest.php
+++ b/tests/CarbonInterval/RoundingTest.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Tests\CarbonInterval;
 
+use Carbon\Carbon;
 use Carbon\CarbonInterval;
+use DateInterval;
 use InvalidArgumentException;
 use Tests\AbstractTestCase;
 
@@ -133,5 +135,33 @@ class RoundingTest extends AbstractTestCase
         $this->assertSame(22.0, CarbonInterval::days(22)->ceil('2 days')->totalDays);
         $this->assertSame(24.0, CarbonInterval::days(22)->ceil(CarbonInterval::days(6))->totalDays);
         $this->assertSame(24.0, CarbonInterval::days(22)->ceilUnit('day', 6)->totalDays);
+    }
+
+    public function testRoundCarbonInstanceToIntervalInNonDefaultLocale()
+    {
+        $interval15m = CarbonInterval::fromString('PT15M')->locale('es');
+
+        $this->assertSame(
+            '19:30',
+            Carbon::parse('2024-04-15T19:36:12')->floor($interval15m)->format('H:i')
+        );
+        $this->assertSame(
+            '19:45',
+            Carbon::parse('2024-04-15T19:36:12')->ceil($interval15m)->format('H:i')
+        );
+        $this->assertSame('15 minutos', $interval15m->forHumans());
+
+        $interval1h = DateInterval::createFromDateString('1 hour');
+        Carbon::setLocale('zh');
+
+        $this->assertSame('1小时', CarbonInterval::make($interval1h)->forHumans());
+        $this->assertSame(
+            '19:00',
+            Carbon::parse('2024-04-15T19:36:12')->floor($interval1h)->format('H:i')
+        );
+        $this->assertSame(
+            '20:00',
+            Carbon::parse('2024-04-15T19:36:12')->ceil($interval1h)->format('H:i')
+        );
     }
 }


### PR DESCRIPTION
Hello there!

## Bug description
In [Carbon\Traits\IntervalRounding::45](https://github.com/briannesbitt/Carbon/blob/master/src/Carbon/Traits/IntervalRounding.php#L45), we convert a CarbonInterval to a string, regardless of the language in which it was given. This fails, if:

- the user passes a CarbonInterval in a specific locale
- the user passes an Object, that is converted to a CarbonInterval, while the CarbonLocale is set to a language different than english.

## Suggested fix
As we are parsing english words, we should ensure in the library, that the passed `unit` is english, regardless of what the user does.

Therefore i suggest always to create a new CarbonInterval, set it's locale to default and parse the output of this object.
