### PR TITLE
Update Occitan locale: small correction

### DIFF
--- a/src/Carbon/Lang/oc.php
+++ b/src/Carbon/Lang/oc.php
@@ -12,6 +12,7 @@
 /*
  * Authors:
  * - Quentí
+ * - Quentin PAGÈS
  */
 // @codeCoverageIgnoreStart
 use Symfony\Component\Translation\PluralizationRules;
@@ -87,8 +88,8 @@ return [
     'ordinal' => static function ($number, string $period = '') {
         $ordinal = [1 => 'èr', 2 => 'nd'][(int) $number] ?? 'en';
 
-        // feminine for year, week, hour, minute, second
-        if (preg_match('/^[yYwWhHgGis]$/', $period)) {
+        // feminine for week, hour, minute, second
+        if (preg_match('/^[wWhHgGis]$/', $period)) {
             $ordinal .= 'a';
         }
 


### PR DESCRIPTION
Correction for ordinals for year.
In Occitan we have two words for 'year':
un an, x ans etc (masculine)
or
una annada, x annadas etc (feminine)
Here the masculine form was chosen so I changed accordingly the function for ordinals.