### PR TITLE
Add /.well-known/security.txt (RFC 9116)

### DIFF
--- a/docs/public/.well-known/security.txt
+++ b/docs/public/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: https://tidelift.com/security
+Expires: 2027-07-15T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://carbon.nesbot.com/.well-known/security.txt
+Policy: https://github.com/briannesbitt/Carbon/blob/master/SECURITY.md


### PR DESCRIPTION
Hi @kylekatarnls — following up on #3347 and your kind go-ahead there, here is the small PR.

**What it does:** adds `docs/public/.well-known/security.txt` so https://carbon.nesbot.com/.well-known/security.txt resolves per [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116). VitePress serves `docs/public/` at the site root, so the file lands at the standard path.

**Contents** (pointing at the channel your SECURITY.md already advertises):
- `Contact:` https://tidelift.com/security
- `Expires:` 2027-07-15 (RFC 9116 §2.5.5 requires a future expiry; happy to adjust the horizon)
- `Canonical:` + `Policy:` linking back to this site and SECURITY.md

Closes #3347.

For transparency: I used AI assistance in this contribution; I verified the 404, the VitePress static-dir behaviour, and the Tidelift contact myself.
