### PR TITLE
Add NO_MONTH_OVERFLOW option to CarbonPeriod

### DIFF
--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -221,6 +221,13 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
     public const EXCLUDE_END_DATE = 8;
 
     /**
+     * Applying a monthly interval to a date at the end of a month will snap to the end of the next month.
+     *
+     * @var int
+     */
+    public const NO_MONTH_OVERFLOW = 16;
+
+    /**
      * Yield CarbonImmutable instances.
      *
      * @var int
@@ -2509,7 +2516,18 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
         $attempts = 0;
 
         do {
-            $this->carbonCurrent = $this->carbonCurrent->add($this->dateInterval);
+            $current = $this->carbonCurrent;
+            $interval = $this->dateInterval;
+
+            if ($this->shouldApplyNoOverflowLogic()) {
+                $this->carbonCurrent = $current
+                    ->addMonthsNoOverflow($interval->m + ($interval->y * 12))
+                    ->endOfMonth()
+                    ->startOfDay();
+            } else {
+                // Default behavior
+                $this->carbonCurrent = $current->add($interval);
+            }
 
             $this->validationResult = null;
 
@@ -2713,5 +2731,18 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
             ($excludeStart ? self::EXCLUDE_START_DATE : 0) | ($includeEnd && \defined('DatePeriod::INCLUDE_END_DATE') ? self::INCLUDE_END_DATE : 0),
         );
         // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * Checks if the special "no overflow" logic should be applied for the current iteration step.
+     */
+    private function shouldApplyNoOverflowLogic(): bool
+    {
+        $interval = $this->dateInterval;
+
+        return ($this->getOptions() & static::NO_MONTH_OVERFLOW) &&
+            ($interval->y || $interval->m) &&
+            $this->startDate->isLastOfMonth() &&
+            !$interval->d && !$interval->h && !$interval->i && !$interval->s && !$interval->f;
     }
 }

--- a/tests/CarbonPeriod/IteratorTest.php
+++ b/tests/CarbonPeriod/IteratorTest.php
@@ -560,4 +560,51 @@ class IteratorTest extends AbstractTestCase
 
         $this->assertSame('00 America/Toronto', $str);
     }
+
+    public function testMonthlyIntervalFromEndOfMonthDoesNotOverflowInLeapYear()
+    {
+        $periodClass = static::$periodClass;
+        $period = $periodClass::create('2020-01-31', 'P1M', 5, $periodClass::NO_MONTH_OVERFLOW);
+
+        $expected = [
+            '2020-01-31 00:00:00',
+            '2020-02-29 00:00:00',
+            '2020-03-31 00:00:00',
+            '2020-04-30 00:00:00',
+            '2020-05-31 00:00:00',
+        ];
+
+        $this->assertSame($expected, array_map('strval', $period->toArray()));
+    }
+
+    public function testMonthlyIntervalFromEndOfMonthDoesNotOverflowInCommonYear()
+    {
+        $periodClass = static::$periodClass;
+        $period = $periodClass::create('2021-01-31', 'P1M', 5, $periodClass::NO_MONTH_OVERFLOW);
+
+        $expected = [
+            '2021-01-31 00:00:00',
+            '2021-02-28 00:00:00',
+            '2021-03-31 00:00:00',
+            '2021-04-30 00:00:00',
+            '2021-05-31 00:00:00',
+        ];
+
+        $this->assertSame($expected, array_map('strval', $period->toArray()));
+    }
+
+    public function testMonthlyIntervalFromEndOfMonthStartingInFebruary()
+    {
+        $periodClass = static::$periodClass;
+        $period = $periodClass::create('2024-02-29', 'P1M', 4, $periodClass::NO_MONTH_OVERFLOW);
+
+        $expected = [
+            '2024-02-29 00:00:00',
+            '2024-03-31 00:00:00',
+            '2024-04-30 00:00:00',
+            '2024-05-31 00:00:00',
+        ];
+
+        $this->assertSame($expected, array_map('strval', $period->toArray()));
+    }
 }


### PR DESCRIPTION
Fixes #3197

This PR introduces a new option, `CarbonPeriod::NO_MONTH_OVERFLOW`, to handle cases where a monthly interval starting from the end of a month should snap to the end of subsequent months, rather than overflowing.

### Problem

Currently, creating a period from a date like `2020-01-31` with a `P1M` interval results in `2020-03-02`. This is because PHP's native `DateTime` logic overflows the extra days when a month is shorter than the starting day number.

### Solution

By providing the `NO_MONTH_OVERFLOW` option, developers can now opt into a new behavior that ensures the iteration correctly snaps to the end of each month.

#### Before (Default Behavior):

```php
$period = CarbonPeriod::create('2020-01-31', 'P1M', 5);

// Result: [2020-01-31, 2020-03-02, 2020-04-02, 2020-05-02, 2020-06-02]
```

#### After (With New Option):

```php
$period = CarbonPeriod::create('2020-01-31', 'P1M', 5, CarbonPeriod::NO_MONTH_OVERFLOW);

// Result: [2020-01-31, 2020-02-29, 2020-03-31, 2020-04-30, 2020-05-31]
```

This implementation intentionally targets "pure" month/year intervals where the user's intent is clear. The behavior for mixed intervals (e.g., P1M5D) is left unchanged to avoid ambiguity. The new logic is isolated and does not affect the default behavior, ensuring full backward compatibility.