### PR TITLE
Fix negative durations lost when converting to spec

### DIFF
--- a/tests/CarbonInterval/SpecTest.php
+++ b/tests/CarbonInterval/SpecTest.php
@@ -97,6 +97,38 @@ class SpecTest extends AbstractTestCase
         $this->assertSame('P1Y2M3DT4H5M6S', $ci->spec());
     }
 
+    public function testNegativeWeeksInterval()
+    {
+        $ci = CarbonInterval::weeks(-2);
+        $this->assertSame('-P14D', $ci->spec());
+    }
+
+    public function testNegativeDaysInterval()
+    {
+        $ci = CarbonInterval::days(-5);
+        $this->assertSame('-P5D', $ci->spec());
+    }
+
+    public function testNegativeHoursInterval()
+    {
+        $ci = CarbonInterval::hours(-3);
+        $this->assertSame('-PT3H', $ci->spec());
+    }
+
+    public function testNegativeMixedDateAndTimeInterval()
+    {
+        $ci = CarbonInterval::create(-1, -2, 0, -3, -4, -5, -6);
+        $this->assertSame('-P1Y2M3DT4H5M6S', $ci->spec());
+    }
+
+    public function testInvertedIntervalSpecDoesNotIncludeSign()
+    {
+        // invert flag is handled separately by consumers, spec() should not include the sign
+        $ci = CarbonInterval::days(5);
+        $ci->invert = 1;
+        $this->assertSame('P5D', $ci->spec());
+    }
+
     public function testCreatingInstanceEquals()
     {
         $ci = new CarbonInterval(1, 2, 0, 3, 4, 5, 6);


### PR DESCRIPTION
## Summary

Fixes #3256

When creating intervals with negative values (e.g. `CarbonInterval::weeks(-2)`), the `spec()` method was returning `P14D` instead of `-P14D` because `getDateIntervalSpec()` used `abs()` on all values without preserving the sign.

## Changes

- **`getDateIntervalSpec()`**: Added detection for intervals where all individual values are negative, prepending `-` to the ISO 8601 duration spec string
- The `invert` flag is intentionally **not** handled here, as it's the standard PHP mechanism and consumers (e.g. `format()`) typically handle it separately

## Examples

| Before | After |
|--------|-------|
| `CarbonInterval::weeks(-2)->spec()` → `P14D` | `CarbonInterval::weeks(-2)->spec()` → `-P14D` |
| `CarbonInterval::days(-5)->spec()` → `P5D` | `CarbonInterval::days(-5)->spec()` → `-P5D` |
| `CarbonInterval::hours(-3)->spec()` → `PT3H` | `CarbonInterval::hours(-3)->spec()` → `-PT3H` |

## Tests

Added 5 new test cases in `tests/CarbonInterval/SpecTest.php`:
- Negative weeks, days, hours
- Negative mixed date and time interval
- Verification that inverted intervals (`invert=1`) don't include sign in spec (handled separately by consumers)