### PR TITLE
Support passing Unit enums to sub method and update type-hints

### DIFF
--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -1081,7 +1081,7 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
      * @example $date->add(CarbonInterval::days(4))
      *
      * @param Unit|int|string|DateInterval|Closure|CarbonConverterInterface $unit
-     * @param int|float|string                                              $value
+     * @param Unit|int|float|string                                         $value
      * @param bool|null                                                     $overflow
      *
      * @return static
@@ -4233,7 +4233,7 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
      * @example $date->sub(CarbonInterval::days(4))
      *
      * @param Unit|int|string|DateInterval|Closure|CarbonConverterInterface $unit
-     * @param int|float|string                                              $value
+     * @param Unit|int|float|string                                         $value
      * @param bool|null                                                     $overflow
      *
      * @return static
@@ -4284,9 +4284,9 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable
      *
      * @see sub()
      *
-     * @param int|string|DateInterval $unit
-     * @param int|float|string        $value
-     * @param bool|null               $overflow
+     * @param Unit|int|string|DateInterval $unit
+     * @param Unit|int|float|string        $value
+     * @param bool|null                    $overflow
      *
      * @return static
      */

--- a/src/Carbon/Traits/Units.php
+++ b/src/Carbon/Traits/Units.php
@@ -243,7 +243,7 @@ trait Units
      * @example $date->add(CarbonInterval::days(4))
      *
      * @param Unit|int|string|DateInterval|Closure|CarbonConverterInterface $unit
-     * @param int|float|string                                              $value
+     * @param Unit|int|float|string                                         $value
      * @param bool|null                                                     $overflow
      *
      * @return static
@@ -395,7 +395,7 @@ trait Units
      * @example $date->sub(CarbonInterval::days(4))
      *
      * @param Unit|int|string|DateInterval|Closure|CarbonConverterInterface $unit
-     * @param int|float|string                                              $value
+     * @param Unit|int|float|string                                         $value
      * @param bool|null                                                     $overflow
      *
      * @return static
