### PR TITLE
#3307 Fix ->end property not updating after setEndDate() on PHP 8.2+

### DIFF
--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -1313,6 +1313,7 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
             $self = $self->toggleOptions(static::EXCLUDE_START_DATE, !$inclusive);
         }
 
+        $self->syncNativePeriod();
         return $self;
     }
 
@@ -1332,11 +1333,15 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
             throw new InvalidPeriodDateException('Invalid end date.');
         }
 
+        $self = $this->copyIfImmutable();
+
         if (!$date) {
-            return $this->removeFilter(static::END_DATE_FILTER);
+            $self = $self->removeFilter(static::END_DATE_FILTER);
+            $self->syncNativePeriod();
+
+            return $self;
         }
 
-        $self = $this->copyIfImmutable();
         $self->endDate = $date;
 
         if ($inclusive !== null) {
@@ -1344,10 +1349,12 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
         }
 
         if (!$self->hasFilter(static::END_DATE_FILTER)) {
-            return $self->addFilter(static::END_DATE_FILTER);
+            $self = $self->addFilter(static::END_DATE_FILTER);
+        } else {
+            $self->handleChangedParameters();
         }
 
-        $self->handleChangedParameters();
+        $self->syncNativePeriod();
 
         return $self;
     }
@@ -2470,6 +2477,29 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
 
         $this->validationResult = null;
     }
+
+    /**
+     * Synchronize the native DatePeriod properties with the current state.
+     */
+    protected function syncNativePeriod(): void
+    {
+        if (\PHP_VERSION_ID < 80200) {
+            return;
+        }
+
+        // Default interval if not set (matches __construct logic)
+        $interval = $this->dateInterval ?? \Carbon\CarbonInterval::day();
+
+        // Reinitialize the parent DatePeriod to update $start, $end, etc.
+        // This mirrors the logic in __construct and initializeSerialization.
+        parent::__construct(
+            $this->startDate,
+            $interval,
+            $this->endDate ?? max(1, min(2147483639, $this->recurrences ?? 1)),
+            $this->options ?? 0,
+        );
+    }
+
 
     /**
      * Validate current date and stop iteration when necessary.

--- a/src/Carbon/CarbonPeriod.php
+++ b/src/Carbon/CarbonPeriod.php
@@ -1314,6 +1314,7 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
         }
 
         $self->syncNativePeriod();
+
         return $self;
     }
 
@@ -2484,7 +2485,7 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
     protected function syncNativePeriod(): void
     {
         if (\PHP_VERSION_ID < 80200) {
-            return;
+            return; // @codeCoverageIgnore
         }
 
         // Default interval if not set (matches __construct logic)
@@ -2499,7 +2500,6 @@ class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable
             $this->options ?? 0,
         );
     }
-
 
     /**
      * Validate current date and stop iteration when necessary.

--- a/tests/CarbonPeriod/GettersTest.php
+++ b/tests/CarbonPeriod/GettersTest.php
@@ -443,14 +443,12 @@ class GettersTest extends AbstractTestCase
     public function testEndPropertySyncsAfterSetEndDate()
     {
         $periodClass = static::$periodClass;
-
         $period = $periodClass::create('2024-09-01/3 days/2024-09-30');
-        $period->setEndDate('2025-06-15');
+        $period = $period->setEndDate('2025-06-15');
         $this->assertSame('2025-06-15 00:00:00', $period->end->format('Y-m-d H:i:s'));
         $this->assertSame('2025-06-15 00:00:00', $period->getEndDate()->format('Y-m-d H:i:s'));
-
         $period2 = $periodClass::between('2024-01-01', '2024-12-31');
-        $period2->setEndDate('2026-03-01');
+        $period2 = $period2->setEndDate('2026-03-01');
         $this->assertSame('2026-03-01 00:00:00', $period2->end->format('Y-m-d H:i:s'));
     }
 

--- a/tests/CarbonPeriod/GettersTest.php
+++ b/tests/CarbonPeriod/GettersTest.php
@@ -440,6 +440,20 @@ class GettersTest extends AbstractTestCase
         $this->assertSame('2024-09-30 00:00:00', $period->endDate->format('Y-m-d H:i:s'));
     }
 
+    public function testEndPropertySyncsAfterSetEndDate()
+    {
+        $periodClass = static::$periodClass;
+
+        $period = $periodClass::create('2024-09-01/3 days/2024-09-30');
+        $period->setEndDate('2025-06-15');
+        $this->assertSame('2025-06-15 00:00:00', $period->end->format('Y-m-d H:i:s'));
+        $this->assertSame('2025-06-15 00:00:00', $period->getEndDate()->format('Y-m-d H:i:s'));
+
+        $period2 = $periodClass::between('2024-01-01', '2024-12-31');
+        $period2->setEndDate('2026-03-01');
+        $this->assertSame('2026-03-01 00:00:00', $period2->end->format('Y-m-d H:i:s'));
+    }
+
     public function testGetCurrent()
     {
         $periodClass = static::$periodClass;


### PR DESCRIPTION
Fixes #3307

## Problem
On PHP 8.2+, `DatePeriod`'s native properties (`$start`, `$end`, etc.) are managed internally by the engine and cannot be written directly after construction. Calling `setEndDate()` correctly updated Carbon's internal `$endDate` property but left the native `$end` property stale:

```php
$period = CarbonPeriod::between('2024-01-01', '2024-12-31');
$period->setEndDate('2025-12-31');
echo $period->end;          // returned 2024-12-31 which is wrong, (stale)
echo $period->getEndDate(); // returned 2025-12-31 which is correct
```

## Fix
created a new method, `syncNativePeriod()` which re-runs `parent::__construct()` with the current state after `setStartDate()` or `setEndDate()` is called, forcing the native `DatePeriod` properties to sync. the method is a no-op on PHP < 8.2 where the properties are writable directly.

## Tests
Added `testEndPropertySyncsAfterSetEndDate()` in `GettersTest.php`.
All 288 existing `CarbonPeriod` tests pass (1302 assertions).