### PR TITLE
Fix CarbonPeriod month overflow with CarbonInterval

### DIFF
--- a/src/Carbon/Traits/IntervalStep.php
+++ b/src/Carbon/Traits/IntervalStep.php
@@ -73,11 +73,28 @@ trait IntervalStep
             return $carbonDate->modify(($this->step)($carbonDate, $negated)->format('Y-m-d H:i:s.u e O'));
         }
 
-        if ($negated) {
-            return $carbonDate->rawSub($this);
+        $sign = (($this->invert === 1) !== $negated) ? -1 : 1;
+
+        foreach ([
+            ['y', 'year'],
+            ['m', 'month'],
+            ['d', 'day'],
+            ['h', 'hour'],
+            ['i', 'minute'],
+            ['s', 'second'],
+        ] as [$property, $unit]) {
+            if ($this->$property !== 0) {
+                $carbonDate = $carbonDate->addUnit($unit, $this->$property * $sign);
+            }
         }
 
-        return $carbonDate->rawAdd($this);
+        $microseconds = (int) round($this->f * CarbonInterface::MICROSECONDS_PER_SECOND);
+
+        if ($microseconds !== 0) {
+            $carbonDate = $carbonDate->addUnit('microsecond', $microseconds * $sign);
+        }
+
+        return $carbonDate;
     }
 
     /**

--- a/tests/CarbonInterval/AddTest.php
+++ b/tests/CarbonInterval/AddTest.php
@@ -187,6 +187,13 @@ class AddTest extends AbstractTestCase
         $this->assertSame('2024-01-18 10:00:00', $result->format('Y-m-d H:i:s'));
     }
 
+    public function testConvertDateCanDisableMonthOverflow()
+    {
+        $date = Carbon::parse('2020-01-31')->settings(['monthOverflow' => false]);
+
+        $this->assertSame('2020-02-29', CarbonInterval::month()->convertDate($date)->toDateString());
+    }
+
     public function testMagicAddAndSubMethods()
     {
         $this->assertCarbonInterval(CarbonInterval::days(3)->addWeeks(2), 0, 0, 17, 0, 0, 0);

--- a/tests/CarbonInterval/AddTest.php
+++ b/tests/CarbonInterval/AddTest.php
@@ -194,6 +194,13 @@ class AddTest extends AbstractTestCase
         $this->assertSame('2020-02-29', CarbonInterval::month()->convertDate($date)->toDateString());
     }
 
+    public function testIntervalStepWithMicroseconds()
+    {
+        $date = Carbon::parse('2020-01-31 01:23:45.678912');
+
+        $this->assertSame('2020-01-31 01:23:45.678936', CarbonInterval::microseconds(24)->convertDate($date)->format('Y-m-d H:i:s.u'));
+    }
+
     public function testMagicAddAndSubMethods()
     {
         $this->assertCarbonInterval(CarbonInterval::days(3)->addWeeks(2), 0, 0, 17, 0, 0, 0);

--- a/tests/CarbonPeriod/IteratorTest.php
+++ b/tests/CarbonPeriod/IteratorTest.php
@@ -309,6 +309,24 @@ class IteratorTest extends AbstractTestCase
         );
     }
 
+    public function testMonthlyCarbonIntervalCanDisableMonthOverflow()
+    {
+        $periodClass = static::$periodClass;
+        $overflowPeriod = $periodClass::create('2024-01-31', new CarbonInterval('P1M'), 5);
+        $noOverflowPeriod = $periodClass::create('2024-01-31', new CarbonInterval('P1M'), 5)
+            ->settings(['monthOverflow' => false]);
+
+        $this->assertSame(
+            $this->standardizeDates(['2024-01-31', '2024-03-02', '2024-04-02', '2024-05-02', '2024-06-02']),
+            $this->standardizeDates($overflowPeriod),
+        );
+
+        $this->assertSame(
+            $this->standardizeDates(['2024-01-31', '2024-02-29', '2024-03-29', '2024-04-29', '2024-05-29']),
+            $this->standardizeDates($noOverflowPeriod),
+        );
+    }
+
     public function testValidateOncePerIteration()
     {
         $period = CarbonPeriodFactory::withCounter(static::$periodClass, $counter);


### PR DESCRIPTION
Fix #3197

Respect `monthOverflow` when iterating a `CarbonPeriod` with `CarbonInterval` (for example `P1M`).

Adds regression tests for CarbonInterval conversion and CarbonPeriod iteration.
