### PR TITLE
Remove overridden EXCLUDE_START_DATE constant

### DIFF
--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -215,13 +215,6 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
     public const END_ITERATION = [self::class, 'endIteration'];
 
     /**
-     * Exclude start date from iteration.
-     *
-     * @var int
-     */
-    public const EXCLUDE_START_DATE = 1;
-
-    /**
      * Exclude end date from iteration.
      *
      * @var int


### PR DESCRIPTION
This constant is has the same value as the one of the base class. Overriding this constant breaks in PHP 8.4 due to the addition of the constant type.

See https://github.com/php/php-src/pull/12361 for the discussion. We might end up reverting this, but it still doesn't seem like this constant is needed.

I wasn't sure which branch to target. Please let me know which one is correct and I can rebase.