### PR TITLE
feat: add phpstan @param-closure-this tags to macro methods

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -31,14 +31,6 @@ parameters:
         - '#^Property Carbon\\Carbon::\$timezone \(Carbon\\CarbonTimeZone\) does not accept string\.$#'
         - '#^Method class@anonymous/tests/Carbon/TestingAidsTest\.php:\d+::modify\(\) should return class@anonymous/tests/Carbon/TestingAidsTest\.php:\d+ but returns \(?DateTimeImmutable#'
         -
-            message: '#^Undefined variable: \$this$#'
-            paths:
-                - src/Carbon/Traits/Mixin.php
-        -
-            message: '#^Variable \$this in isset\(\) is never defined\.$#'
-            paths:
-                - src/Carbon/Traits/Mixin.php
-        -
             message: '#^Call to an undefined method Carbon\\Carbon::[a-zA-Z]+Of[a-zA-Z]+\(\)\.$#'
             paths:
                 - tests/Carbon/SettersTest.php
@@ -83,11 +75,6 @@ parameters:
             message: '#^Parameter \$foo of anonymous function has invalid type Tests\\Factory\\FooBar\.#'
             paths:
                 - tests/Factory/CallbackTest.php
-        -
-            message: '#^Call to an undefined method Tests\\Carbon(Immutable)?\\MacroTest::diffInYears\(\)\.#'
-            paths:
-                - tests/Carbon/MacroTest.php
-                - tests/CarbonImmutable/MacroTest.php
         -
             message: '#^Call to an undefined method SubCarbon(Immutable)?::diffInDecades\(\)\.#'
             paths:

--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -3351,6 +3351,8 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
      * });
      * echo Carbon::yesterday()->hours(11)->userFormat();
      * ```
+     *
+     * @param-closure-this  static  $macro
      */
     public static function macro(string $name, ?callable $macro): void;
 

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -1516,6 +1516,8 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
      * });
      * echo CarbonInterval::hours(2)->twice();
      * ```
+     *
+     * @param-closure-this  static  $macro
      */
     public static function macro(string $name, ?callable $macro): void
     {

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -529,6 +529,8 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
      * });
      * echo CarbonPeriod::since('2011-05-12')->until('2011-06-03')->middle();
      * ```
+     *
+     * @param-closure-this  static  $macro
      */
     public static function macro(string $name, ?callable $macro): void
     {

--- a/src/Carbon/Factory.php
+++ b/src/Carbon/Factory.php
@@ -318,6 +318,8 @@ class Factory
      * });
      * echo $factory->yesterday()->hours(11)->userFormat();
      * ```
+     *
+     * @param-closure-this  static  $macro
      */
     public function macro(string $name, ?callable $macro): void
     {

--- a/src/Carbon/Traits/Macro.php
+++ b/src/Carbon/Traits/Macro.php
@@ -40,6 +40,8 @@ trait Macro
      * });
      * echo Carbon::yesterday()->hours(11)->userFormat();
      * ```
+     *
+     * @param-closure-this  static  $macro
      */
     public static function macro(string $name, ?callable $macro): void
     {

--- a/src/Carbon/Traits/Mixin.php
+++ b/src/Carbon/Traits/Mixin.php
@@ -101,8 +101,8 @@ trait Mixin
             $closureBase = Closure::fromCallable([$context, $name]);
 
             static::macro($name, function (...$parameters) use ($closureBase, $className, $baseClass) {
-                $downContext = isset($this) ? ($this) : new $baseClass();
-                $context = isset($this) ? $this->cast($className) : new $className();
+                $downContext = isset(${'this'}) ? $this : new $baseClass();
+                $context = isset(${'this'}) ? $this->cast($className) : new $className();
 
                 try {
                     // @ is required to handle error if not converted into exceptions


### PR DESCRIPTION
Hello!

This adds the `@param-closure-this` to the macro methods so that PHPStan properly understands the type of `$this` in the closures.

Should fix this: https://github.com/larastan/larastan/discussions/2189

Thanks!