### PR TITLE
Narrow getter/setter return types via conditional return

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -67,10 +67,6 @@ parameters:
             paths:
                 - tests/CarbonPeriod/GettersTest.php
         -
-            message: '#^Cannot access property \$locale on Carbon\\CarbonPeriod\|string\.$#'
-            paths:
-                - tests/CarbonPeriod/GettersTest.php
-        -
             message: '#^Access to protected property Carbon\\CarbonPeriod::\$startDate\.$#'
             paths:
                 - tests/CarbonPeriod/GettersTest.php

--- a/src/Carbon/CarbonInterface.php
+++ b/src/Carbon/CarbonInterface.php
@@ -1428,15 +1428,9 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable, DiffOptio
     /**
      * Get/set the day of year.
      *
-     * @template T of int|null
-     *
      * @param int|null $value new value for day of year if using as setter.
      *
-     * @psalm-param T $value
-     *
-     * @return static|int
-     *
-     * @psalm-return (T is int ? static : int)
+     * @return ($value is null ? int : static)
      */
     public function dayOfYear(?int $value = null): static|int;
 
@@ -3079,6 +3073,8 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable, DiffOptio
      * Get/set the ISO weekday from 1 (Monday) to 7 (Sunday).
      *
      * @param WeekDay|int|null $value new value for weekday if using as setter.
+     *
+     * @return ($value is null ? int : static)
      */
     public function isoWeekday(WeekDay|int|null $value = null): static|int;
 
@@ -3165,7 +3161,7 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable, DiffOptio
      * @param string|null $locale
      * @param string      ...$fallbackLocales
      *
-     * @return $this|string
+     * @return ($locale is null ? string : static)
      */
     public function locale(?string $locale = null, string ...$fallbackLocales): static|string;
 
@@ -4776,6 +4772,8 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable, DiffOptio
 
     /**
      * Returns the minutes offset to UTC if no arguments passed, else set the timezone with given minutes shift passed.
+     *
+     * @return ($minuteOffset is null ? int : static)
      */
     public function utcOffset(?int $minuteOffset = null): static|int;
 
@@ -4816,6 +4814,8 @@ interface CarbonInterface extends DateTimeInterface, JsonSerializable, DiffOptio
      * Get/set the weekday from 0 (Sunday) to 6 (Saturday).
      *
      * @param WeekDay|int|null $value new value for weekday if using as setter.
+     *
+     * @return ($value is null ? int : static)
      */
     public function weekday(WeekDay|int|null $value = null): static|int;
 

--- a/src/Carbon/Traits/Date.php
+++ b/src/Carbon/Traits/Date.php
@@ -1618,15 +1618,9 @@ trait Date
     /**
      * Get/set the day of year.
      *
-     * @template T of int|null
-     *
      * @param int|null $value new value for day of year if using as setter.
      *
-     * @psalm-param T $value
-     *
-     * @return static|int
-     *
-     * @psalm-return (T is int ? static : int)
+     * @return ($value is null ? int : static)
      */
     public function dayOfYear(?int $value = null): static|int
     {
@@ -1639,6 +1633,8 @@ trait Date
      * Get/set the weekday from 0 (Sunday) to 6 (Saturday).
      *
      * @param WeekDay|int|null $value new value for weekday if using as setter.
+     *
+     * @return ($value is null ? int : static)
      */
     public function weekday(WeekDay|int|null $value = null): static|int
     {
@@ -1656,6 +1652,8 @@ trait Date
      * Get/set the ISO weekday from 1 (Monday) to 7 (Sunday).
      *
      * @param WeekDay|int|null $value new value for weekday if using as setter.
+     *
+     * @return ($value is null ? int : static)
      */
     public function isoWeekday(WeekDay|int|null $value = null): static|int
     {
@@ -1770,6 +1768,8 @@ trait Date
 
     /**
      * Returns the minutes offset to UTC if no arguments passed, else set the timezone with given minutes shift passed.
+     *
+     * @return ($minuteOffset is null ? int : static)
      */
     public function utcOffset(?int $minuteOffset = null): static|int
     {

--- a/src/Carbon/Traits/Localization.php
+++ b/src/Carbon/Traits/Localization.php
@@ -345,7 +345,7 @@ trait Localization
      * @param string|null $locale
      * @param string      ...$fallbackLocales
      *
-     * @return $this|string
+     * @return ($locale is null ? string : static)
      */
     public function locale(?string $locale = null, string ...$fallbackLocales): static|string
     {


### PR DESCRIPTION
## Summary

Methods that double as a getter when no argument is passed and a setter otherwise currently advertise a raw union return type (e.g. `static|int`, `static|string`). Callers cannot statically rely on either branch.

This replaces the raw unions with conditional returns of the form `@return ($param is null ? T : static)` so the result is narrowed by the actual argument at each call site.

Methods updated:

| Method | When `null` | When non-null |
|---|---|---|
| `dayOfYear()` | `int` | `static` |
| `weekday()` | `int` | `static` |
| `isoWeekday()` | `int` | `static` |
| `utcOffset()` | `int` | `static` |
| `locale()` | `string` | `static` |

`tz()` already uses this form. The rest now match.

## Notes

- Both PHPStan and Psalm understand the conditional return syntax on plain `@return`, so no analyzer-specific annotations are introduced.
- The interface declaration and the trait implementation both receive the docblock. PHPStan and Psalm do not propagate interface docblocks down to trait methods, so the narrowing has to live on both layers.
- The previous template-based form on `dayOfYear` (`@template T of int|null` + `@psalm-param` + `@psalm-return`) is replaced by the simpler conditional form for consistency with the other five methods and with the already-shipped form on `tz()`.
- `phpstan.neon`: removed the `\$locale on CarbonPeriod|string` ignore in `tests/CarbonPeriod/GettersTest.php`. The chain `->locale('fi')->locale` no longer hits that error because the setter branch now returns `static` instead of `static|string`. Without removal PHPStan reports an unmatched-ignore error.

### Concern about other tools reading conditional `@return`

If maintainers are concerned about how non-PHPStan/non-Psalm tools (IDEs, doc generators, etc.) parse a conditional expression placed in plain `@return`, an equivalent alternative is to keep the raw `@return` union and add a sibling `@phpstan-return` with the conditional form:

```php
/**
 * @return static|int
 * @phpstan-return ($value is null ? int : static)
 */
```

Psalm also reads `@phpstan-return`, so both analyzers narrow identically while third-party tools that do not understand conditionals fall back to the raw union. Happy to switch to that form if preferred — let me know.

## Why this matters for Psalm users

This change closes part of psalm/psalm-plugin-laravel#922 (raw union return). Carbon users running Psalm can drop a workaround in the Laravel plugin once this lands.
