### PR TITLE
Fix Incorrect Type Inference when Declaring Macros

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -35,6 +35,10 @@ parameters:
             paths:
                 - src/Carbon/Traits/Mixin.php
         -
+            message: '#^Variable \$this in isset\(\) always exists and is not nullable\.$#'
+            paths:
+                - src/Carbon/Traits/Mixin.php
+        -
             message: '#^Variable \$this in isset\(\) is never defined\.$#'
             paths:
                 - src/Carbon/Traits/Mixin.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -31,15 +31,7 @@ parameters:
         - '#^Property Carbon\\Carbon::\$timezone \(Carbon\\CarbonTimeZone\) does not accept string\.$#'
         - '#^Method class@anonymous/tests/Carbon/TestingAidsTest\.php:\d+::modify\(\) should return class@anonymous/tests/Carbon/TestingAidsTest\.php:\d+ but returns \(?DateTimeImmutable#'
         -
-            message: '#^Undefined variable: \$this$#'
-            paths:
-                - src/Carbon/Traits/Mixin.php
-        -
             message: '#^Variable \$this in isset\(\) always exists and is not nullable\.$#'
-            paths:
-                - src/Carbon/Traits/Mixin.php
-        -
-            message: '#^Variable \$this in isset\(\) is never defined\.$#'
             paths:
                 - src/Carbon/Traits/Mixin.php
         -

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -80,11 +80,6 @@ parameters:
             paths:
                 - tests/Factory/CallbackTest.php
         -
-            message: '#^Call to an undefined method Tests\\Carbon(Immutable)?\\MacroTest::diffInYears\(\)\.#'
-            paths:
-                - tests/Carbon/MacroTest.php
-                - tests/CarbonImmutable/MacroTest.php
-        -
             message: '#^Call to an undefined method SubCarbon(Immutable)?::diffInDecades\(\)\.#'
             paths:
                 - tests/Carbon/MacroTest.php

--- a/src/Carbon/CarbonInterval.php
+++ b/src/Carbon/CarbonInterval.php
@@ -1516,6 +1516,8 @@ class CarbonInterval extends DateInterval implements CarbonConverterInterface
      * });
      * echo CarbonInterval::hours(2)->twice();
      * ```
+     *
+     * @param-closure-this static $macro
      */
     public static function macro(string $name, ?callable $macro): void
     {

--- a/src/Carbon/Traits/Macro.php
+++ b/src/Carbon/Traits/Macro.php
@@ -40,6 +40,8 @@ trait Macro
      * });
      * echo Carbon::yesterday()->hours(11)->userFormat();
      * ```
+     *
+     * @param-closure-this static $macro
      */
     public static function macro(string $name, ?callable $macro): void
     {


### PR DESCRIPTION
Hey, resolves #3173 using [param-closure-this](https://phpstan.org/writing-php-code/phpdocs-basics#callables).