### PR TITLE
Fix incorrect documentation for CarbonInterval

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8199,7 +8199,7 @@ echo CarbonInterval::createFromDateString('3 months'); // 3 months
     </p>
 
     <p>Be careful, Carbon 2 accepts only integer unit values by default, which means:
-        <code>CarbonInterval::days(3.5)</code> produces a 3h 00min interval. In Carbon
+        <code>CarbonInterval::days(3.5)</code> produces a 3 days 0 hrs interval. In Carbon
         3, it will cascade decimal part to smaller units. To enable this behavior in
         Carbon 2, you can call <code>CarbonInterval::enableFloatSetters();</code>.</p>
 


### PR DESCRIPTION
Documentation says `CarbonInterval::days(3.5)` returns `3.0hrs` in Carbon 2, but it actually returns `3.0 days`.

I assume the latter part of this example is where the mistake lies rather than the code itself, as `CarbonInterval::days(3.5)` is used multiple times in the example code block directly beneath it, and it makes sense that these should all match.

I've tried to match the existing documentation convention for units (`days` and `hours`), instead of writing `3d 00h`.

NOTE: This is my first contribution to this repository, please let me know if you need me to adjust anything.

Thanks!