### PR TITLE
After updating Laravel in the Filament project, an error occurs when uploading an image.

### DIFF
--- a/src/Carbon/Traits/Units.php
+++ b/src/Carbon/Traits/Units.php
@@ -353,7 +353,7 @@ trait Units
         $previousException = null;
 
         try {
-            $date = self::rawAddUnit($date, $unit, $value);
+            $date = self::rawAddUnit($date, $unit, intval($value));
 
             if (isset($timeString)) {
                 $date = $date?->setTimeFromTimeString($timeString);


### PR DESCRIPTION
## Issue Description
- After updating Laravel version 9 to 11 in the Filament project, an error occurs when uploading an image. The error message is this: `Carbon\Carbon::rawAddUnit(): Argument #3 ($value) must be of type int|float, string given, called in /Users/afroz/Desktop/Projects/official-website-backend/vendor/nesbot/carbon/src/Carbon/Traits/Units.php on line 356.`
- i Fixed that error
- screenshot
![image](https://github.com/user-attachments/assets/395ddb84-5e1c-42ec-a268-b424882f542d)
