### PR TITLE
Modify the CDN of static files

### DIFF
--- a/contribute/docs/index.html
+++ b/contribute/docs/index.html
@@ -8,8 +8,8 @@
         <title>Carbon - A simple PHP API extension for DateTime.</title>
         <meta name="description" content="Carbon - A simple PHP API extension for DateTime.">
         <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet' type='text/css'>
-        <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/tomorrow-night.min.css">
+        <link href="//cdn.jsdelivr.net/npm/bootstrap@3.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+        <link href="//cdn.jsdelivr.net/npm/highlight.js@8.4.0/styles/tomorrow-night.min.css" rel="stylesheet">
         <link href="/carbon.css?v=2019-08-01-21-40" rel="stylesheet">
         <script>
             (function (i, s, o, g, r, a, m) {
@@ -182,8 +182,8 @@ echo 6;              // 6
     </footer>
 
     <script async src="https://media.ethicalads.io/media/client/ethicalads.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/jquery@1.11.2/dist/jquery.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/bootstrap@3.3.2/dist/js/bootstrap.min.js"></script>
     <script>
 
         var liveEditorHosts = [
@@ -896,7 +896,7 @@ echo 6;              // 6
         }
 
     </script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/highlight.js@8.4.0/lib/highlight.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
     <script type="text/javascript">
         var _paq = _paq || [];

--- a/contribute/index.html
+++ b/contribute/index.html
@@ -8,8 +8,8 @@
         <title>Carbon - A simple PHP API extension for DateTime.</title>
         <meta name="description" content="Carbon - A simple PHP API extension for DateTime.">
         <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet' type='text/css'>
-        <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/tomorrow-night.min.css">
+        <link href="//cdn.jsdelivr.net/npm/bootstrap@3.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+        <link href="//cdn.jsdelivr.net/npm/highlight.js@8.4.0/styles/tomorrow-night.min.css" rel="stylesheet">
         <link href="/carbon.css?v=2019-08-01-21-40" rel="stylesheet">
         <script>
             (function (i, s, o, g, r, a, m) {
@@ -104,8 +104,8 @@
     </footer>
 
     <script async src="https://media.ethicalads.io/media/client/ethicalads.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/jquery@1.11.2/dist/jquery.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/bootstrap@3.3.2/dist/js/bootstrap.min.js"></script>
     <script>
 
         var liveEditorHosts = [
@@ -818,7 +818,7 @@
         }
 
     </script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/highlight.js@8.4.0/lib/highlight.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
     <script type="text/javascript">
         var _paq = _paq || [];

--- a/contribute/translate/index.html
+++ b/contribute/translate/index.html
@@ -8,8 +8,8 @@
         <title>Carbon - A simple PHP API extension for DateTime.</title>
         <meta name="description" content="Carbon - A simple PHP API extension for DateTime.">
         <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet' type='text/css'>
-        <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/tomorrow-night.min.css">
+        <link href="//cdn.jsdelivr.net/npm/bootstrap@3.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+        <link href="//cdn.jsdelivr.net/npm/highlight.js@8.4.0/styles/tomorrow-night.min.css" rel="stylesheet">
         <link href="/carbon.css?v=2019-08-01-21-40" rel="stylesheet">
         <script>
             (function (i, s, o, g, r, a, m) {
@@ -104,8 +104,8 @@
     </footer>
 
     <script async src="https://media.ethicalads.io/media/client/ethicalads.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/jquery@1.11.2/dist/jquery.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/bootstrap@3.3.2/dist/js/bootstrap.min.js"></script>
     <script>
 
         var liveEditorHosts = [
@@ -818,7 +818,7 @@
         }
 
     </script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/highlight.js@8.4.0/lib/highlight.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
     <script type="text/javascript">
         var _paq = _paq || [];

--- a/contribute/translators/index.html
+++ b/contribute/translators/index.html
@@ -8,8 +8,8 @@
         <title>Carbon - A simple PHP API extension for DateTime.</title>
         <meta name="description" content="Carbon - A simple PHP API extension for DateTime.">
         <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet' type='text/css'>
-        <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/tomorrow-night.min.css">
+        <link href="//cdn.jsdelivr.net/npm/bootstrap@3.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+        <link href="//cdn.jsdelivr.net/npm/highlight.js@8.4.0/styles/tomorrow-night.min.css" rel="stylesheet">
         <link href="/carbon.css?v=2019-08-01-21-40" rel="stylesheet">
         <script>
             (function (i, s, o, g, r, a, m) {
@@ -1086,8 +1086,8 @@
     </footer>
 
     <script async src="https://media.ethicalads.io/media/client/ethicalads.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/jquery@1.11.2/dist/jquery.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/bootstrap@3.3.2/dist/js/bootstrap.min.js"></script>
     <script>
 
         var liveEditorHosts = [
@@ -1800,7 +1800,7 @@
         }
 
     </script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/highlight.js@8.4.0/lib/highlight.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
     <script type="text/javascript">
         var _paq = _paq || [];

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,8 +8,8 @@
         <title>Carbon - A simple PHP API extension for DateTime.</title>
         <meta name="description" content="Carbon - A simple PHP API extension for DateTime.">
         <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet' type='text/css'>
-        <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/tomorrow-night.min.css">
+        <link href="//cdn.jsdelivr.net/npm/bootstrap@3.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+        <link href="//cdn.jsdelivr.net/npm/highlight.js@8.4.0/styles/tomorrow-night.min.css" rel="stylesheet">
         <link href="/carbon.css?v=2019-08-01-21-40" rel="stylesheet">
         <script>
             (function (i, s, o, g, r, a, m) {
@@ -9650,8 +9650,8 @@ echo CarbonImmutable::now()->locale('en_US@Cinema')->startOfWeek()->dayName; // 
     </footer>
 
     <script async src="https://media.ethicalads.io/media/client/ethicalads.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/jquery@1.11.2/dist/jquery.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/bootstrap@3.3.2/dist/js/bootstrap.min.js"></script>
     <script>
 
         var liveEditorHosts = [
@@ -10364,7 +10364,7 @@ echo CarbonImmutable::now()->locale('en_US@Cinema')->startOfWeek()->dayName; // 
         }
 
     </script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/highlight.js@8.4.0/lib/highlight.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
     <script type="text/javascript">
         var _paq = _paq || [];

--- a/history/index.html
+++ b/history/index.html
@@ -8,8 +8,8 @@
         <title>Carbon - A simple PHP API extension for DateTime.</title>
         <meta name="description" content="Carbon - A simple PHP API extension for DateTime.">
         <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet' type='text/css'>
-        <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/tomorrow-night.min.css">
+        <link href="//cdn.jsdelivr.net/npm/bootstrap@3.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+        <link href="//cdn.jsdelivr.net/npm/highlight.js@8.4.0/styles/tomorrow-night.min.css" rel="stylesheet">
         <link href="/carbon.css?v=2019-08-01-21-40" rel="stylesheet">
         <script>
             (function (i, s, o, g, r, a, m) {
@@ -100,8 +100,8 @@
     </footer>
 
     <script async src="https://media.ethicalads.io/media/client/ethicalads.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/jquery@1.11.2/dist/jquery.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/bootstrap@3.3.2/dist/js/bootstrap.min.js"></script>
     <script>
 
         var liveEditorHosts = [
@@ -814,7 +814,7 @@
         }
 
     </script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/highlight.js@8.4.0/lib/highlight.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
     <script type="text/javascript">
         var _paq = _paq || [];

--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
         <title>Carbon - A simple PHP API extension for DateTime.</title>
         <meta name="description" content="Carbon - A simple PHP API extension for DateTime.">
         <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet' type='text/css'>
-        <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/tomorrow-night.min.css">
+        <link href="//cdn.jsdelivr.net/npm/bootstrap@3.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+        <link href="//cdn.jsdelivr.net/npm/highlight.js@8.4.0/styles/tomorrow-night.min.css" rel="stylesheet">
         <link href="/carbon.css?v=2019-08-01-21-40" rel="stylesheet">
         <script>
             (function (i, s, o, g, r, a, m) {
@@ -377,8 +377,8 @@ Thank you to all our backers! 🙏 <a href="https://opencollective.com/Carbon#ba
     </footer>
 
     <script async src="https://media.ethicalads.io/media/client/ethicalads.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/jquery@1.11.2/dist/jquery.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/bootstrap@3.3.2/dist/js/bootstrap.min.js"></script>
     <script>
 
         var liveEditorHosts = [
@@ -1091,7 +1091,7 @@ Thank you to all our backers! 🙏 <a href="https://opencollective.com/Carbon#ba
         }
 
     </script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/highlight.js@8.4.0/lib/highlight.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
     <script type="text/javascript">
         var _paq = _paq || [];

--- a/laravel/index.html
+++ b/laravel/index.html
@@ -8,8 +8,8 @@
         <title>Carbon - A simple PHP API extension for DateTime.</title>
         <meta name="description" content="Carbon - A simple PHP API extension for DateTime.">
         <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet' type='text/css'>
-        <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/tomorrow-night.min.css">
+        <link href="//cdn.jsdelivr.net/npm/bootstrap@3.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+        <link href="//cdn.jsdelivr.net/npm/highlight.js@8.4.0/styles/tomorrow-night.min.css" rel="stylesheet">
         <link href="/carbon.css?v=2019-08-01-21-40" rel="stylesheet">
         <script>
             (function (i, s, o, g, r, a, m) {
@@ -290,8 +290,8 @@ it in the <strong>config/app.php</strong> file:</p>
     </footer>
 
     <script async src="https://media.ethicalads.io/media/client/ethicalads.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/jquery@1.11.2/dist/jquery.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/bootstrap@3.3.2/dist/js/bootstrap.min.js"></script>
     <script>
 
         var liveEditorHosts = [
@@ -1004,7 +1004,7 @@ it in the <strong>config/app.php</strong> file:</p>
         }
 
     </script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/highlight.js@8.4.0/lib/highlight.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
     <script type="text/javascript">
         var _paq = _paq || [];

--- a/symfony/index.html
+++ b/symfony/index.html
@@ -8,8 +8,8 @@
         <title>Carbon - A simple PHP API extension for DateTime.</title>
         <meta name="description" content="Carbon - A simple PHP API extension for DateTime.">
         <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet' type='text/css'>
-        <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/tomorrow-night.min.css">
+        <link href="//cdn.jsdelivr.net/npm/bootstrap@3.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+        <link href="//cdn.jsdelivr.net/npm/highlight.js@8.4.0/styles/tomorrow-night.min.css" rel="stylesheet">
         <link href="/carbon.css?v=2019-08-01-21-40" rel="stylesheet">
         <script>
             (function (i, s, o, g, r, a, m) {
@@ -291,8 +291,8 @@ private $created_at;</code></pre>
     </footer>
 
     <script async src="https://media.ethicalads.io/media/client/ethicalads.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/jquery@1.11.2/dist/jquery.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/bootstrap@3.3.2/dist/js/bootstrap.min.js"></script>
     <script>
 
         var liveEditorHosts = [
@@ -1005,7 +1005,7 @@ private $created_at;</code></pre>
         }
 
     </script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/highlight.js@8.4.0/lib/highlight.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
     <script type="text/javascript">
         var _paq = _paq || [];

--- a/template.src.html
+++ b/template.src.html
@@ -8,8 +8,8 @@
         <title>Carbon - A simple PHP API extension for DateTime.</title>
         <meta name="description" content="Carbon - A simple PHP API extension for DateTime.">
         <link href='//fonts.googleapis.com/css?family=Open+Sans:400,300,600' rel='stylesheet' type='text/css'>
-        <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/tomorrow-night.min.css">
+        <link href="//cdn.jsdelivr.net/npm/bootstrap@3.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+        <link href="//cdn.jsdelivr.net/npm/highlight.js@8.4.0/styles/tomorrow-night.min.css" rel="stylesheet">
         <link href="/carbon.css?v=2019-08-01-21-40" rel="stylesheet">
         <script>
             (function (i, s, o, g, r, a, m) {
@@ -99,8 +99,8 @@
     </footer>
 
     <script async src="https://media.ethicalads.io/media/client/ethicalads.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/jquery@1.11.2/dist/jquery.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/bootstrap@3.3.2/dist/js/bootstrap.min.js"></script>
     <script>
 
         var liveEditorHosts = [
@@ -813,7 +813,7 @@
         }
 
     </script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/highlight.js@8.4.0/lib/highlight.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
     <script type="text/javascript">
         var _paq = _paq || [];


### PR DESCRIPTION
Since the link https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css couldn't be accessed in China, I simply replaced it with https://cdn.jsdelivr.net/ altogether.