### PR TITLE
Introduce `isStartOfWeek()` and `isEndOfWeek()`

### DIFF
--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -2932,6 +2932,17 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
     public function isTomorrow(): bool;
 
     /**
+     * Determines if the instance is start of week.
+     *
+     * @example
+     * ```
+     * Carbon::parse('2024-08-31')->startOfWeek()->isStartOfWeek(); // true
+     * Carbon::parse('2024-08-31')->isStartOfWeek(); // false
+     * ```
+     */
+    public function isStartOfWeek():bool;
+
+    /**
      * Determines if the instance is a weekday.
      *
      * @example

--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -2945,6 +2945,19 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
     public function isStartOfWeek(): bool;
 
     /**
+     * Determines if the instance is end of week.
+     *
+     * @example
+     * ```
+     * Carbon::parse('2024-08-31')->endOfWeek()->isEndOfWeek(); // true
+     * Carbon::parse('2024-08-31')->isEndOfWeek(); // false
+     * ```
+     *
+     * @return bool
+     */
+    public function isEndOfWeek(): bool;
+
+    /**
      * Determines if the instance is a weekday.
      *
      * @example

--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -2939,8 +2939,10 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
      * Carbon::parse('2024-08-31')->startOfWeek()->isStartOfWeek(); // true
      * Carbon::parse('2024-08-31')->isStartOfWeek(); // false
      * ```
+     *
+     * @return bool
      */
-    public function isStartOfWeek():bool;
+    public function isStartOfWeek(): bool;
 
     /**
      * Determines if the instance is a weekday.

--- a/src/Carbon/Traits/Comparison.php
+++ b/src/Carbon/Traits/Comparison.php
@@ -445,6 +445,22 @@ trait Comparison
     }
 
     /**
+     * Determines if the instance is end of week.
+     *
+     * @example
+     * ```
+     * Carbon::parse('2024-08-31')->endOfWeek()->isEndOfWeek(); // true
+     * Carbon::parse('2024-08-31')->isEndOfWeek(); // false
+     * ```
+     *
+     * @return bool
+     */
+    public function isEndOfWeek(): bool
+    {
+        return $this->dayOfWeek === $this->lastWeekDay;
+    }
+
+    /**
      * Determines if the instance is in the future, ie. greater (after) than now.
      *
      * @example

--- a/src/Carbon/Traits/Comparison.php
+++ b/src/Carbon/Traits/Comparison.php
@@ -433,7 +433,7 @@ trait Comparison
      *
      * @example
      * ```
-     * Carbon::parse('2024-08-31')->isStartOfWeek(); // true
+     * Carbon::parse('2024-08-31')->startOfWeek()->isStartOfWeek(); // true
      * Carbon::parse('2024-08-31')->isStartOfWeek(); // false
      * ```
      */

--- a/src/Carbon/Traits/Comparison.php
+++ b/src/Carbon/Traits/Comparison.php
@@ -429,6 +429,20 @@ trait Comparison
     }
 
     /**
+     * Determines if the instance is start of week.
+     *
+     * @example
+     * ```
+     * Carbon::parse('2024-08-31')->isStartOfWeek(); // true
+     * Carbon::parse('2024-08-31')->isStartOfWeek(); // false
+     * ```
+     */
+    public function isStartOfWeek()
+    {
+        return $this->dayOfWeek === $this->firstWeekDay;
+    }
+
+    /**
      * Determines if the instance is in the future, ie. greater (after) than now.
      *
      * @example

--- a/src/Carbon/Traits/Comparison.php
+++ b/src/Carbon/Traits/Comparison.php
@@ -436,8 +436,10 @@ trait Comparison
      * Carbon::parse('2024-08-31')->startOfWeek()->isStartOfWeek(); // true
      * Carbon::parse('2024-08-31')->isStartOfWeek(); // false
      * ```
+     *
+     * @return bool
      */
-    public function isStartOfWeek()
+    public function isStartOfWeek(): bool
     {
         return $this->dayOfWeek === $this->firstWeekDay;
     }

--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -207,6 +207,20 @@ class IsTest extends AbstractTestCase
         $this->assertFalse(Carbon::now()->addDays(2)->startOfDay()->isTomorrow());
     }
 
+    public function testIsStartOfWeek()
+    {
+        $date = Carbon::create(1997, 8, 31, 01, 6, 12)->startOfWeek();
+
+        $this->assertTrue($date->isStartOfWeek());
+        $this->assertTrue($date->is(WeekDay::Monday));
+
+        Carbon::setLocale('ar');
+        $date = Carbon::create(2024, 8, 31, 01, 6, 12)->startOfWeek();
+
+        $this->assertTrue($date->isStartOfWeek());
+        $this->assertTrue($date->is(WeekDay::Saturday));
+    }
+
     public function testIsFutureTrue()
     {
         $this->assertTrue(Carbon::now()->addSecond()->isFuture());

--- a/tests/Carbon/IsTest.php
+++ b/tests/Carbon/IsTest.php
@@ -221,6 +221,20 @@ class IsTest extends AbstractTestCase
         $this->assertTrue($date->is(WeekDay::Saturday));
     }
 
+    public function testIsEndOfWeek()
+    {
+        $date = Carbon::create(1997, 8, 31, 01, 6, 12)->endOfWeek();
+
+        $this->assertTrue($date->isEndOfWeek());
+        $this->assertTrue($date->is(WeekDay::Sunday));
+
+        Carbon::setLocale('ar');
+        $date = Carbon::create(2024, 8, 31, 01, 6, 12)->endOfWeek();
+
+        $this->assertTrue($date->isEndOfWeek());
+        $this->assertTrue($date->is(WeekDay::Friday));
+    }
+
     public function testIsFutureTrue()
     {
         $this->assertTrue(Carbon::now()->addSecond()->isFuture());


### PR DESCRIPTION
Hellooo :wave:

In this PR I have added two methods:
- `isStartOfWeek()` that will allow us to check if a date is start of week.
- `isEndOfWeek()` that will allow us to check if a date is end of week.

```php
Carbon::parse('2024-08-31')->startOfWeek()->isStartOfWeek(); // true
Carbon::parse('2024-08-31')->isStartOfWeek(); // false
```

```php
Carbon::parse('2024-08-31')->endOfWeek()->isEndOfWeek(); // true
Carbon::parse('2024-08-31')->isEndOfWeek(); // false
```