### PR TITLE
must be of type int|float, string given error fixed

### DIFF
--- a/src/Carbon/Traits/Units.php
+++ b/src/Carbon/Traits/Units.php
@@ -353,7 +353,7 @@ trait Units
         $previousException = null;
 
         try {
-            $date = self::rawAddUnit($date, $unit, $value);
+            $date = self::rawAddUnit($date, $unit, interval($value));
 
             if (isset($timeString)) {
                 $date = $date?->setTimeFromTimeString($timeString);

--- a/src/Carbon/Traits/Units.php
+++ b/src/Carbon/Traits/Units.php
@@ -353,7 +353,7 @@ trait Units
         $previousException = null;
 
         try {
-            $date = self::rawAddUnit($date, $unit, intval($value));
+            $date = self::rawAddUnit($date, $unit, floatval($value));
 
             if (isset($timeString)) {
                 $date = $date?->setTimeFromTimeString($timeString);

--- a/src/Carbon/Traits/Units.php
+++ b/src/Carbon/Traits/Units.php
@@ -353,7 +353,7 @@ trait Units
         $previousException = null;
 
         try {
-            $date = self::rawAddUnit($date, $unit, interval($value));
+            $date = self::rawAddUnit($date, $unit, intval($value));
 
             if (isset($timeString)) {
                 $date = $date?->setTimeFromTimeString($timeString);


### PR DESCRIPTION
#[2024-04-26 17:10:51] production.ERROR: Carbon\Carbon::rawAddUnit(): Argument #3 ($value) must be of type int|float, string given, called in /vendor/nesbot/carbon/src/Carbon/Traits/Units.php on line 356 {"exception":"[object] (TypeError(code: 0): Carbon\\Carbon::rawAddUnit(): Argument #3 ($value) must be of type int|float, string given, called in /vendor/nesbot/carbon/src/Carbon/Traits/Units.php on line 356 at /vendor/nesbot/carbon/src/Carbon/Traits/Units.php:455)
[stacktrace]

Got this error with Laravel 11.5 version and php 8.3.6. It is expecting a int or float, however it is coming as string. So made this fix.