@@ -403,6 +403,9 @@ trait Units
     #[ReturnTypeWillChange]
     public function sub($unit, $value = 1, ?bool $overflow = null): static
     {
+        $unit = Unit::toNameIfUnit($unit);
+        $value = Unit::toNameIfUnit($value);
+
         if (\is_string($unit) && \func_num_args() === 1) {
             $unit = CarbonInterval::make($unit, [], true);
         }
@@ -437,9 +440,9 @@ trait Units
      *
      * @see sub()
      *
-     * @param int|string|DateInterval $unit
-     * @param int|float|string        $value
-     * @param bool|null               $overflow
+     * @param Unit|int|string|DateInterval $unit
+     * @param Unit|int|float|string        $value
+     * @param bool|null                    $overflow
      *
      * @return static
      */

--- a/tests/Carbon/SubTest.php
+++ b/tests/Carbon/SubTest.php
@@ -15,6 +15,7 @@ namespace Tests\Carbon;
 
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
+use Carbon\Unit;
 use DateTime;
 use Tests\AbstractTestCase;
 
@@ -24,6 +25,8 @@ class SubTest extends AbstractTestCase
     {
         $this->assertSame(1973, Carbon::createFromDate(1975)->sub(2, 'year')->year);
         $this->assertSame(1973, Carbon::createFromDate(1975)->sub('year', 2)->year);
+        $this->assertSame(1973, Carbon::createFromDate(1975)->sub(2, Unit::Year)->year);
+        $this->assertSame(1973, Carbon::createFromDate(1975)->sub(Unit::Year, 2)->year);
         $this->assertSame(1973, Carbon::createFromDate(1975)->sub('2 years')->year);
         $lastNegated = null;
         $date = Carbon::createFromDate(1975)->sub(
@@ -37,6 +40,8 @@ class SubTest extends AbstractTestCase
         $this->assertSame(1973, $date->year);
         $this->assertSame(1973, Carbon::createFromDate(1975)->subtract(2, 'year')->year);
         $this->assertSame(1973, Carbon::createFromDate(1975)->subtract('year', 2)->year);
+        $this->assertSame(1973, Carbon::createFromDate(1975)->subtract(2, Unit::Year)->year);
+        $this->assertSame(1973, Carbon::createFromDate(1975)->subtract(Unit::Year, 2)->year);
         $this->assertSame(1973, Carbon::createFromDate(1975)->subtract('2 years')->year);
         $lastNegated = null;
         $this->assertSame(1973, Carbon::createFromDate(1975)->subtract(

--- a/tests/CarbonImmutable/AddTest.php
+++ b/tests/CarbonImmutable/AddTest.php
@@ -15,6 +15,7 @@ namespace Tests\CarbonImmutable;
 
 use Carbon\CarbonImmutable as Carbon;
 use Carbon\CarbonInterval;
+use Carbon\Unit;
 use DateTimeImmutable;
 use Tests\AbstractTestCase;
 
@@ -24,6 +25,8 @@ class AddTest extends AbstractTestCase
     {
         $this->assertSame(1977, Carbon::createFromDate(1975)->add(2, 'year')->year);
         $this->assertSame(1977, Carbon::createFromDate(1975)->add('year', 2)->year);
+        $this->assertSame(1977, Carbon::createFromDate(1975)->add(2, Unit::Year)->year);
+        $this->assertSame(1977, Carbon::createFromDate(1975)->add(Unit::Year, 2)->year);
         $this->assertSame(1977, Carbon::createFromDate(1975)->add('2 years')->year);
         $lastNegated = null;
         $date = Carbon::createFromDate(1975)->add(

--- a/tests/CarbonImmutable/SubTest.php
+++ b/tests/CarbonImmutable/SubTest.php
@@ -15,6 +15,7 @@ namespace Tests\CarbonImmutable;
 
 use Carbon\CarbonImmutable as Carbon;
 use Carbon\CarbonInterval;
+use Carbon\Unit;
 use DateTimeImmutable;
 use Tests\AbstractTestCase;
 
@@ -24,6 +25,8 @@ class SubTest extends AbstractTestCase
     {
         $this->assertSame(1973, Carbon::createFromDate(1975)->sub(2, 'year')->year);
         $this->assertSame(1973, Carbon::createFromDate(1975)->sub('year', 2)->year);
+        $this->assertSame(1973, Carbon::createFromDate(1975)->sub(2, Unit::Year)->year);
+        $this->assertSame(1973, Carbon::createFromDate(1975)->sub(Unit::Year, 2)->year);
         $this->assertSame(1973, Carbon::createFromDate(1975)->sub('2 years')->year);
         $lastNegated = null;
         $date = Carbon::createFromDate(1975)->sub(
@@ -38,6 +41,8 @@ class SubTest extends AbstractTestCase
         $this->assertTrue($lastNegated);
         $this->assertSame(1973, Carbon::createFromDate(1975)->subtract(2, 'year')->year);
         $this->assertSame(1973, Carbon::createFromDate(1975)->subtract('year', 2)->year);
+        $this->assertSame(1973, Carbon::createFromDate(1975)->subtract(2, Unit::Year)->year);
+        $this->assertSame(1973, Carbon::createFromDate(1975)->subtract(Unit::Year, 2)->year);
         $this->assertSame(1973, Carbon::createFromDate(1975)->subtract('2 years')->year);
         $lastNegated = null;
         $this->assertSame(1973, Carbon::createFromDate(1975)->subtract(


### PR DESCRIPTION
This adds support for passing Unit enums to the `sub` method, matching the existing behaviour of the `add` method.  It also updates the phpdocs for the add, sub, and subtract methods to reflect the available usage patterns.  Specifically, the documentation only includes examples of using these methods with the ($value, $unit) order of arguments.  e.g.
```php
$modifiedMutable = $mutable->add(1, 'day');
$modifiedImmutable = CarbonImmutable::now()->add(1, 'day');
echo $dt->add(61, 'seconds');                      // 2012-02-03 00:01:01
$interval->subtract(10, 'minutes');
```
However, the current type-hinting only supports the ($unit, $value) order, producing the following errors from PHPStan:
```
phpstan: Parameter #1 $unit of method Carbon\CarbonInterface::add() expects Carbon\CarbonConverterInterface|Carbon\Unit|Closure|DateInterval|string, 1 given.
phpstan: Parameter #2 $value of method Carbon\CarbonInterface::add() expects float|int, string given.
```
I think if you're wanting to deprecate the ($value, $unit) order (which also seems reasonable), then the documentation should be updated to reflect the preferred order going forward.