### PR TITLE
feat: Apply Laravel fallback locale

### DIFF
--- a/src/Carbon/Laravel/ServiceProvider.php
+++ b/src/Carbon/Laravel/ServiceProvider.php
@@ -32,6 +32,9 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     /** @var callable|null */
     protected $localeGetter = null;
 
+    /** @var callable|null */
+    protected $fallbackLocaleGetter = null;
+
     public function setAppGetter(?callable $appGetter): void
     {
         $this->appGetter = $appGetter;
@@ -40,6 +43,11 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     public function setLocaleGetter(?callable $localeGetter): void
     {
         $this->localeGetter = $localeGetter;
+    }
+
+    public function setFallbackLocaleGetter(?callable $fallbackLocaleGetter): void
+    {
+        $this->fallbackLocaleGetter = $fallbackLocaleGetter;
     }
 
     public function boot()
@@ -136,8 +144,8 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
     protected function getFallbackLocale()
     {
-        if ($this->localeGetter) {
-            return ($this->localeGetter)(true);
+        if ($this->fallbackLocaleGetter) {
+            return ($this->fallbackLocaleGetter)();
         }
 
         $app = $this->getApp();

--- a/src/Carbon/Laravel/ServiceProvider.php
+++ b/src/Carbon/Laravel/ServiceProvider.php
@@ -117,7 +117,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             try {
                 $root = Date::getFacadeRoot();
                 $root->setFallbackLocale($locale);
-            } catch (Throwable) {
+            } catch (Throwable) { // @codeCoverageIgnore
                 // Non Carbon class in use in Date facade
             }
         }

--- a/tests/Laravel/App.php
+++ b/tests/Laravel/App.php
@@ -26,6 +26,11 @@ class App implements ArrayAccess
     /**
      * @var string
      */
+    protected $fallbackLocale = 'en';
+
+    /**
+     * @var string
+     */
     protected static $version;
 
     /**
@@ -42,6 +47,7 @@ class App implements ArrayAccess
     {
         include_once __DIR__.'/EventDispatcher.php';
         $this->locale = 'de';
+        $this->fallbackLocale = 'fr';
         $this->translator = new Translator($this->locale);
     }
 
@@ -78,9 +84,19 @@ class App implements ArrayAccess
         $this->events->dispatch(static::getLocaleChangeEventName());
     }
 
+    public function setFallbackLocale(string $fallbackLocale)
+    {
+        $this->fallbackLocale = $fallbackLocale;
+    }
+
     public function getLocale()
     {
         return $this->locale;
+    }
+
+    public function getFallbackLocale()
+    {
+        return $this->fallbackLocale;
     }
 
     public function bound($service)

--- a/tests/Laravel/ServiceProviderTest.php
+++ b/tests/Laravel/ServiceProviderTest.php
@@ -113,15 +113,24 @@ class ServiceProviderTest extends TestCase
         CarbonImmutable::setLocale('en');
         CarbonPeriod::setLocale('en');
         CarbonInterval::setLocale('en');
+        Carbon::setFallbackLocale('en');
+        CarbonImmutable::setFallbackLocale('en');
+        CarbonPeriod::setFallbackLocale('en');
+        CarbonInterval::setFallbackLocale('en');
 
         $service->boot();
         $service->app->register();
         $service->app->setLocaleWithoutEvent('fr');
+        $service->app->setFallbackLocale('it');
         $dispatcher->dispatch('locale.changed');
         $this->assertSame('fr', Carbon::getLocale());
         $this->assertSame('fr', CarbonImmutable::getLocale());
         $this->assertSame('fr', CarbonPeriod::getLocale());
         $this->assertSame('fr', CarbonInterval::getLocale());
+        $this->assertSame('en', Carbon::getFallbackLocale());
+        $this->assertSame('en', CarbonImmutable::getFallbackLocale());
+        $this->assertSame('en', CarbonPeriod::getFallbackLocale());
+        $this->assertSame('en', CarbonInterval::getFallbackLocale());
     }
 
     public function testListenerWithLocaleUpdatedClass()
@@ -137,18 +146,28 @@ class ServiceProviderTest extends TestCase
         CarbonImmutable::setLocale('en');
         CarbonPeriod::setLocale('en');
         CarbonInterval::setLocale('en');
+        Carbon::setFallbackLocale('en');
+        CarbonImmutable::setFallbackLocale('en');
+        CarbonPeriod::setFallbackLocale('en');
+        CarbonInterval::setFallbackLocale('en');
 
         $service->boot();
         $service->app->register();
         $service->app->setLocaleWithoutEvent('fr');
+        $service->app->setFallbackLocale('it');
         $app = new App();
         $app->register();
         $app->setLocaleWithoutEvent('de_DE');
+        $app->setFallbackLocale('es_ES');
         $dispatcher->dispatch('Illuminate\Foundation\Events\LocaleUpdated');
         $this->assertSame('fr', Carbon::getLocale());
         $this->assertSame('fr', CarbonImmutable::getLocale());
         $this->assertSame('fr', CarbonPeriod::getLocale());
         $this->assertSame('fr', CarbonInterval::getLocale());
+        $this->assertSame('en', Carbon::getFallbackLocale());
+        $this->assertSame('en', CarbonImmutable::getFallbackLocale());
+        $this->assertSame('en', CarbonPeriod::getFallbackLocale());
+        $this->assertSame('en', CarbonInterval::getFallbackLocale());
 
         $service->setAppGetter(static fn () => $app);
         $this->assertSame('fr', Carbon::getLocale());
@@ -162,6 +181,19 @@ class ServiceProviderTest extends TestCase
         $service->setAppGetter(static fn () => null);
         $service->updateLocale();
         $this->assertSame('ckb', Carbon::getLocale());
+
+        $service->setAppGetter(static fn () => $app);
+        $this->assertSame('en', Carbon::getFallbackLocale());
+        $service->updateFallbackLocale();
+        $this->assertSame('es_ES', Carbon::getFallbackLocale());
+        $service->setFallbackLocaleGetter(static fn () => 'ckb');
+        $this->assertSame('es_ES', Carbon::getFallbackLocale());
+        $service->updateFallbackLocale();
+        $this->assertSame('ckb', Carbon::getFallbackLocale());
+        $service->setFallbackLocaleGetter(null);
+        $service->setAppGetter(static fn () => null);
+        $service->updateFallbackLocale();
+        $this->assertSame('ckb', Carbon::getFallbackLocale());
     }
 
     public function testUpdateLocale()

--- a/tests/Laravel/ServiceProviderTest.php
+++ b/tests/Laravel/ServiceProviderTest.php
@@ -51,6 +51,10 @@ class ServiceProviderTest extends TestCase
         CarbonImmutable::setLocale('en');
         CarbonPeriod::setLocale('en');
         CarbonInterval::setLocale('en');
+        Carbon::setFallbackLocale('en');
+        CarbonImmutable::setFallbackLocale('en');
+        CarbonPeriod::setFallbackLocale('en');
+        CarbonInterval::setFallbackLocale('en');
 
         $service = new ServiceProvider($dispatcher);
 
@@ -58,17 +62,29 @@ class ServiceProviderTest extends TestCase
         $this->assertSame('en', CarbonImmutable::getLocale());
         $this->assertSame('en', CarbonPeriod::getLocale());
         $this->assertSame('en', CarbonInterval::getLocale());
+        $this->assertSame('en', Carbon::getFallbackLocale());
+        $this->assertSame('en', CarbonImmutable::getFallbackLocale());
+        $this->assertSame('en', CarbonPeriod::getFallbackLocale());
+        $this->assertSame('en', CarbonInterval::getFallbackLocale());
         $service->boot();
         $this->assertSame('en', Carbon::getLocale());
         $this->assertSame('en', CarbonImmutable::getLocale());
         $this->assertSame('en', CarbonPeriod::getLocale());
         $this->assertSame('en', CarbonInterval::getLocale());
+        $this->assertSame('en', Carbon::getFallbackLocale());
+        $this->assertSame('en', CarbonImmutable::getFallbackLocale());
+        $this->assertSame('en', CarbonPeriod::getFallbackLocale());
+        $this->assertSame('en', CarbonInterval::getFallbackLocale());
         $service->app->register();
         $service->boot();
         $this->assertSame('de', Carbon::getLocale());
         $this->assertSame('de', CarbonImmutable::getLocale());
         $this->assertSame('de', CarbonPeriod::getLocale());
         $this->assertSame('de', CarbonInterval::getLocale());
+        $this->assertSame('fr', Carbon::getFallbackLocale());
+        $this->assertSame('fr', CarbonImmutable::getFallbackLocale());
+        $this->assertSame('fr', CarbonPeriod::getFallbackLocale());
+        $this->assertSame('fr', CarbonInterval::getFallbackLocale());
         $service->app->setLocale('fr');
         $this->assertSame('fr', Carbon::getLocale());
         $this->assertSame('fr', CarbonImmutable::getLocale());
@@ -78,6 +94,7 @@ class ServiceProviderTest extends TestCase
 
         // Reset language
         Carbon::setLocale('en');
+        Carbon::setFallbackLocale('en');
 
         $service->app->removeService('events');
         $this->assertNull($service->boot());


### PR DESCRIPTION
Not sure if this is a fix or a feature.
This PR applies Laravel's configured fallback locale to Carbon.
Laravel doesn't emit any events while setting fallback locale at run-time, so this is one-time thing during service provider boot up.