### PR TITLE
feat: Add tryParse method

### DIFF
--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -3607,6 +3607,15 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
     public static function parse(DateTimeInterface|WeekDay|Month|string|int|float|null $time, DateTimeZone|string|int|null $timezone = null): static;
 
     /**
+     * Try create a carbon instance from a string.
+     *
+     * This wraps the regular parse method in a try catch statement and returns null if an exception is caught.
+     *
+     * @return static|null
+     */
+    public static function tryParse(DateTimeInterface|WeekDay|Month|string|int|float|null $time, DateTimeZone|string|int|null $timezone = null): static|null;
+
+    /**
      * Create a carbon instance from a localized string (in French, Japanese, Arabic, etc.).
      *
      * @param string                       $time     date/time string in the given language (may also contain English).

--- a/src/Carbon/Traits/Creator.php
+++ b/src/Carbon/Traits/Creator.php
@@ -222,6 +222,26 @@ trait Creator
     }
 
     /**
+     * Create a carbon instance from a string.
+     *
+     * This is an alias for the constructor that allows better fluent syntax
+     * as it allows you to do Carbon::parse('Monday next week')->fn() rather
+     * than (new Carbon('Monday next week'))->fn().
+     *
+     * @return static|null
+     */
+    public static function tryParse(
+        DateTimeInterface|WeekDay|Month|string|int|float|null $time,
+        DateTimeZone|string|int|null $timezone = null,
+    ): static|null {
+        try{ 
+            return static::parse($time, $timezone);
+        } catch (InvalidFormatException) {
+            return null;
+        }
+    }
+
+    /**
      * Create a carbon instance from a localized string (in French, Japanese, Arabic, etc.).
      *
      * @param string                       $time     date/time string in the given language (may also contain English).

--- a/tests/Carbon/TryParseTest.php
+++ b/tests/Carbon/TryParseTest.php
@@ -26,7 +26,7 @@ class TryParseTest extends AbstractTestCase
 
         $this->assertEquals('2025-01-22 00:00:00', Carbon::tryParse('2025-01-22 00:00:00')->format('Y-m-d H:i:s'));
 
-        $this->assertNull(Carbon::tryParse('2025-99-99'));       
+        $this->assertNull(Carbon::tryParse('2025-99-99'));
 
         Carbon::setTestNow();
     }

--- a/tests/Carbon/TryParseTest.php
+++ b/tests/Carbon/TryParseTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Carbon package.
+ *
+ * (c) Brian Nesbitt <brian@nesbot.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Carbon;
+
+use Carbon\Carbon;
+use Tests\AbstractTestCase;
+
+class TryParseTest extends AbstractTestCase
+{
+    public function testTryParse()
+    {
+        Carbon::setTestNow('2025-01-22 00:00:00');
+
+        $this->assertInstanceOf(Carbon::class, Carbon::tryParse('2025-01-22'));
+
+        $this->assertEquals('2025-01-22 00:00:00', Carbon::tryParse('2025-01-22 00:00:00')->format('Y-m-d H:i:s'));
+
+        $this->assertNull(Carbon::tryParse('2025-99-99'));       
+
+        Carbon::setTestNow();
+    }
+}


### PR DESCRIPTION
This PR introduces a tryParse method.

Previously...
```php
try { 
    $date = Carbon::parse('invalid-input');
} catch (InvalidFormatException) { 
    $date = null;
}
```

Now...
```php
$date = Carbon::tryParse('invalid-input');
```