### PR TITLE
Fix incorrect function calls in Units

### DIFF
--- a/src/Carbon/Traits/Units.php
+++ b/src/Carbon/Traits/Units.php
@@ -255,7 +255,7 @@ trait Units
         $value = Unit::toNameIfUnit($value);
 
         if (\is_string($unit) && \func_num_args() === 1) {
-            $unit = CarbonInterval::make($unit, [], true);
+            $unit = CarbonInterval::make($value, $unit, true);
         }
 
         if ($unit instanceof CarbonConverterInterface) {
@@ -404,7 +404,7 @@ trait Units
     public function sub($unit, $value = 1, ?bool $overflow = null): static
     {
         if (\is_string($unit) && \func_num_args() === 1) {
-            $unit = CarbonInterval::make($unit, [], true);
+            $unit = CarbonInterval::make($value, $unit, true);
         }
 
         if ($unit instanceof CarbonConverterInterface) {
@@ -446,7 +446,7 @@ trait Units
     public function subtract($unit, $value = 1, ?bool $overflow = null): static
     {
         if (\is_string($unit) && \func_num_args() === 1) {
-            $unit = CarbonInterval::make($unit, [], true);
+            $unit = CarbonInterval::make($value, $unit, true);
         }
 
         return $this->sub($unit, $value, $overflow);


### PR DESCRIPTION
The CarbonInterval make function appears to accept the following arguments: `$intervals`, `$units`, and `$skipCopy`, but Units class is instead sending $units, an empty array, and true. This causes issues with the following calls `->sub('day')` `->add('day')` or `->subtract('day')` on the Carbon object

Useful Link: https://github.com/briannesbitt/Carbon/blob/5607f63713142842b3cac9c9a69b371bc27f213b/src/Carbon/CarbonInterval.php#L1201C16-L1201C88